### PR TITLE
Add abilities support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 - **Modo Jugador y Modo Máster**. Los jugadores pueden crear su ficha introduciendo su nombre y el máster puede acceder con una contraseña para refrescar el catálogo de armas y armaduras.
 - **Gestión de atributos y recursos**. Cada ficha contiene los cuatro atributos principales (destreza, vigor, intelecto y voluntad) representados con dados y una lista editable de recursos (postura, vida, ingenio, cordura, armadura, etc.). Es posible añadir o eliminar recursos personalizados y definir su color e información emergente.
 - **Equipamiento desde Google Sheets**. Las armas y armaduras se cargan de hojas de cálculo públicas. El máster puede buscar y revisar todas las opciones y los jugadores pueden equiparse desde su ficha.
+- **Habilidades personalizadas**. El máster puede crear poderes en Firebase y los jugadores pueden equiparlos en su ficha.
 - **Carga física y mental**. El peso del equipo afecta a la Postura y a la Cordura. La aplicación calcula automáticamente la carga física y mental acumulada e indica la penalización correspondiente.
 - **Edición de tooltips**. Los textos explicativos de cada recurso pueden editarse directamente en la interfaz tanto en ordenador como en móviles.
 - **Interfaz responsive**. Está pensada para verse correctamente en móviles y escritorio y utiliza TailwindCSS para los estilos.
@@ -43,6 +44,7 @@ A lo largo del proyecto se han añadido numerosas mejoras, entre ellas:
 - Mejoras de estilo y responsividad utilizando Tailwind.
 - Actualización de metadatos y pruebas automatizadas.
 - Interfaz de equipamiento mejorada.
+- Gestión de poderes creados en Firebase.
 - Barras de estadísticas con diseño responsive.
 - Recursos con unidades en círculos para mayor claridad.
 - Cartas de atributos optimizadas para móvil.

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -24,7 +24,9 @@ test('master login shows refresh buttons', async () => {
   // Verificar que aparecen los botones de refrescar catálogo
   const refreshArmas = await screen.findByRole('button', { name: /refrescar armas/i });
   const refreshArmaduras = screen.getByRole('button', { name: /refrescar armaduras/i });
+  const refreshHabilidades = screen.getByRole('button', { name: /refrescar habilidades/i });
 
   expect(refreshArmas).toBeInTheDocument();
   expect(refreshArmaduras).toBeInTheDocument();
+  expect(refreshHabilidades).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- create firebase-powered ability catalog
- allow players to equip powers
- add responsive UI for ability creation and listing
- update tests and docs for abilities

## Testing
- `npm test --silent` *(fails: ReferenceError setImmediate is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68409b7917a0832682894dd1793707f9