### PR TITLE
Mejoras UI inventario y persistencia en Firestore

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,4 +59,9 @@ A lo largo del proyecto se han añadido numerosas mejoras, entre ellas:
 - Selector de estados con iconos para llevar el control de efectos activos.
 - Inventario disponible en las fichas de jugador.
 - Slots del inventario habilitables con un clic y almacenamiento persistente.
+- Persistencia del inventario en Firestore en lugar de localStorage.
+- Buscador de objetos con texto visible y envío con Enter.
+- Botón de papelera para eliminar objetos arrastrándolos.
+- Estilo de los slots y botones optimizado para móviles.
+- Opción para borrar slots del inventario.
 

--- a/src/components/inventory/ItemGenerator.jsx
+++ b/src/components/inventory/ItemGenerator.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import Input from '../Input';
 
 const ITEMS = ['remedio', 'chatarra', 'comida'];
 
@@ -15,11 +16,12 @@ const ItemGenerator = ({ onGenerate }) => {
 
   return (
     <div className="flex flex-col sm:flex-row sm:items-center gap-2">
-      <input
-        className="border rounded px-2 py-1 flex-1"
+      <Input
+        className="flex-1 text-black"
         placeholder="Buscar objeto"
         value={query}
         onChange={(e) => setQuery(e.target.value)}
+        onKeyDown={(e) => e.key === 'Enter' && handleGenerate()}
       />
       <button
         onClick={handleGenerate}

--- a/src/components/inventory/ItemToken.jsx
+++ b/src/components/inventory/ItemToken.jsx
@@ -17,14 +17,14 @@ const colors = {
   comida: 'bg-green-300',
 };
 
-const ItemToken = ({ type = 'remedio', count = 1 }) => {
+const ItemToken = ({ id, type = 'remedio', count = 1, fromSlot = null }) => {
   const [{ isDragging }, drag] = useDrag(() => ({
     type: ItemTypes.TOKEN,
-    item: { type, count },
+    item: { id, type, count, fromSlot },
     collect: (monitor) => ({
       isDragging: monitor.isDragging(),
     }),
-  }), [type, count]);
+  }), [id, type, count, fromSlot]);
 
   const opacity = isDragging ? 0.5 : 1;
   const bg = colors[type] || 'bg-gray-300';

--- a/src/components/inventory/Slot.jsx
+++ b/src/components/inventory/Slot.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useDrop } from 'react-dnd';
 import ItemToken, { ItemTypes } from './ItemToken';
 
-const Slot = ({ id, enabled, item, onDrop, onIncrement, onDecrement, onToggle, onClose }) => {
+const Slot = ({ id, enabled, item, onDrop, onIncrement, onDecrement, onToggle, onClose, onDelete }) => {
   const [{ isOver, canDrop }, drop] = useDrop(() => ({
     accept: ItemTypes.TOKEN,
     canDrop: () => enabled,
@@ -29,14 +29,39 @@ const Slot = ({ id, enabled, item, onDrop, onIncrement, onDecrement, onToggle, o
         <span className="text-gray-400 text-3xl select-none pointer-events-none">+</span>
       )}
       {enabled && !item && (
-        <button onClick={(e) => { e.stopPropagation(); onClose && onClose(); }} className="absolute top-1 right-1 text-xs">✕</button>
+        <>
+          <button
+            onClick={(e) => { e.stopPropagation(); onClose && onClose(); }}
+            className="absolute top-1 right-1 text-xs"
+          >
+            ✕
+          </button>
+          {onDelete && (
+            <button
+              onClick={(e) => { e.stopPropagation(); onDelete(); }}
+              className="absolute bottom-1 right-1 text-xs"
+            >
+              🗑
+            </button>
+          )}
+        </>
       )}
       {item && (
         <div className="absolute inset-0 flex items-center justify-center">
-          <ItemToken type={item.type} count={item.count} />
+          <ItemToken type={item.type} count={item.count} fromSlot={id} />
           <div className="absolute bottom-1 right-1 flex space-x-1">
-            <button onClick={onIncrement} className="bg-white text-xs px-1 rounded">+</button>
-            <button onClick={onDecrement} className="bg-white text-xs px-1 rounded">-</button>
+            <button
+              onClick={onIncrement}
+              className="w-6 h-6 bg-gray-800/80 text-white text-xs rounded flex items-center justify-center"
+            >
+              +
+            </button>
+            <button
+              onClick={onDecrement}
+              className="w-6 h-6 bg-gray-800/80 text-white text-xs rounded flex items-center justify-center"
+            >
+              -
+            </button>
           </div>
         </div>
       )}


### PR DESCRIPTION
## Summary
- reimplement `Inventory` to store slots in Firestore
- add delete slot and trash drop area
- restyle slot buttons and center layout
- fix item generator input style and allow enter to submit
- expose token origin in `ItemToken`
- document new features

## Testing
- `npm test -- -w 1`

------
https://chatgpt.com/codex/tasks/task_e_68410448c0bc83268aa6a13901468214