### PR TITLE
Add interactive inventory with persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,4 +58,5 @@ A lo largo del proyecto se han añadido numerosas mejoras, entre ellas:
 - Equipamiento y poderes centrados cuando solo hay un elemento equipado.
 - Selector de estados con iconos para llevar el control de efectos activos.
 - Inventario disponible en las fichas de jugador.
+- Slots del inventario habilitables con un clic y almacenamiento persistente.
 

--- a/src/components/inventory/Inventory.jsx
+++ b/src/components/inventory/Inventory.jsx
@@ -1,16 +1,36 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { DndProvider } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
 import Slot from './Slot';
 import ItemToken from './ItemToken';
+import ItemGenerator from './ItemGenerator';
 
+const STORAGE_KEY = 'inventory-slots';
 const initialSlots = Array.from({ length: 4 }, (_, i) => ({ id: i, enabled: false, item: null }));
 
 const Inventory = () => {
-  const [slots, setSlots] = useState(initialSlots);
+  const [slots, setSlots] = useState(() => {
+    const saved = localStorage.getItem(STORAGE_KEY);
+    return saved ? JSON.parse(saved) : initialSlots;
+  });
+  const [nextId, setNextId] = useState(slots.length);
+  const [tokens, setTokens] = useState([]);
+
+  useEffect(() => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(slots));
+  }, [slots]);
 
   const toggleSlot = (index) => {
     setSlots(s => s.map((slot, i) => i === index ? { ...slot, enabled: !slot.enabled } : slot));
+  };
+
+  const closeSlot = (index) => {
+    setSlots(s => s.map((slot, i) => i === index ? { ...slot, enabled: false, item: null } : slot));
+  };
+
+  const addSlot = () => {
+    setSlots(s => [...s, { id: nextId, enabled: false, item: null }]);
+    setNextId(id => id + 1);
   };
 
   const handleDrop = (index, dragged) => {
@@ -29,18 +49,14 @@ const Inventory = () => {
     setSlots(s => s.map((slot, i) => i === index ? { ...slot, item: { ...slot.item, count: Math.max(slot.item.count - 1, 0) } } : slot));
   };
 
+  const generateItem = (type) => {
+    setTokens(t => [...t, { id: Date.now() + Math.random(), type }]);
+  };
+
   return (
     <DndProvider backend={HTML5Backend}>
       <div className="space-y-4">
-        <div className="flex space-x-2">
-          {slots.map((slot, i) => (
-            <label key={slot.id} className="flex items-center space-x-1">
-              <input type="checkbox" checked={slot.enabled} onChange={() => toggleSlot(i)} />
-              <span>Slot {i + 1}</span>
-            </label>
-          ))}
-        </div>
-        <div className="flex space-x-2">
+        <div className="flex flex-wrap gap-2">
           {slots.map((slot, i) => (
             <Slot
               key={slot.id}
@@ -50,11 +66,17 @@ const Inventory = () => {
               onDrop={(dragged) => handleDrop(i, dragged)}
               onIncrement={() => increment(i)}
               onDecrement={() => decrement(i)}
+              onToggle={() => toggleSlot(i)}
+              onClose={() => closeSlot(i)}
             />
           ))}
+          <button onClick={addSlot} className="w-20 h-20 border border-dashed rounded flex items-center justify-center text-xl text-gray-400">+</button>
         </div>
-        <div className="mt-4">
-          <ItemToken />
+        <ItemGenerator onGenerate={generateItem} />
+        <div className="flex flex-wrap gap-2">
+          {tokens.map(token => (
+            <ItemToken key={token.id} type={token.type} />
+          ))}
         </div>
       </div>
     </DndProvider>

--- a/src/components/inventory/ItemGenerator.jsx
+++ b/src/components/inventory/ItemGenerator.jsx
@@ -1,0 +1,34 @@
+import React, { useState } from 'react';
+
+const ITEMS = ['remedio', 'chatarra', 'comida'];
+
+const ItemGenerator = ({ onGenerate }) => {
+  const [query, setQuery] = useState('');
+
+  const handleGenerate = () => {
+    const type = query.toLowerCase();
+    if (ITEMS.includes(type)) {
+      onGenerate(type);
+      setQuery('');
+    }
+  };
+
+  return (
+    <div className="flex flex-col sm:flex-row sm:items-center gap-2">
+      <input
+        className="border rounded px-2 py-1 flex-1"
+        placeholder="Buscar objeto"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+      />
+      <button
+        onClick={handleGenerate}
+        className="bg-blue-600 text-white px-3 py-1 rounded"
+      >
+        Generar
+      </button>
+    </div>
+  );
+};
+
+export default ItemGenerator;

--- a/src/components/inventory/ItemToken.jsx
+++ b/src/components/inventory/ItemToken.jsx
@@ -5,6 +5,18 @@ export const ItemTypes = {
   TOKEN: 'token'
 };
 
+const icons = {
+  remedio: '💊',
+  chatarra: '⚙️',
+  comida: '🍖',
+};
+
+const colors = {
+  remedio: 'bg-blue-300',
+  chatarra: 'bg-yellow-300',
+  comida: 'bg-green-300',
+};
+
 const ItemToken = ({ type = 'remedio', count = 1 }) => {
   const [{ isDragging }, drag] = useDrag(() => ({
     type: ItemTypes.TOKEN,
@@ -15,10 +27,11 @@ const ItemToken = ({ type = 'remedio', count = 1 }) => {
   }), [type, count]);
 
   const opacity = isDragging ? 0.5 : 1;
+  const bg = colors[type] || 'bg-gray-300';
 
   return (
-    <div ref={drag} className="w-16 p-2 bg-blue-300 rounded shadow text-center select-none" style={{ opacity }}>
-      <div className="text-black text-2xl">💊</div>
+    <div ref={drag} className={`w-16 p-2 ${bg} rounded shadow text-center select-none`} style={{ opacity }}>
+      <div className="text-black text-2xl">{icons[type] || '❔'}</div>
       <div className="mt-1 text-sm bg-white text-black rounded-full px-2 inline-block">{count}</div>
     </div>
   );

--- a/src/components/inventory/Slot.jsx
+++ b/src/components/inventory/Slot.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useDrop } from 'react-dnd';
 import ItemToken, { ItemTypes } from './ItemToken';
 
-const Slot = ({ id, enabled, item, onDrop, onIncrement, onDecrement }) => {
+const Slot = ({ id, enabled, item, onDrop, onIncrement, onDecrement, onToggle, onClose }) => {
   const [{ isOver, canDrop }, drop] = useDrop(() => ({
     accept: ItemTypes.TOKEN,
     canDrop: () => enabled,
@@ -20,7 +20,17 @@ const Slot = ({ id, enabled, item, onDrop, onIncrement, onDecrement }) => {
   const highlight = isOver && canDrop ? 'ring-2 ring-blue-400' : '';
 
   return (
-    <div ref={drop} className={`w-20 h-20 flex items-center justify-center border ${border} ${bg} ${highlight} rounded relative`}>
+    <div
+      ref={drop}
+      onClick={() => !enabled && onToggle && onToggle()}
+      className={`w-20 h-20 flex items-center justify-center border ${border} ${bg} ${highlight} rounded relative`}
+    >
+      {!enabled && (
+        <span className="text-gray-400 text-3xl select-none pointer-events-none">+</span>
+      )}
+      {enabled && !item && (
+        <button onClick={(e) => { e.stopPropagation(); onClose && onClose(); }} className="absolute top-1 right-1 text-xs">✕</button>
+      )}
       {item && (
         <div className="absolute inset-0 flex items-center justify-center">
           <ItemToken type={item.type} count={item.count} />


### PR DESCRIPTION
## Summary
- allow tokens for remedio, chatarra and comida
- add item generator to create draggable tokens
- store inventory state in localStorage and allow adding slots
- enable/disable slots with click plus close button
- document new inventory feature

## Testing
- `npm test -- -w 1`

------
https://chatgpt.com/codex/tasks/task_e_6840fa951d34832695f2aba8a76475cd