### PR TITLE
Update equipment card styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,5 @@ A lo largo del proyecto se han añadido numerosas mejoras, entre ellas:
 - Edición y eliminación de habilidades creadas por el máster.
 - Los slots del inventario se crean habilitados por defecto y se eliminan con doble clic.
 - Tamaño de los slots adaptado a pantallas grandes.
-- Tarjetas de armas, armaduras y poderes con iconos y bordes de color.
-
-- Iconos de equipo como marca de agua en las tarjetas.
+- Tarjetas de armas, armaduras y poderes sin bordes de color.
+- Imágenes de espada, armadura y músculo como marcas de agua.

--- a/src/App.js
+++ b/src/App.js
@@ -1371,11 +1371,7 @@ function App() {
               {playerData.weapons.map((n, i) => {
                 const a = armas.find(x => x.nombre === n);
                 return a && (
-                  <div
-                    key={i}
-                    className="bg-gray-800 rounded-xl shadow-md p-4 w-full flex flex-col items-center text-center transform transition hover:-translate-y-1 hover:shadow-lg border-2 border-red-600 relative"
-                  >
-                    <span className="absolute top-2 right-2 text-xl">⚔️</span>
+                  <Tarjeta key={i} variant="weapon" className="w-full flex flex-col items-center text-center">
                     <p className="font-bold text-lg">{a.nombre}</p>
                     <p><strong>Daño:</strong> {dadoIcono()} {a.dano} {iconoDano(a.tipoDano)}</p>
                     <p><strong>Alcance:</strong> {a.alcance}</p>
@@ -1389,7 +1385,7 @@ function App() {
                       className="py-3 px-4 rounded-lg font-extrabold text-base tracking-wide shadow-sm max-w-xs w-full mx-auto mt-4"
                       onClick={() => handlePlayerUnequip(a.nombre)}
                     >Desequipar</Boton>
-                  </div>
+                  </Tarjeta>
                 );
               })}
             </div>
@@ -1436,11 +1432,7 @@ function App() {
               {playerData.armaduras.map((n, i) => {
                 const a = armaduras.find(x => x.nombre === n);
                 return a && (
-                  <div
-                    key={i}
-                    className="bg-gray-800 rounded-xl shadow-md p-4 w-full flex flex-col items-center text-center transform transition hover:-translate-y-1 hover:shadow-lg border-2 border-blue-600 relative"
-                  >
-                    <span className="absolute top-2 right-2 text-xl">🛡️</span>
+                  <Tarjeta key={i} variant="armor" className="w-full flex flex-col items-center text-center">
                     <p className="font-bold text-lg">{a.nombre}</p>
                     <p><strong>Defensa:</strong> {a.defensa}</p>
                     <p><strong>Carga física:</strong> {parseCargaValue(a.cargaFisica ?? a.carga) > 0 ? '🔲'.repeat(parseCargaValue(a.cargaFisica ?? a.carga)) : '❌'}</p>
@@ -1452,7 +1444,7 @@ function App() {
                       className="py-3 px-4 rounded-lg font-extrabold text-base tracking-wide shadow-sm max-w-xs w-full mx-auto mt-4"
                       onClick={() => handlePlayerUnequipArmadura(a.nombre)}
                     >Desequipar</Boton>
-                  </div>
+                  </Tarjeta>
                 );
               })}
             </div>
@@ -1499,11 +1491,7 @@ function App() {
               {playerData.poderes.map((n, i) => {
                 const p = habilidades.find(x => x.nombre === n);
                 return p && (
-                  <div
-                    key={i}
-                    className="bg-gray-800 rounded-xl shadow-md p-4 w-full flex flex-col items-center text-center transform transition hover:-translate-y-1 hover:shadow-lg border-2 border-purple-600 relative"
-                  >
-                    <span className="absolute top-2 right-2 text-xl">✨</span>
+                  <Tarjeta key={i} variant="power" className="w-full flex flex-col items-center text-center">
                     <p className="font-bold text-lg">{p.nombre}</p>
                     <p><strong>Alcance:</strong> {p.alcance}</p>
                     <p><strong>Consumo:</strong> {p.consumo}</p>
@@ -1516,7 +1504,7 @@ function App() {
                       className="py-3 px-4 rounded-lg font-extrabold text-base tracking-wide shadow-sm max-w-xs w-full mx-auto mt-4"
                       onClick={() => handlePlayerUnequipPoder(p.nombre)}
                     >Desequipar</Boton>
-                  </div>
+                  </Tarjeta>
                 );
               })}
             </div>

--- a/src/components/Tarjeta.jsx
+++ b/src/components/Tarjeta.jsx
@@ -2,16 +2,13 @@ import React from 'react';
 
 const variantStyles = {
   weapon: {
-    border: 'border-red-600',
-    icon: '⚔️',
+    image: '/marcas/Espada.png',
   },
   armor: {
-    border: 'border-blue-600',
-    icon: '🛡️',
+    image: '/marcas/Armadura.png',
   },
   power: {
-    border: 'border-purple-600',
-    icon: '✨',
+    image: '/marcas/Músculo.png',
   },
 };
 
@@ -19,12 +16,12 @@ const Tarjeta = ({ children, className = '', variant }) => {
   const style = variantStyles[variant] || {};
   return (
     <div
-      className={`bg-gray-800/80 backdrop-blur-sm p-4 rounded-xl shadow-lg transition transform hover:-translate-y-1 border-2 ${style.border || 'border-gray-700'} relative overflow-hidden ${className}`}
+      className={`bg-gray-800/80 backdrop-blur-sm p-4 rounded-xl shadow-lg transition transform hover:-translate-y-1 border border-gray-700 relative overflow-hidden ${className}`}
     >
-      {style.icon && (
-        <span className="absolute inset-0 flex items-center justify-center text-[7rem] sm:text-[8rem] text-white/30 opacity-30 pointer-events-none select-none blur-sm">
-          {style.icon}
-        </span>
+      {style.image && (
+        <div className="absolute inset-0 flex items-center justify-center pointer-events-none select-none">
+          <img src={style.image} alt="" className="w-3/4 opacity-20 blur-sm" />
+        </div>
       )}
       <div className="relative z-10">
         {children}


### PR DESCRIPTION
## Summary
- use watermark images for cards instead of colored borders
- tweak equipped item blocks to use new `Tarjeta` component
- document new style in README

## Testing
- `npm test --silent -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6841f2ae6a608326bfe6a8e400e6102b