### PR TITLE
Implement item search autocomplete

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ A lo largo del proyecto se han añadido numerosas mejoras, entre ellas:
 - Slots del inventario habilitables con un clic y almacenamiento persistente.
 - Persistencia del inventario en Firestore en lugar de localStorage.
 - Buscador de objetos con texto visible y envío con Enter.
+- Sugerencia automática al buscar objetos con tabulación para autocompletar.
 - Botón de papelera para eliminar objetos arrastrándolos.
 - Estilo de los slots y botones optimizado para móviles.
 - Opción para borrar slots del inventario.

--- a/src/components/inventory/ItemGenerator.jsx
+++ b/src/components/inventory/ItemGenerator.jsx
@@ -1,28 +1,79 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import Input from '../Input';
 
 const ITEMS = ['remedio', 'chatarra', 'comida'];
 
 const ItemGenerator = ({ onGenerate }) => {
   const [query, setQuery] = useState('');
+  const [suggest, setSuggest] = useState('');
+  const mirrorRef = useRef(null);
+  const [offset, setOffset] = useState(0);
+
+  useEffect(() => {
+    if (!query) {
+      setSuggest('');
+      return;
+    }
+    const match = ITEMS.find((i) => i.startsWith(query.toLowerCase()));
+    if (match && match !== query.toLowerCase()) {
+      setSuggest(match.slice(query.length));
+    } else {
+      setSuggest('');
+    }
+  }, [query]);
+
+  useEffect(() => {
+    if (mirrorRef.current) {
+      setOffset(mirrorRef.current.offsetWidth);
+    }
+  }, [query, suggest]);
 
   const handleGenerate = () => {
     const type = query.toLowerCase();
     if (ITEMS.includes(type)) {
       onGenerate(type);
       setQuery('');
+      setSuggest('');
+    }
+  };
+
+  const handleKeyDown = (e) => {
+    if (e.key === 'Tab' && suggest) {
+      e.preventDefault();
+      setQuery(query + suggest);
+      setSuggest('');
+    } else if (e.key === 'Enter') {
+      handleGenerate();
     }
   };
 
   return (
     <div className="flex flex-col sm:flex-row sm:items-center gap-2">
-      <Input
-        className="flex-1 text-black"
-        placeholder="Buscar objeto"
-        value={query}
-        onChange={(e) => setQuery(e.target.value)}
-        onKeyDown={(e) => e.key === 'Enter' && handleGenerate()}
-      />
+      <div className="relative flex-1">
+        <Input
+          className="w-full text-black bg-transparent relative z-10"
+          placeholder="Buscar objeto"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          onKeyDown={handleKeyDown}
+        />
+        {suggest && (
+          <>
+            <span
+              ref={mirrorRef}
+              className="absolute left-4 top-1/2 -translate-y-1/2 invisible whitespace-pre"
+            >
+              {query}
+            </span>
+            <span
+              className="absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 pointer-events-none"
+              style={{ marginLeft: offset }}
+            >
+              {suggest}
+            </span>
+          </>
+        )}
+      </div>
       <button
         onClick={handleGenerate}
         className="bg-blue-600 text-white px-3 py-1 rounded"


### PR DESCRIPTION
## Summary
- add autocomplete logic to ItemGenerator so item search offers suggestions
- display and accept suggestions with Tab key
- mention new autocomplete feature in README

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68420adc97788326b119e4bf6073e53a