### PR TITLE
Improve mobile inventory and animations

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,4 +73,9 @@ A lo largo del proyecto se han añadido numerosas mejoras, entre ellas:
 - Efecto luminoso al pasar el ratón sobre los slots o al contener un objeto.
 - Animaciones de arrastre y para indicar intentos inválidos sobre slots deshabilitados.
 - Iconos de eliminar y cerrar slot ampliados y adaptados a pantallas táctiles.
+- Inventario guardado de forma individual para cada jugador.
+- Soporte de arrastre en dispositivos móviles gracias a TouchBackend.
+- Cantidad de objetos aumentable arrastrando repetidas veces al mismo slot.
+- Animación de activación del slot con resaltado verde.
+- Papelera y botón de nuevo slot con animaciones al pasar el ratón.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "react": "^19.1.0",
         "react-dnd": "^16.0.1",
         "react-dnd-html5-backend": "^16.0.1",
+        "react-dnd-touch-backend": "^16.0.1",
         "react-dom": "^19.1.0",
         "react-icons": "^5.5.0",
         "react-scripts": "5.0.1",
@@ -14794,6 +14795,16 @@
       "integrity": "sha512-Wu3dw5aDJmOGw8WjH1I1/yTH+vlXEL4vmjk5p+MHxP8HuHJS1lAGeIdG/hze1AvNeXWo/JgULV87LyQOr+r5jw==",
       "license": "MIT",
       "dependencies": {
+        "dnd-core": "^16.0.1"
+      }
+    },
+    "node_modules/react-dnd-touch-backend": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/react-dnd-touch-backend/-/react-dnd-touch-backend-16.0.1.tgz",
+      "integrity": "sha512-NonoCABzzjyWGZuDxSG77dbgMZ2Wad7eQiCd/ECtsR2/NBLTjGksPUx9UPezZ1nQ/L7iD130Tz3RUshL/ClKLA==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-dnd/invariant": "^4.0.1",
         "dnd-core": "^16.0.1"
       }
     },

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "react": "^19.1.0",
     "react-dnd": "^16.0.1",
     "react-dnd-html5-backend": "^16.0.1",
+    "react-dnd-touch-backend": "^16.0.1",
     "react-dom": "^19.1.0",
     "react-icons": "^5.5.0",
     "react-scripts": "5.0.1",

--- a/src/App.js
+++ b/src/App.js
@@ -1304,7 +1304,7 @@ function App() {
           {/* INVENTARIO */}
           <h2 className="text-xl font-semibold text-center mb-2">Inventario</h2>
           <div className="mb-6 w-full">
-            <Inventory />
+            <Inventory playerName={playerName} />
           </div>
 
           {/* EQUIPAR ARMA */}

--- a/src/components/inventory/Slot.jsx
+++ b/src/components/inventory/Slot.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useDrop } from 'react-dnd';
 import ItemToken, { ItemTypes } from './ItemToken';
 
-const Slot = ({ id, enabled, item, onDrop, onIncrement, onDecrement, onToggle, onClose, onDelete }) => {
+const Slot = ({ id, enabled, item, onDrop, onToggle, onClose, onDelete }) => {
   const [{ isOver, canDrop }, drop] = useDrop(() => ({
     accept: ItemTypes.TOKEN,
     canDrop: () => enabled,
@@ -16,7 +16,7 @@ const Slot = ({ id, enabled, item, onDrop, onIncrement, onDecrement, onToggle, o
   }), [enabled, onDrop]);
 
   const border = enabled ? 'border-gray-500' : 'border-dashed border-gray-400';
-  const bg = enabled ? 'bg-gray-700/70' : 'bg-gray-600/40';
+  const bg = enabled ? 'bg-gray-700/70' : 'bg-gray-600/40 group-hover:bg-green-700/40';
   const highlight = isOver && canDrop ? 'ring-2 ring-blue-400' : '';
   const blocked = isOver && !canDrop ? 'animate-shake ring-2 ring-red-500' : '';
   const glow = item ? 'ring-2 ring-yellow-300' : 'hover:ring-2 hover:ring-yellow-300';
@@ -26,10 +26,10 @@ const Slot = ({ id, enabled, item, onDrop, onIncrement, onDecrement, onToggle, o
     <div
       ref={drop}
       onClick={() => !enabled && onToggle && onToggle()}
-      className={`w-20 h-20 flex items-center justify-center border ${border} ${bg} ${highlight} ${blocked} ${glow} ${scale} rounded relative transition-all duration-300 transform`}
+      className={`group w-20 h-20 flex items-center justify-center border ${border} ${bg} ${highlight} ${blocked} ${glow} ${scale} rounded relative transition-all duration-300 transform`}
     >
       {!enabled && (
-        <span className="text-gray-400 text-3xl select-none pointer-events-none">+</span>
+        <span className="text-gray-400 group-active:scale-125 group-active:text-green-400 group-hover:text-green-400 text-3xl select-none pointer-events-none transition-transform duration-200">+</span>
       )}
       {enabled && !item && (
         <>
@@ -52,20 +52,6 @@ const Slot = ({ id, enabled, item, onDrop, onIncrement, onDecrement, onToggle, o
       {item && (
         <div className="absolute inset-0 flex items-center justify-center">
           <ItemToken type={item.type} count={item.count} fromSlot={id} />
-          <div className="absolute bottom-1 right-1 flex space-x-1">
-            <button
-              onClick={onIncrement}
-              className="w-5 h-5 bg-gray-800/70 text-white text-xs rounded-full flex items-center justify-center"
-            >
-              +
-            </button>
-            <button
-              onClick={onDecrement}
-              className="w-5 h-5 bg-gray-800/70 text-white text-xs rounded-full flex items-center justify-center"
-            >
-              -
-            </button>
-          </div>
         </div>
       )}
     </div>

--- a/src/index.js
+++ b/src/index.js
@@ -4,13 +4,13 @@ import './index.css'       // <- importa Tailwind + tu CSS
 import 'react-tooltip/dist/react-tooltip.css'
 import App from './App';
 import { DndProvider } from 'react-dnd';
-import { HTML5Backend } from 'react-dnd-html5-backend';
+import { TouchBackend } from 'react-dnd-touch-backend';
 import reportWebVitals from './reportWebVitals';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
-    <DndProvider backend={HTML5Backend}>
+    <DndProvider backend={TouchBackend} options={{ enableMouseEvents: true }}>
       <App />
     </DndProvider>
   </React.StrictMode>


### PR DESCRIPTION
## Summary
- make inventory persist per player via Firestore document `inventory/<player>`
- remove increment/decrement buttons and allow stacking items by dragging again
- add mobile drag support using `react-dnd-touch-backend`
- enhance slot enable animation and update trash/new-slot button animations
- update README with recent changes

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684115c9a9008326bdd235514e75268d