### PR TITLE
Improve tooltip behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ Aplicación web para crear y gestionar fichas de rol de jugadores. Permite almac
 
 ## Funcionalidades
 
- - Gestión de armas, armaduras, atributos y recursos de personajes.
+- Gestión de armas, armaduras, atributos y recursos de personajes.
 - Interfaz adaptable a distintos dispositivos.
 - Autenticación básica mediante contraseña maestra.
+- Tooltip de recursos mejorado: se muestra al pasar el ratón,
+  se puede fijar con un clic y editar con doble clic.
 

--- a/src/App.js
+++ b/src/App.js
@@ -153,6 +153,20 @@ function App() {
   const [editingInfoId, setEditingInfoId] = useState(null);
   const [editingInfoText, setEditingInfoText] = useState('');
   const [hoveredTipId, setHoveredTipId] = useState(null);
+  const [pinnedTipId, setPinnedTipId] = useState(null);
+
+  useEffect(() => {
+    if (!pinnedTipId) return;
+    const handleClick = e => {
+      const anchor = document.querySelector(`[data-tooltip-id="tip-${pinnedTipId}"]`);
+      const tip = document.getElementById(`tip-${pinnedTipId}`);
+      if (anchor && anchor.contains(e.target)) return;
+      if (tip && tip.contains(e.target)) return;
+      setPinnedTipId(null);
+    };
+    document.addEventListener('click', handleClick);
+    return () => document.removeEventListener('click', handleClick);
+  }, [pinnedTipId]);
 
   // ───────────────────────────────────────────────────────────
   // NAVIGATION
@@ -533,6 +547,7 @@ function App() {
   };
 
   const startEditInfo = (id, current) => {
+    setPinnedTipId(null);
     setEditingInfoId(id);
     setEditingInfoText(current);
   };
@@ -546,6 +561,10 @@ function App() {
     savePlayer(playerData, newList);
     setEditingInfoId(null);
     setEditingInfoText('');
+  };
+
+  const togglePinnedTip = id => {
+    setPinnedTipId(prev => (prev === id ? null : id));
   };
 
   const dadoIcono = () => <BsDice6 className="inline" />;
@@ -796,8 +815,8 @@ function App() {
                         className="absolute left-1/2 transform -translate-x-1/2 font-bold text-lg capitalize cursor-pointer"
                         data-tooltip-id={`tip-${r}`}
                         data-tooltip-content={info}
-                        onClick={isTouchDevice ? undefined : () => startEditInfo(r, info)}
-                        onDoubleClick={isTouchDevice ? () => startEditInfo(r, info) : undefined}
+                        onClick={isTouchDevice ? undefined : () => togglePinnedTip(r)}
+                        onDoubleClick={() => startEditInfo(r, info)}
                         onMouseEnter={() => setHoveredTipId(r)}
                         onMouseLeave={() => setHoveredTipId(null)}
                       >
@@ -809,7 +828,7 @@ function App() {
                         id={`tip-${r}`}
                         place="top"
                         openOnClick={isTouchDevice}
-                        isOpen={!isTouchDevice && hoveredTipId === r}
+                        isOpen={!isTouchDevice && (hoveredTipId === r || pinnedTipId === r)}
                         className="max-w-[90vw] sm:max-w-xs whitespace-pre-line break-words"
                       />
                     )}


### PR DESCRIPTION
## Summary
- allow hovering tooltips on PC while letting them be pinned
- pin is released when clicking outside or entering edit mode
- double click to edit a tooltip
- document the new tooltip behavior

## Testing
- `npm test --silent --no-progress` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840364fb5208326973062d2660321fc