### PR TITLE
Update armor load display

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -878,8 +878,8 @@ function App() {
                     <p><strong>Daño:</strong> {dadoIcono()} {a.dano} {iconoDano(a.tipoDano)}</p>
                     <p><strong>Alcance:</strong> {a.alcance}</p>
                     <p><strong>Consumo:</strong> {a.consumo}</p>
-                    <p><strong>Carga física:</strong> {'🔲'.repeat(parseCargaValue(a.cargaFisica ?? a.carga))}</p>
-                    <p><strong>Carga mental:</strong> {parseCargaValue(a.cargaMental)}</p>
+                    <p><strong>Carga física:</strong> {parseCargaValue(a.cargaFisica ?? a.carga) > 0 ? '🔲'.repeat(parseCargaValue(a.cargaFisica ?? a.carga)) : '❌'}</p>
+                    <p><strong>Carga mental:</strong> {parseCargaValue(a.cargaMental) || '❌'}</p>
                     <p><strong>Rasgos:</strong> {a.rasgos.join(', ')}</p>
                     {a.descripcion && <p className="italic">{a.descripcion}</p>}
                     <Boton
@@ -921,10 +921,8 @@ function App() {
                   >
                     <p className="font-bold text-lg">{a.nombre}</p>
                     <p><strong>Defensa:</strong> {a.defensa}</p>
-                    <p><strong>Cuerpo:</strong> {a.cuerpo || '❌'}</p>
-                    <p><strong>Mente:</strong> {a.mente || '❌'}</p>
-                    <p><strong>Carga física:</strong> {'🔲'.repeat(parseCargaValue(a.cargaFisica ?? a.carga))}</p>
-                    <p><strong>Carga mental:</strong> {parseCargaValue(a.cargaMental)}</p>
+                    <p><strong>Carga física:</strong> {parseCargaValue(a.cargaFisica ?? a.carga) > 0 ? '🔲'.repeat(parseCargaValue(a.cargaFisica ?? a.carga)) : '❌'}</p>
+                    <p><strong>Carga mental:</strong> {parseCargaValue(a.cargaMental) || '❌'}</p>
                     <p><strong>Rasgos:</strong> {a.rasgos.length ? a.rasgos.join(', ') : '❌'}</p>
                     {a.descripcion && <p className="italic">{a.descripcion}</p>}
                     <Boton
@@ -974,8 +972,8 @@ function App() {
                     <p><strong>Daño:</strong> {dadoIcono()} {a.dano} {iconoDano(a.tipoDano)}</p>
                     <p><strong>Alcance:</strong> {a.alcance}</p>
                     <p><strong>Consumo:</strong> {a.consumo}</p>
-                    <p><strong>Carga física:</strong> {'🔲'.repeat(parseCargaValue(a.cargaFisica ?? a.carga))}</p>
-                    <p><strong>Carga mental:</strong> {parseCargaValue(a.cargaMental)}</p>
+                    <p><strong>Carga física:</strong> {parseCargaValue(a.cargaFisica ?? a.carga) > 0 ? '🔲'.repeat(parseCargaValue(a.cargaFisica ?? a.carga)) : '❌'}</p>
+                    <p><strong>Carga mental:</strong> {parseCargaValue(a.cargaMental) || '❌'}</p>
                     <p><strong>Rasgos:</strong> {a.rasgos.length ? a.rasgos.join(', ') : '❌'}</p>
                     <p><strong>Valor:</strong> {a.valor}</p>
                     {a.tecnologia && <p><strong>Tecnología:</strong> {a.tecnologia}</p>}
@@ -994,10 +992,8 @@ function App() {
                   <Tarjeta key={`armadura-${i}`}>
                     <p className="font-bold text-lg">{a.nombre}</p>
                     <p><strong>Defensa:</strong> {a.defensa}</p>
-                    <p><strong>Cuerpo:</strong> {a.cuerpo || '❌'}</p>
-                    <p><strong>Mente:</strong> {a.mente || '❌'}</p>
-                    <p><strong>Carga física:</strong> {'🔲'.repeat(parseCargaValue(a.cargaFisica ?? a.carga))}</p>
-                    <p><strong>Carga mental:</strong> {parseCargaValue(a.cargaMental)}</p>
+                    <p><strong>Carga física:</strong> {parseCargaValue(a.cargaFisica ?? a.carga) > 0 ? '🔲'.repeat(parseCargaValue(a.cargaFisica ?? a.carga)) : '❌'}</p>
+                    <p><strong>Carga mental:</strong> {parseCargaValue(a.cargaMental) || '❌'}</p>
                     <p><strong>Rasgos:</strong> {a.rasgos.length ? a.rasgos.join(', ') : '❌'}</p>
                     <p><strong>Valor:</strong> {a.valor}</p>
                     {a.tecnologia && <p><strong>Tecnología:</strong> {a.tecnologia}</p>}


### PR DESCRIPTION
## Summary
- remove `Cuerpo`/`Mente` fields from equipped armor display
- show a ❌ when physical or mental load is zero

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_683f9de8170c83268111c295902748ee