### PR TITLE
Add inventory drag-and-drop module

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 - **Carga física y mental**. El peso del equipo afecta a la Postura y a la Cordura. La aplicación calcula automáticamente la carga física y mental acumulada e indica la penalización correspondiente.
 - **Edición de tooltips**. Los textos explicativos de cada recurso pueden editarse directamente en la interfaz tanto en ordenador como en móviles.
 - **Interfaz responsive**. Está pensada para verse correctamente en móviles y escritorio y utiliza TailwindCSS para los estilos.
+- **Inventario drag & drop**. Nuevo componente modular con slots configurables para arrastrar objetos.
 - **Pruebas automáticas**. Se incluye un conjunto básico de pruebas con React Testing Library en `src/App.test.js`.
 
 ## Instalación y uso
@@ -47,6 +48,7 @@ A lo largo del proyecto se han añadido numerosas mejoras, entre ellas:
 - Interfaz de equipamiento mejorada.
 - Gestión de poderes creados en Firebase.
 - Sección de Claves con contador de usos personalizable.
+- Inventario modular con arrastrar y soltar.
 - Barras de estadísticas con diseño responsive.
 - Recursos con unidades en círculos para mayor claridad.
 - Cartas de atributos optimizadas para móvil.

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,8 @@
         "@testing-library/user-event": "^13.5.0",
         "firebase": "^11.8.1",
         "react": "^19.1.0",
+        "react-dnd": "^16.0.1",
+        "react-dnd-html5-backend": "^16.0.1",
         "react-dom": "^19.1.0",
         "react-icons": "^5.5.0",
         "react-scripts": "5.0.1",
@@ -3862,6 +3864,24 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/@react-dnd/asap": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@react-dnd/asap/-/asap-5.0.2.tgz",
+      "integrity": "sha512-WLyfoHvxhs0V9U+GTsGilGgf2QsPl6ZZ44fnv0/b8T3nQyvzxidxsg/ZltbWssbsRDlYW8UKSQMTGotuTotZ6A==",
+      "license": "MIT"
+    },
+    "node_modules/@react-dnd/invariant": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@react-dnd/invariant/-/invariant-4.0.2.tgz",
+      "integrity": "sha512-xKCTqAK/FFauOM9Ta2pswIyT3D8AQlfrYdOi/toTPEhqCuAs1v5tcJ3Y08Izh1cJ5Jchwy9SeAXmMg6zrKs2iw==",
+      "license": "MIT"
+    },
+    "node_modules/@react-dnd/shallowequal": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@react-dnd/shallowequal/-/shallowequal-4.0.2.tgz",
+      "integrity": "sha512-/RVXdLvJxLg4QKvMoM5WlwNR9ViO9z8B/qPcc+C0Sa/teJY7QG7kJ441DwzOjMYEY7GmU4dj5EcGHIkKZiQZCA==",
+      "license": "MIT"
+    },
     "node_modules/@rollup/plugin-babel": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-5.3.1.tgz",
@@ -7424,6 +7444,17 @@
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA=="
     },
+    "node_modules/dnd-core": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/dnd-core/-/dnd-core-16.0.1.tgz",
+      "integrity": "sha512-HK294sl7tbw6F6IeuK16YSBUoorvHpY8RHO+9yFfaJyCDVb6n7PRcezrOEOa2SBCqiYpemh5Jx20ZcjKdFAVng==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-dnd/asap": "^5.0.1",
+        "@react-dnd/invariant": "^4.0.1",
+        "redux": "^4.2.0"
+      }
+    },
     "node_modules/dns-packet": {
       "version": "5.6.1",
       "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.6.1.tgz",
@@ -9648,6 +9679,21 @@
       "bin": {
         "he": "bin/he"
       }
+    },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/hoist-non-react-statics/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
     },
     "node_modules/hoopy": {
       "version": "0.1.4",
@@ -14712,6 +14758,45 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/react-dnd": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/react-dnd/-/react-dnd-16.0.1.tgz",
+      "integrity": "sha512-QeoM/i73HHu2XF9aKksIUuamHPDvRglEwdHL4jsp784BgUuWcg6mzfxT0QDdQz8Wj0qyRKx2eMg8iZtWvU4E2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-dnd/invariant": "^4.0.1",
+        "@react-dnd/shallowequal": "^4.0.1",
+        "dnd-core": "^16.0.1",
+        "fast-deep-equal": "^3.1.3",
+        "hoist-non-react-statics": "^3.3.2"
+      },
+      "peerDependencies": {
+        "@types/hoist-non-react-statics": ">= 3.3.1",
+        "@types/node": ">= 12",
+        "@types/react": ">= 16",
+        "react": ">= 16.14"
+      },
+      "peerDependenciesMeta": {
+        "@types/hoist-non-react-statics": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-dnd-html5-backend": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/react-dnd-html5-backend/-/react-dnd-html5-backend-16.0.1.tgz",
+      "integrity": "sha512-Wu3dw5aDJmOGw8WjH1I1/yTH+vlXEL4vmjk5p+MHxP8HuHJS1lAGeIdG/hze1AvNeXWo/JgULV87LyQOr+r5jw==",
+      "license": "MIT",
+      "dependencies": {
+        "dnd-core": "^16.0.1"
+      }
+    },
     "node_modules/react-dom": {
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
@@ -14898,6 +14983,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/redux": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
+      "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.9.2"
       }
     },
     "node_modules/reflect.getprototypeof": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "@testing-library/user-event": "^13.5.0",
     "firebase": "^11.8.1",
     "react": "^19.1.0",
+    "react-dnd": "^16.0.1",
+    "react-dnd-html5-backend": "^16.0.1",
     "react-dom": "^19.1.0",
     "react-icons": "^5.5.0",
     "react-scripts": "5.0.1",

