### PR TITLE
Implement state effects selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,4 +54,5 @@ A lo largo del proyecto se han añadido numerosas mejoras, entre ellas:
 - Barra de Claves limitada a 10 unidades y botón para reiniciar sus usos.
 - Botón "Volver al menú principal" en la pantalla de acceso de Máster.
 - Equipamiento y poderes centrados cuando solo hay un elemento equipado.
+- Selector de estados con iconos para llevar el control de efectos activos.
 

--- a/src/App.js
+++ b/src/App.js
@@ -11,6 +11,7 @@ import Tarjeta from './components/Tarjeta';
 import ResourceBar from './components/ResourceBar';
 import AtributoCard from './components/AtributoCard';
 import Collapsible from './components/Collapsible';
+import EstadoSelector, { ESTADOS } from './components/EstadoSelector';
 import { Tooltip } from 'react-tooltip';
 const isTouchDevice = typeof window !== 'undefined' &&
   (('ontouchstart' in window) || navigator.maxTouchPoints > 0);
@@ -133,7 +134,7 @@ function App() {
   const [playerName, setPlayerName]           = useState('');
   const [nameEntered, setNameEntered]         = useState(false);
   const [existingPlayers, setExistingPlayers] = useState([]);
-  const [playerData, setPlayerData]           = useState({ weapons: [], armaduras: [], poderes: [], claves: [], atributos: {}, stats: {}, cargaAcumulada: { fisica: 0, mental: 0 } });
+  const [playerData, setPlayerData]           = useState({ weapons: [], armaduras: [], poderes: [], claves: [], estados: [], atributos: {}, stats: {}, cargaAcumulada: { fisica: 0, mental: 0 } });
   const [playerError, setPlayerError]         = useState('');
   const [playerInputArma, setPlayerInputArma] = useState('');
   const [playerInputArmadura, setPlayerInputArmadura] = useState('');
@@ -180,6 +181,9 @@ function App() {
   const [newClaveTotal, setNewClaveTotal] = useState(0);
   const [newClaveError, setNewClaveError] = useState('');
 
+  // Estados del personaje
+  const [estados, setEstados] = useState([]);
+
   // Sugerencias dinámicas para inputs de equipo
   const armaSugerencias = playerInputArma
     ? armas.filter(a =>
@@ -207,7 +211,7 @@ function App() {
     setNameEntered(false);
     setPlayerName('');
     setPasswordInput('');
-    setPlayerData({ weapons: [], armaduras: [], poderes: [], claves: [], atributos: {}, stats: {}, cargaAcumulada: { fisica: 0, mental: 0 } });
+    setPlayerData({ weapons: [], armaduras: [], poderes: [], claves: [], estados: [], atributos: {}, stats: {}, cargaAcumulada: { fisica: 0, mental: 0 } });
     setPlayerError('');
     setPlayerInputArma('');
     setPlayerInputArmadura('');
@@ -222,6 +226,7 @@ function App() {
     setEditingInfoId(null);
     setEditingInfoText('');
     setClaves([]);
+    setEstados([]);
     setShowAddClaveForm(false);
     setNewClaveName('');
     setNewClaveColor('#ffffff');
@@ -404,11 +409,13 @@ function App() {
       // Guardar en estado
       setResourcesList(lista);
       setClaves(d.claves || []);
+      setEstados(d.estados || []);
       const loaded = {
         weapons:   d.weapons    || [],
         armaduras: d.armaduras  || [],
         poderes:   d.poderes    || [],
         claves:    d.claves     || [],
+        estados:   d.estados    || [],
         atributos: { ...baseA, ...(d.atributos || {}) },
         stats:     statsInit,
         cargaAcumulada: d.cargaAcumulada || { fisica: 0, mental: 0 }
@@ -429,7 +436,8 @@ function App() {
       }));
       setResourcesList(lista);
       setClaves([]);
-      const created = { weapons: [], armaduras: [], poderes: [], claves: [], atributos: baseA, stats: baseS, cargaAcumulada: { fisica: 0, mental: 0 } };
+      setEstados([]);
+      const created = { weapons: [], armaduras: [], poderes: [], claves: [], estados: [], atributos: baseA, stats: baseS, cargaAcumulada: { fisica: 0, mental: 0 } };
       setPlayerData(applyCargaPenalties(created, armas, armaduras));
     }
   }, [nameEntered, playerName]);
@@ -444,13 +452,15 @@ function App() {
   const savePlayer = async (
     data,
     listaParaGuardar = resourcesList,
-    clavesParaGuardar = claves
+    clavesParaGuardar = claves,
+    estadosParaGuardar = estados
   ) => {
     const recalculated = applyCargaPenalties(data, armas, armaduras);
     const fullData = {
       ...recalculated,
       resourcesList: listaParaGuardar,
       claves: clavesParaGuardar,
+      estados: estadosParaGuardar,
       updatedAt: new Date(),
     };
     setPlayerData(fullData);
@@ -735,6 +745,17 @@ function App() {
     const list = claves.filter(c => c.id !== id);
     setClaves(list);
     savePlayer({ ...playerData, claves: list }, undefined, list);
+  };
+
+  // ────────────────────────────────
+  // Estados handlers
+  // ────────────────────────────────
+  const toggleEstado = id => {
+    const list = estados.includes(id)
+      ? estados.filter(e => e !== id)
+      : [...estados, id];
+    setEstados(list);
+    savePlayer({ ...playerData, estados: list }, undefined, undefined, list);
   };
 
   const startEditInfo = (id, current) => {
@@ -1271,6 +1292,12 @@ function App() {
                 )}
               </div>
             )}
+          </div>
+
+          {/* ESTADOS */}
+          <h2 className="text-xl font-semibold text-center mb-2">Estados</h2>
+          <div className="mb-6 w-full">
+            <EstadoSelector selected={estados} onToggle={toggleEstado} />
           </div>
 
           {/* EQUIPAR ARMA */}

--- a/src/components/EstadoSelector.jsx
+++ b/src/components/EstadoSelector.jsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { Tooltip } from 'react-tooltip';
+
+const ESTADOS = [
+  { id: 'acido', name: 'Ácido', img: '/estados/Ácido.png', desc: 'Pierdes una propiedad de armadura hasta que tu u otro personaje realice la acción de REPARAR sobre la armadura.' },
+  { id: 'apresado', name: 'Apresado', img: '/estados/Apresado.png', desc: 'No puedes realizar acciones de evasión ni de movimiento hasta que tu u otro personaje realice la acción de LIBERAR sobre ti.' },
+  { id: 'ardiendo', name: 'Ardiendo', img: '/estados/Ardiendo.png', desc: 'Por cada tiempo que gastes hasta que tu u otro personaje realice la acción de APAGAR sobre ti, pierdes un bloque de cuerpo o de mente.' },
+  { id: 'asfixiado', name: 'Asfixiado', img: '/estados/Asfixiado.png', desc: 'Por cada tiempo que gastes hasta que tu u otro personaje realice la acción de RESPIRAR sobre ti, pierdes un bloque de cuerpo.' },
+  { id: 'asustado', name: 'Asustado', img: '/estados/Asustado.png', desc: 'Por cada tiempo que gastes hasta que tu u otro personaje realice la acción de TRANQUILIZAR sobre ti, pierdes un bloque de mente.' },
+  { id: 'aturdido', name: 'Aturdido', img: '/estados/Aturdido.png', desc: 'Por cada tiempo que gastes hasta que tu u otro personaje realice la acción de ESPABILAR sobre ti, pierdes un bloque de mente.' },
+  { id: 'cansado', name: 'Cansado', img: '/estados/Enfermo.png', desc: 'Por cada tiempo que gastes hasta que realices la acción de DESCANSAR, pierdes un bloque de cuerpo.' },
+  { id: 'cegado', name: 'Cegado', img: '/estados/Cegado.png', desc: 'Por cada tiempo que gastes para realizar una tirada hasta que realices la acción de ACLARAR, se anula un dado del resultado.' },
+  { id: 'congelado', name: 'Congelado', img: '/estados/Congelado.png', desc: 'Por cada tiempo que gastes hasta que tu u otro personaje realice la acción de CALENTAR sobre ti, pierdes un bloque de cuerpo o de mente.' },
+  { id: 'derribado', name: 'Derribado', img: '/estados/Derribado.png', desc: 'No puedes defenderte ni realizar acciones de movimiento hasta que tu u otro personaje realice la acción de LEVANTAR sobre tí.' },
+  { id: 'enfermo', name: 'Enfermo', img: '/estados/Enfermo.png', desc: 'Por cada tiempo que gastes hasta que tu u otro personaje realice la acción de TRATAR sobre ti, pierdes un bloque de cuerpo o de mente.' },
+  { id: 'ensordecido', name: 'Ensordecido', img: '/estados/Ensordecido.png', desc: 'No puedes oir hasta que realices la acción de ACLARAR.' },
+  { id: 'envenenado', name: 'Envenenado', img: '/estados/Envenenado.png', desc: 'No puedes recibir curaciones hasta que tu u otro personaje realice la acción de TRATAR sobre ti.' },
+  { id: 'herido', name: 'Herido', img: '/estados/Herido.png', desc: 'Puede ser utilizado por el scheduler como una clave que garantiza un fracaso. Desaparece tras un descanso largo.' },
+  { id: 'iluminado', name: 'Iluminado', img: '/estados/Iluminado.png', desc: 'Emites luz a tu alrededor.' },
+  { id: 'regeneracion', name: 'Regeneración', img: '/estados/Regeneración.png', desc: 'Por cada tiempo que gastes hasta que recibas daño, recuperas un bloque de cuerpo.' },
+  { id: 'sangrado', name: 'Sangrado', img: '/estados/Sangrado.png', desc: 'Por cada tiempo que gastes hasta que recibas una curación, pierdes un bloque de cuerpo.' },
+  { id: 'silenciado', name: 'Silenciado', img: '/estados/Silenciado.png', desc: 'No puedes hablar hasta que realices la acción de ACLARAR.' },
+];
+
+function EstadoSelector({ selected = [], onToggle }) {
+  return (
+    <div className="grid grid-cols-3 sm:grid-cols-4 gap-4">
+      {ESTADOS.map(e => (
+        <button
+          key={e.id}
+          onClick={() => onToggle(e.id)}
+          className={`relative rounded-lg p-2 bg-gray-800 hover:bg-gray-700 transition flex flex-col items-center justify-center ${selected.includes(e.id) ? 'ring-2 ring-green-400' : ''}`}
+          data-tooltip-id={`estado-${e.id}`}
+          data-tooltip-content={e.desc}
+        >
+          <img src={e.img} alt={e.name} className="w-12 h-12" />
+          <span className="text-xs mt-1">{e.name}</span>
+          <Tooltip id={`estado-${e.id}`} place="top" className="max-w-[90vw] sm:max-w-xs whitespace-pre-line break-words" />
+        </button>
+      ))}
+    </div>
+  );
+}
+
+export default EstadoSelector;
+export { ESTADOS };


### PR DESCRIPTION
## Summary
- add `EstadoSelector` component with tooltips and icons
- store player's active states in Firestore
- show the selector in the player's sheet
- document new feature in README

## Testing
- `npm install --silent`
- `npm test --silent` *(fails: Firestore connection timeout)*

------
https://chatgpt.com/codex/tasks/task_e_6840d8a8fb608326a61ca1994351cba0