### PR TITLE
Add distinct styling for equipment cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ A lo largo del proyecto se han añadido numerosas mejoras, entre ellas:
 - Animaciones de arrastre y para indicar intentos inválidos sobre slots deshabilitados.
 - Iconos de eliminar y cerrar slot ampliados y adaptados a pantallas táctiles.
 - Inventario guardado de forma individual para cada jugador.
+- Cartas de armas, armaduras y poderes con icono de fondo diferenciador.
+- Cartas de armas, armaduras y poderes con colores de borde distintivos.
 - Soporte de arrastre en dispositivos móviles gracias a TouchBackend.
 - Cantidad de objetos aumentable arrastrando repetidas veces al mismo slot.
 - Animación de activación del slot con resaltado verde.

--- a/src/App.js
+++ b/src/App.js
@@ -3,7 +3,7 @@ import React, { useState, useEffect, useCallback } from 'react';
 import { doc, getDoc, setDoc, deleteDoc, collection, getDocs } from 'firebase/firestore';
 import { db } from './firebase';
 import { BsDice6 } from 'react-icons/bs';
-import { GiFist } from 'react-icons/gi';
+import { GiFist, GiCrossedSwords, GiShield, GiMagicSwirl } from 'react-icons/gi';
 import { FaFire, FaBolt, FaSnowflake, FaRadiationAlt } from 'react-icons/fa';
 import Boton from './components/Boton';
 import Input from './components/Input';
@@ -1574,7 +1574,11 @@ function App() {
                     a.descripcion.toLowerCase().includes(searchTerm.toLowerCase())
                   )
                   .map((a, i) => (
-                    <Tarjeta key={`arma-${i}`}>
+                    <Tarjeta
+                      key={`arma-${i}`}
+                      Icon={GiCrossedSwords}
+                      className="border-red-600 bg-red-800/40"
+                    >
                       <p className="font-bold text-lg">{a.nombre}</p>
                       <p><strong>Daño:</strong> {dadoIcono()} {a.dano} {iconoDano(a.tipoDano)}</p>
                       <p><strong>Alcance:</strong> {a.alcance}</p>
@@ -1597,7 +1601,11 @@ function App() {
                     a.descripcion.toLowerCase().includes(searchTerm.toLowerCase())
                   )
                   .map((a, i) => (
-                    <Tarjeta key={`armadura-${i}`}>
+                    <Tarjeta
+                      key={`armadura-${i}`}
+                      Icon={GiShield}
+                      className="border-blue-600 bg-blue-800/40"
+                    >
                       <p className="font-bold text-lg">{a.nombre}</p>
                       <p><strong>Defensa:</strong> {a.defensa}</p>
                       <p><strong>Carga física:</strong> {parseCargaValue(a.cargaFisica ?? a.carga) > 0 ? '🔲'.repeat(parseCargaValue(a.cargaFisica ?? a.carga)) : '❌'}</p>
@@ -1618,7 +1626,11 @@ function App() {
                     (h.descripcion || '').toLowerCase().includes(searchTerm.toLowerCase())
                   )
                   .map((h, i) => (
-                    <Tarjeta key={`hab-${i}`}>
+                    <Tarjeta
+                      key={`hab-${i}`}
+                      Icon={GiMagicSwirl}
+                      className="border-purple-600 bg-purple-800/40"
+                    >
                       <p className="font-bold text-lg">{h.nombre}</p>
                       <p><strong>Alcance:</strong> {h.alcance}</p>
                       <p><strong>Consumo:</strong> {h.consumo}</p>

--- a/src/components/Tarjeta.jsx
+++ b/src/components/Tarjeta.jsx
@@ -1,9 +1,14 @@
 import React from 'react';
 
-const Tarjeta = ({ children, className = '' }) => {
+const Tarjeta = ({ children, className = '', Icon }) => {
   return (
-    <div className={`bg-gray-800/80 backdrop-blur-sm p-4 rounded-xl shadow-lg transition transform hover:-translate-y-1 ${className}`}>
-      {children}
+    <div className={`relative bg-gray-800/80 backdrop-blur-sm p-4 rounded-xl border border-gray-700 shadow-lg transition transform hover:-translate-y-1 hover:shadow-xl ${className}`}>
+      {Icon && (
+        <div className="absolute inset-0 flex items-center justify-center pointer-events-none opacity-10">
+          <Icon className="text-8xl" />
+        </div>
+      )}
+      <div className="relative z-10">{children}</div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- differentiate weapon, armor and ability cards with color borders
- document new colored borders in the README

## Testing
- `npm install`
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68417f53e0d88326bedbc5aca9b4e1b3