--- a/public/items/README.md
+++ b/public/items/README.md
@@ -1,0 +1,1 @@
+Este directorio almacena imagenes para los distintos objetos del inventario.

--- a/src/components/inventory/Inventory.jsx
+++ b/src/components/inventory/Inventory.jsx
@@ -1,0 +1,64 @@
+import React, { useState } from 'react';
+import { DndProvider } from 'react-dnd';
+import { HTML5Backend } from 'react-dnd-html5-backend';
+import Slot from './Slot';
+import ItemToken from './ItemToken';
+
+const initialSlots = Array.from({ length: 4 }, (_, i) => ({ id: i, enabled: false, item: null }));
+
+const Inventory = () => {
+  const [slots, setSlots] = useState(initialSlots);
+
+  const toggleSlot = (index) => {
+    setSlots(s => s.map((slot, i) => i === index ? { ...slot, enabled: !slot.enabled } : slot));
+  };
+
+  const handleDrop = (index, dragged) => {
+    setSlots(s => s.map((slot, i) => {
+      if (i !== index) return slot;
+      if (!slot.item) return { ...slot, item: { type: dragged.type, count: 1 } };
+      return { ...slot, item: { ...slot.item, count: Math.min(slot.item.count + 1, 99) } };
+    }));
+  };
+
+  const increment = (index) => {
+    setSlots(s => s.map((slot, i) => i === index ? { ...slot, item: { ...slot.item, count: Math.min(slot.item.count + 1, 99) } } : slot));
+  };
+
+  const decrement = (index) => {
+    setSlots(s => s.map((slot, i) => i === index ? { ...slot, item: { ...slot.item, count: Math.max(slot.item.count - 1, 0) } } : slot));
+  };
+
+  return (
+    <DndProvider backend={HTML5Backend}>
+      <div className="space-y-4">
+        <div className="flex space-x-2">
+          {slots.map((slot, i) => (
+            <label key={slot.id} className="flex items-center space-x-1">
+              <input type="checkbox" checked={slot.enabled} onChange={() => toggleSlot(i)} />
+              <span>Slot {i + 1}</span>
+            </label>
+          ))}
+        </div>
+        <div className="flex space-x-2">
+          {slots.map((slot, i) => (
+            <Slot
+              key={slot.id}
+              id={slot.id}
+              enabled={slot.enabled}
+              item={slot.item}
+              onDrop={(dragged) => handleDrop(i, dragged)}
+              onIncrement={() => increment(i)}
+              onDecrement={() => decrement(i)}
+            />
+          ))}
+        </div>
+        <div className="mt-4">
+          <ItemToken />
+        </div>
+      </div>
+    </DndProvider>
+  );
+};
+
+export default Inventory;

--- a/src/components/inventory/ItemToken.jsx
+++ b/src/components/inventory/ItemToken.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { useDrag } from 'react-dnd';
+
+export const ItemTypes = {
+  TOKEN: 'token'
+};
+
+const ItemToken = ({ type = 'remedio', count = 1 }) => {
+  const [{ isDragging }, drag] = useDrag(() => ({
+    type: ItemTypes.TOKEN,
+    item: { type, count },
+    collect: (monitor) => ({
+      isDragging: monitor.isDragging(),
+    }),
+  }), [type, count]);
+
+  const opacity = isDragging ? 0.5 : 1;
+
+  return (
+    <div ref={drag} className="w-16 p-2 bg-blue-300 rounded shadow text-center select-none" style={{ opacity }}>
+      <div className="text-black text-2xl">💊</div>
+      <div className="mt-1 text-sm bg-white text-black rounded-full px-2 inline-block">{count}</div>
+    </div>
+  );
+};
+
+export default ItemToken;

--- a/src/components/inventory/Slot.jsx
+++ b/src/components/inventory/Slot.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { useDrop } from 'react-dnd';
+import ItemToken, { ItemTypes } from './ItemToken';
+
+const Slot = ({ id, enabled, item, onDrop, onIncrement, onDecrement }) => {
+  const [{ isOver, canDrop }, drop] = useDrop(() => ({
+    accept: ItemTypes.TOKEN,
+    canDrop: () => enabled,
+    drop: (dragged) => {
+      onDrop && onDrop(dragged);
+    },
+    collect: monitor => ({
+      isOver: monitor.isOver(),
+      canDrop: monitor.canDrop(),
+    })
+  }), [enabled, onDrop]);
+
+  const border = enabled ? 'border-gray-500' : 'border-dashed border-gray-400';
+  const bg = enabled ? 'bg-gray-700/70' : 'bg-gray-600/40';
+  const highlight = isOver && canDrop ? 'ring-2 ring-blue-400' : '';
+
+  return (
+    <div ref={drop} className={`w-20 h-20 flex items-center justify-center border ${border} ${bg} ${highlight} rounded relative`}>
+      {item && (
+        <div className="absolute inset-0 flex items-center justify-center">
+          <ItemToken type={item.type} count={item.count} />
+          <div className="absolute bottom-1 right-1 flex space-x-1">
+            <button onClick={onIncrement} className="bg-white text-xs px-1 rounded">+</button>
+            <button onClick={onDecrement} className="bg-white text-xs px-1 rounded">-</button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default Slot;


### PR DESCRIPTION
## Summary
- add new inventory module with `Inventory`, `Slot` and `ItemToken` components
- include drag and drop using `react-dnd`
- create `public/items` directory for item images
- document new feature in README
- add `react-dnd` dependencies

## Testing
- `npm install --silent`
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6840eac5b1bc832698ea4dff25f14de4