### PR TITLE
Implement glossary term highlights

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,3 +88,4 @@ A lo largo del proyecto se han añadido numerosas mejoras, entre ellas:
 - Bordes de los slots se colorean según el objeto almacenado.
 - Efectos de gradiente animado y brillo pulsante en las fichas de objeto.
 - Descripción emergente de cada objeto al pasar el cursor o tocar brevemente.
+- Glosario configurable por el máster con palabras destacadas y tooltip de ayuda.


### PR DESCRIPTION
## Summary
- allow master to manage glossary terms with color and info
- highlight glossary terms in item traits and ability descriptions
- fetch glossary from Firestore
- document glossary feature in README

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684233ecfc3483268129dc91a56d8cc0