### PR TITLE
Enhance equipment cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,4 +81,5 @@ A lo largo del proyecto se han añadido numerosas mejoras, entre ellas:
 - Edición y eliminación de habilidades creadas por el máster.
 - Los slots del inventario se crean habilitados por defecto y se eliminan con doble clic.
 - Tamaño de los slots adaptado a pantallas grandes.
+- Tarjetas de armas, armaduras y poderes con iconos y bordes de color.
 

--- a/src/App.js
+++ b/src/App.js
@@ -1373,8 +1373,9 @@ function App() {
                 return a && (
                   <div
                     key={i}
-                    className="bg-gray-800 rounded-xl shadow-md p-4 w-full flex flex-col items-center text-center transform transition hover:-translate-y-1 hover:shadow-lg"
+                    className="bg-gray-800 rounded-xl shadow-md p-4 w-full flex flex-col items-center text-center transform transition hover:-translate-y-1 hover:shadow-lg border-2 border-red-600 relative"
                   >
+                    <span className="absolute top-2 right-2 text-xl">⚔️</span>
                     <p className="font-bold text-lg">{a.nombre}</p>
                     <p><strong>Daño:</strong> {dadoIcono()} {a.dano} {iconoDano(a.tipoDano)}</p>
                     <p><strong>Alcance:</strong> {a.alcance}</p>
@@ -1437,8 +1438,9 @@ function App() {
                 return a && (
                   <div
                     key={i}
-                    className="bg-gray-800 rounded-xl shadow-md p-4 w-full flex flex-col items-center text-center transform transition hover:-translate-y-1 hover:shadow-lg"
+                    className="bg-gray-800 rounded-xl shadow-md p-4 w-full flex flex-col items-center text-center transform transition hover:-translate-y-1 hover:shadow-lg border-2 border-blue-600 relative"
                   >
+                    <span className="absolute top-2 right-2 text-xl">🛡️</span>
                     <p className="font-bold text-lg">{a.nombre}</p>
                     <p><strong>Defensa:</strong> {a.defensa}</p>
                     <p><strong>Carga física:</strong> {parseCargaValue(a.cargaFisica ?? a.carga) > 0 ? '🔲'.repeat(parseCargaValue(a.cargaFisica ?? a.carga)) : '❌'}</p>
@@ -1499,8 +1501,9 @@ function App() {
                 return p && (
                   <div
                     key={i}
-                    className="bg-gray-800 rounded-xl shadow-md p-4 w-full flex flex-col items-center text-center transform transition hover:-translate-y-1 hover:shadow-lg"
+                    className="bg-gray-800 rounded-xl shadow-md p-4 w-full flex flex-col items-center text-center transform transition hover:-translate-y-1 hover:shadow-lg border-2 border-purple-600 relative"
                   >
+                    <span className="absolute top-2 right-2 text-xl">✨</span>
                     <p className="font-bold text-lg">{p.nombre}</p>
                     <p><strong>Alcance:</strong> {p.alcance}</p>
                     <p><strong>Consumo:</strong> {p.consumo}</p>
@@ -1600,7 +1603,7 @@ function App() {
                     a.descripcion.toLowerCase().includes(searchTerm.toLowerCase())
                   )
                   .map((a, i) => (
-                    <Tarjeta key={`arma-${i}`}>
+                    <Tarjeta key={`arma-${i}`} variant="weapon">
                       <p className="font-bold text-lg">{a.nombre}</p>
                       <p><strong>Daño:</strong> {dadoIcono()} {a.dano} {iconoDano(a.tipoDano)}</p>
                       <p><strong>Alcance:</strong> {a.alcance}</p>
@@ -1623,7 +1626,7 @@ function App() {
                     a.descripcion.toLowerCase().includes(searchTerm.toLowerCase())
                   )
                   .map((a, i) => (
-                    <Tarjeta key={`armadura-${i}`}>
+                    <Tarjeta key={`armadura-${i}`} variant="armor">
                       <p className="font-bold text-lg">{a.nombre}</p>
                       <p><strong>Defensa:</strong> {a.defensa}</p>
                       <p><strong>Carga física:</strong> {parseCargaValue(a.cargaFisica ?? a.carga) > 0 ? '🔲'.repeat(parseCargaValue(a.cargaFisica ?? a.carga)) : '❌'}</p>
@@ -1644,7 +1647,7 @@ function App() {
                     (h.descripcion || '').toLowerCase().includes(searchTerm.toLowerCase())
                   )
                   .map((h, i) => (
-                  <Tarjeta key={`hab-${i}`}>
+                  <Tarjeta key={`hab-${i}`} variant="power">
                     <p className="font-bold text-lg">{h.nombre}</p>
                     <p><strong>Alcance:</strong> {h.alcance}</p>
                     <p><strong>Consumo:</strong> {h.consumo}</p>

--- a/src/components/Tarjeta.jsx
+++ b/src/components/Tarjeta.jsx
@@ -1,8 +1,29 @@
 import React from 'react';
 
-const Tarjeta = ({ children, className = '' }) => {
+const variantStyles = {
+  weapon: {
+    border: 'border-red-600',
+    icon: '⚔️',
+  },
+  armor: {
+    border: 'border-blue-600',
+    icon: '🛡️',
+  },
+  power: {
+    border: 'border-purple-600',
+    icon: '✨',
+  },
+};
+
+const Tarjeta = ({ children, className = '', variant }) => {
+  const style = variantStyles[variant] || {};
   return (
-    <div className={`bg-gray-800/80 backdrop-blur-sm p-4 rounded-xl shadow-lg transition transform hover:-translate-y-1 ${className}`}>
+    <div
+      className={`bg-gray-800/80 backdrop-blur-sm p-4 rounded-xl shadow-lg transition transform hover:-translate-y-1 border-2 ${style.border || 'border-gray-700'} relative ${className}`}
+    >
+      {style.icon && (
+        <span className="absolute top-2 right-2 text-xl pointer-events-none">{style.icon}</span>
+      )}
       {children}
     </div>
   );


### PR DESCRIPTION
## Summary
- style equipment cards with color borders and icons
- support variants in `Tarjeta` component
- document styled cards in README

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684188287c8c83268505135f603ef17d