### PR TITLE
Fix inventory persistence on load

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,4 +67,6 @@ A lo largo del proyecto se han añadido numerosas mejoras, entre ellas:
 - `DndProvider` movido al nivel raíz de la aplicación para evitar errores de contexto.
 - Persistencia completa del inventario (posiciones, cantidades y objetos eliminados).
 - Botones de aumento y disminución con estilo más compacto y adaptable a móviles.
+- Arreglada la sincronización inicial del inventario para que los cambios se
+  conserven tras recargar la página.
 

--- a/src/components/inventory/Inventory.jsx
+++ b/src/components/inventory/Inventory.jsx
@@ -13,6 +13,7 @@ const Inventory = () => {
   const [slots, setSlots] = useState(initialSlots);
   const [nextId, setNextId] = useState(initialSlots.length);
   const [tokens, setTokens] = useState([]);
+  const [loaded, setLoaded] = useState(false);
 
   useEffect(() => {
     const fetchState = async () => {
@@ -23,13 +24,16 @@ const Inventory = () => {
         setTokens(data.tokens || []);
         setNextId(data.nextId || initialSlots.length);
       }
+      setLoaded(true);
     };
     fetchState();
   }, []);
 
   useEffect(() => {
-    setDoc(STORAGE_DOC, { slots, tokens, nextId });
-  }, [slots, tokens, nextId]);
+    if (loaded) {
+      setDoc(STORAGE_DOC, { slots, tokens, nextId });
+    }
+  }, [slots, tokens, nextId, loaded]);
 
   const toggleSlot = (index) => {
     setSlots(s => s.map((slot, i) => i === index ? { ...slot, enabled: !slot.enabled } : slot));


### PR DESCRIPTION
## Summary
- add a loaded state when fetching inventory from Firestore
- only save inventory after initial load
- document inventory persistence fix

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68410b7810908326a9f4880aee1f2c9a