### PR TITLE
Improve stats bar design

### DIFF
--- a/src/components/ResourceBar.jsx
+++ b/src/components/ResourceBar.jsx
@@ -6,26 +6,26 @@ const ResourceBar = ({ color, penalizacion = 0, actual = 0, base = 0, buff = 0 }
   const baseEfectiva = Math.max(0, base - penalizacion);
   const buffLimit = Math.min(buff, RESOURCE_MAX - baseEfectiva);
 
-  const segments = [
-    { value: penalizacion, bg: '#f87171aa' },
-    { value: actual, bg: color },
-    { value: Math.max(0, baseEfectiva - actual), bg: color + '55' },
-    { value: buffLimit, bg: '#facc15' },
-  ];
+  const circles = Array.from({ length: RESOURCE_MAX }, (_, i) => {
+    if (i < penalizacion) return '#f87171aa';
+    if (i < penalizacion + actual) return color;
+    if (i < penalizacion + baseEfectiva) return color + '55';
+    if (i < penalizacion + baseEfectiva + buffLimit) return '#facc15';
+    return 'transparent';
+  });
 
-  let offset = 0;
   return (
-    <div className="relative w-full h-4 rounded-lg overflow-hidden bg-gray-700">
-      {segments.map((seg, i) => {
-        const style = {
-          left: `${(offset / RESOURCE_MAX) * 100}%`,
-          width: `${(seg.value / RESOURCE_MAX) * 100}%`,
-          background: seg.bg,
-          transition: 'width 0.3s',
-        };
-        offset += seg.value;
-        return <div key={i} className="absolute top-0 h-full" style={style} />;
-      })}
+    <div
+      className="w-full h-4 bg-gray-700 rounded-lg grid gap-[2px] p-[2px]"
+      style={{ gridTemplateColumns: `repeat(${RESOURCE_MAX}, minmax(0, 1fr))` }}
+    >
+      {circles.map((bg, i) => (
+        <div
+          key={i}
+          className="rounded-full transition-colors duration-300"
+          style={{ background: bg }}
+        />
+      ))}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- redesign ResourceBar to show resources as 20 animated circles

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68409108e2ec83269d238095efd39c5d