### PR TITLE
Make mobile tooltip editable on double tap

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -796,7 +796,8 @@ function App() {
                         className="absolute left-1/2 transform -translate-x-1/2 font-bold text-lg capitalize cursor-pointer"
                         data-tooltip-id={`tip-${r}`}
                         data-tooltip-content={info}
-                        onClick={() => startEditInfo(r, info)}
+                        onClick={isTouchDevice ? undefined : () => startEditInfo(r, info)}
+                        onDoubleClick={isTouchDevice ? () => startEditInfo(r, info) : undefined}
                       >
                         {name}
                       </span>


### PR DESCRIPTION
## Summary
- allow editing resource tooltip by double-tapping on touch devices
- keep single click for edit on desktop

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68402c57e1688326bcf81dc85f002433