### PR TITLE
Add full inventory persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,4 +65,6 @@ A lo largo del proyecto se han añadido numerosas mejoras, entre ellas:
 - Estilo de los slots y botones optimizado para móviles.
 - Opción para borrar slots del inventario.
 - `DndProvider` movido al nivel raíz de la aplicación para evitar errores de contexto.
+- Persistencia completa del inventario (posiciones, cantidades y objetos eliminados).
+- Botones de aumento y disminución con estilo más compacto y adaptable a móviles.
 

--- a/src/components/inventory/Inventory.jsx
+++ b/src/components/inventory/Inventory.jsx
@@ -11,24 +11,25 @@ const initialSlots = Array.from({ length: 4 }, (_, i) => ({ id: i, enabled: fals
 
 const Inventory = () => {
   const [slots, setSlots] = useState(initialSlots);
-  const [nextId, setNextId] = useState(slots.length);
+  const [nextId, setNextId] = useState(initialSlots.length);
   const [tokens, setTokens] = useState([]);
 
   useEffect(() => {
-    const fetchSlots = async () => {
+    const fetchState = async () => {
       const snap = await getDoc(STORAGE_DOC);
       if (snap.exists()) {
-        const data = snap.data().slots || initialSlots;
-        setSlots(data);
-        setNextId(data.length);
+        const data = snap.data();
+        setSlots(data.slots || initialSlots);
+        setTokens(data.tokens || []);
+        setNextId(data.nextId || initialSlots.length);
       }
     };
-    fetchSlots();
+    fetchState();
   }, []);
 
   useEffect(() => {
-    setDoc(STORAGE_DOC, { slots });
-  }, [slots]);
+    setDoc(STORAGE_DOC, { slots, tokens, nextId });
+  }, [slots, tokens, nextId]);
 
   const toggleSlot = (index) => {
     setSlots(s => s.map((slot, i) => i === index ? { ...slot, enabled: !slot.enabled } : slot));

--- a/src/components/inventory/Slot.jsx
+++ b/src/components/inventory/Slot.jsx
@@ -52,13 +52,13 @@ const Slot = ({ id, enabled, item, onDrop, onIncrement, onDecrement, onToggle, o
           <div className="absolute bottom-1 right-1 flex space-x-1">
             <button
               onClick={onIncrement}
-              className="w-6 h-6 bg-gray-800/80 text-white text-xs rounded flex items-center justify-center"
+              className="w-5 h-5 bg-gray-800/70 text-white text-xs rounded-full flex items-center justify-center"
             >
               +
             </button>
             <button
               onClick={onDecrement}
-              className="w-6 h-6 bg-gray-800/80 text-white text-xs rounded flex items-center justify-center"
+              className="w-5 h-5 bg-gray-800/70 text-white text-xs rounded-full flex items-center justify-center"
             >
               -
             </button>


### PR DESCRIPTION
## Summary
- persist complete inventory state including tokens and next slot id
- tweak slot increment/decrement buttons for mobile
- document changes in README

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684108d38a4083269ee5ee75fb92e5aa