### PR TITLE
Add inventory to player sheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,4 +57,5 @@ A lo largo del proyecto se han añadido numerosas mejoras, entre ellas:
 - Botón "Volver al menú principal" en la pantalla de acceso de Máster.
 - Equipamiento y poderes centrados cuando solo hay un elemento equipado.
 - Selector de estados con iconos para llevar el control de efectos activos.
+- Inventario disponible en las fichas de jugador.
 

--- a/src/App.js
+++ b/src/App.js
@@ -12,6 +12,7 @@ import ResourceBar from './components/ResourceBar';
 import AtributoCard from './components/AtributoCard';
 import Collapsible from './components/Collapsible';
 import EstadoSelector, { ESTADOS } from './components/EstadoSelector';
+import Inventory from './components/inventory/Inventory';
 import { Tooltip } from 'react-tooltip';
 const isTouchDevice = typeof window !== 'undefined' &&
   (('ontouchstart' in window) || navigator.maxTouchPoints > 0);
@@ -1298,6 +1299,12 @@ function App() {
           <h2 className="text-xl font-semibold text-center mb-2">Estados</h2>
           <div className="mb-6 w-full">
             <EstadoSelector selected={estados} onToggle={toggleEstado} />
+          </div>
+
+          {/* INVENTARIO */}
+          <h2 className="text-xl font-semibold text-center mb-2">Inventario</h2>
+          <div className="mb-6 w-full">
+            <Inventory />
           </div>
 
           {/* EQUIPAR ARMA */}

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import App from './App';
+jest.mock('./components/inventory/Inventory', () => () => <div>Inventory</div>);
 
 test('renders main menu', () => {
   render(<App />);


### PR DESCRIPTION
## Summary
- import inventory component
- show inventory section in the player sheet
- mock inventory in tests
- document inventory visibility in README

## Testing
- `npm test --silent -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6840f194a8a48326af7505cd4996788d