### PR TITLE
Add inventory preview and rotation improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,4 +90,5 @@ A lo largo del proyecto se han añadido numerosas mejoras, entre ellas:
 - Descripción emergente de cada objeto al pasar el cursor o tocar brevemente.
 
 - Inventario en cuadrícula con rotación al estilo Resident Evil 8.
+- Previsualización de espacio con validación de colisión y rotación con la tecla R.
 - Validación de objetos del inventario para evitar guardar datos incompletos en Firebase.

--- a/src/components/inventory-grid/InventoryGrid.jsx
+++ b/src/components/inventory-grid/InventoryGrid.jsx
@@ -1,25 +1,54 @@
-import React, { useRef } from 'react';
+import React, { useRef, useState, useEffect } from 'react';
 import { useDrop } from 'react-dnd';
 import InventoryItem from './InventoryItem';
 import { ItemTypes } from '../inventory/ItemToken';
-import { canPlaceItem } from './GridUtils';
+import { canPlaceItem, createGrid, placeItem } from './GridUtils';
 
 const CELL_SIZE = 48;
 
 const InventoryGrid = ({ width, height, items, onMove, onRotate }) => {
   const gridRef = useRef(null);
+  const [preview, setPreview] = useState(null);
 
-  const [, drop] = useDrop(() => ({
+  const handleKey = (e) => {
+    if (e.key.toLowerCase() === 'r' && preview) {
+      setPreview(p => p ? { ...p, rotated: !p.rotated, width: p.height, height: p.width } : p);
+    }
+  };
+
+  useEffect(() => {
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [preview]);
+
+  const [{ isOver }, drop] = useDrop(() => ({
     accept: ItemTypes.TOKEN,
-    drop: (dragged, monitor) => {
+    hover: (dragged, monitor) => {
       const offset = monitor.getClientOffset();
       if (!offset || !gridRef.current) return;
       const rect = gridRef.current.getBoundingClientRect();
       const x = Math.floor((offset.x - rect.left) / CELL_SIZE);
       const y = Math.floor((offset.y - rect.top) / CELL_SIZE);
-      onMove(dragged, x, y);
+      const rotated = preview?.rotated ?? dragged.rotated;
+      const w = rotated ? dragged.height : dragged.width;
+      const h = rotated ? dragged.width : dragged.height;
+      const grid = createGrid(width, height);
+      items.filter(it => it.id !== dragged.id).forEach(it => placeItem(grid, it, it.x, it.y));
+      const valid = canPlaceItem(grid, { id: dragged.id, width: w, height: h }, x, y);
+      setPreview({ item: dragged, rotated, x, y, width: w, height: h, valid });
     },
-  }), [onMove]);
+    drop: (dragged) => {
+      if (!preview) return;
+      dragged.rotated = preview.rotated;
+      onMove(dragged, preview.x, preview.y);
+      setPreview(null);
+    },
+    collect: (monitor) => ({ isOver: monitor.isOver() })
+  }), [onMove, items, preview, width, height]);
+
+  useEffect(() => {
+    if (!isOver) setPreview(null);
+  }, [isOver]);
 
   const style = {
     width: width * CELL_SIZE,
@@ -35,6 +64,17 @@ const InventoryGrid = ({ width, height, items, onMove, onRotate }) => {
           <div key={i} className="bg-gray-700/70 border border-gray-600" />
         ))}
       </div>
+      {preview && (
+        <div
+          className={`absolute pointer-events-none ${preview.valid ? 'ring-2 ring-green-500/70' : 'ring-2 ring-red-500/70'} bg-white/10`}
+          style={{
+            width: preview.width * CELL_SIZE,
+            height: preview.height * CELL_SIZE,
+            left: preview.x * CELL_SIZE,
+            top: preview.y * CELL_SIZE,
+          }}
+        />
+      )}
       {items.map(item => (
         <InventoryItem key={item.id} item={item} cellSize={CELL_SIZE} onRotate={onRotate} />
       ))}

--- a/src/components/inventory/Inventory.jsx
+++ b/src/components/inventory/Inventory.jsx
@@ -101,6 +101,10 @@ const Inventory = ({ playerName }) => {
     }));
   };
 
+  const rotateToken = (id) => {
+    setTokens(ts => ts.map(t => t.id === id ? { ...t, rotated: !t.rotated, width: t.height, height: t.width } : t));
+  };
+
   const [, trashDrop] = useDrop(() => ({
     accept: ItemTypes.TOKEN,
     drop: (dragged) => {
@@ -128,6 +132,7 @@ const Inventory = ({ playerName }) => {
             width={token.width}
             height={token.height}
             rotated={token.rotated}
+            onRotate={rotateToken}
           />
         ))}
       </div>

--- a/src/components/inventory/ItemToken.jsx
+++ b/src/components/inventory/ItemToken.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useDrag } from 'react-dnd';
 import { Tooltip } from 'react-tooltip';
+import RotationHandle from '../inventory-grid/RotationHandle';
 
 export const ItemTypes = {
   TOKEN: 'token'
@@ -36,7 +37,8 @@ const descriptions = {
   comida: 'Provisiones comestibles',
 };
 
-const ItemToken = ({ id, type = 'remedio', count = 1, fromSlot = null, width = 1, height = 1, rotated = false }) => {
+
+const ItemToken = ({ id, type = 'remedio', count = 1, fromSlot = null, width = 1, height = 1, rotated = false, onRotate }) => {
   const [{ isDragging }, drag] = useDrag(() => ({
     type: ItemTypes.TOKEN,
     item: { id, type, count, fromSlot, width, height, rotated },
@@ -54,13 +56,16 @@ const ItemToken = ({ id, type = 'remedio', count = 1, fromSlot = null, width = 1
   return (
     <div
       ref={drag}
-      className={`w-16 p-2 ${bg} ${border} border-2 rounded shadow text-center select-none transition-transform ${dragStyle} bg-gradient-to-r ${gradient} bg-[length:200%_200%] animate-gradient animate-glow`}
+      className={`relative w-16 p-2 ${bg} ${border} border-2 rounded shadow text-center select-none transition-transform ${dragStyle} bg-gradient-to-r ${gradient} bg-[length:200%_200%] animate-gradient animate-glow`}
       style={{ opacity }}
       data-tooltip-id={`item-${id}`}
       data-tooltip-content={descriptions[type]}
     >
       <div className="text-black text-2xl">{icons[type] || '❔'}</div>
       <div className="mt-1 text-sm bg-white text-black rounded-full px-2 inline-block">{count}</div>
+      {onRotate && (
+        <RotationHandle onRotate={(e) => { e.stopPropagation(); onRotate(id); }} />
+      )}
       <Tooltip id={`item-${id}`} place="top" className="max-w-[90vw] sm:max-w-xs" />
     </div>
   );


### PR DESCRIPTION
## Summary
- support rotating tokens individually via button or keyboard
- show placement preview while dragging items
- prevent invalid placement with red highlight
- document new preview and rotation features in README

## Testing
- `npm test --silent`
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68422810a57c83269de7d7bfbb4f4cb5