### PR TITLE
Improve attribute cards for mobile

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -9,6 +9,7 @@ import Boton from './components/Boton';
 import Input from './components/Input';
 import Tarjeta from './components/Tarjeta';
 import ResourceBar from './components/ResourceBar';
+import AtributoCard from './components/AtributoCard';
 import { Tooltip } from 'react-tooltip';
 const isTouchDevice = typeof window !== 'undefined' &&
   (('ontouchstart' in window) || navigator.maxTouchPoints > 0);
@@ -736,28 +737,16 @@ function App() {
           {/* ATRIBUTOS */}
           <h2 className="text-xl font-semibold text-center mb-4">Atributos</h2>
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-6 w-full">
-            {atributos.map(attr => {
-              const val = playerData.atributos[attr] || 'D4';
-              return (
-                <div
-                  key={attr}
-                  className="flex items-center justify-between p-3 rounded-xl shadow w-full"
-                  style={{ backgroundColor: atributoColor[attr] }}
-                >
-                  <span className="flex-1 text-lg sm:text-xl font-bold text-gray-800 text-center">
-                    {attr.charAt(0).toUpperCase() + attr.slice(1)}
-                  </span>
-                  <select
-                    value={val}
-                    onChange={e => handleAtributoChange(attr, e.target.value)}
-                    className="bg-gray-700 text-white border border-gray-500 rounded px-2 py-1 w-24 mr-2 text-center"
-                  >
-                    {DADOS.map(d => <option key={d} value={d}>{d}</option>)}
-                  </select>
-                  <img src={dadoImgUrl(val)} alt={val} className="w-10 h-10 object-contain" />
-                </div>
-              );
-            })}
+            {atributos.map(attr => (
+              <AtributoCard
+                key={attr}
+                name={attr}
+                value={playerData.atributos[attr] || 'D4'}
+                color={atributoColor[attr]}
+                dadoImgUrl={dadoImgUrl}
+                onChange={v => handleAtributoChange(attr, v)}
+              />
+            ))}
           </div>
 
           {/* ESTADÍSTICAS */}

--- a/src/components/AtributoCard.jsx
+++ b/src/components/AtributoCard.jsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { FaChevronLeft, FaChevronRight } from 'react-icons/fa';
+
+const DADOS = ['D4', 'D6', 'D8', 'D10', 'D12'];
+
+const AtributoCard = ({ name, value, onChange, color, dadoImgUrl }) => {
+  const index = DADOS.indexOf(value);
+  const prev = () => onChange(DADOS[(index - 1 + DADOS.length) % DADOS.length]);
+  const next = () => onChange(DADOS[(index + 1) % DADOS.length]);
+
+  return (
+    <div
+      className="relative rounded-xl shadow-md p-4 flex flex-col items-center text-gray-900"
+      style={{ background: `linear-gradient(135deg, ${color}, ${color}aa)` }}
+    >
+      <p className="text-lg font-bold capitalize mb-2">{name}</p>
+      <img src={dadoImgUrl(value)} alt={value} className="w-12 h-12 mb-2" />
+      <select
+        value={value}
+        onChange={e => onChange(e.target.value)}
+        className="bg-gray-700 text-white rounded px-2 py-1 text-center mt-1"
+      >
+        {DADOS.map(d => (
+          <option key={d} value={d}>{d}</option>
+        ))}
+      </select>
+      <button
+        className="absolute left-2 top-1/2 -translate-y-1/2 bg-gray-900/70 text-white rounded-full p-1"
+        onClick={prev}
+      >
+        <FaChevronLeft />
+      </button>
+      <button
+        className="absolute right-2 top-1/2 -translate-y-1/2 bg-gray-900/70 text-white rounded-full p-1"
+        onClick={next}
+      >
+        <FaChevronRight />
+      </button>
+    </div>
+  );
+};
+
+export default AtributoCard;


### PR DESCRIPTION
## Summary
- add new `AtributoCard` component with swipe buttons
- display attributes with the new card for a modern responsive look

## Testing
- `npm install`
- `npm test -- -w=0`

------
https://chatgpt.com/codex/tasks/task_e_684093aec1488326bba33580c42316a2