### PR TITLE
Add inventory RE4 prototype and master menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,3 +90,4 @@ A lo largo del proyecto se han añadido numerosas mejoras, entre ellas:
 - Descripción emergente de cada objeto al pasar el cursor o tocar brevemente.
 - Glosario configurable por el máster con palabras destacadas y tooltip de ayuda.
 - Tooltips del glosario con identificadores únicos para cada palabra.
+- Prototipo de inventario estilo RE4 accesible para el máster.

--- a/src/App.js
+++ b/src/App.js
@@ -13,6 +13,8 @@ import AtributoCard from './components/AtributoCard';
 import Collapsible from './components/Collapsible';
 import EstadoSelector, { ESTADOS } from './components/EstadoSelector';
 import Inventory from './components/inventory/Inventory';
+import MasterMenu from './components/MasterMenu';
+import InventoryRE4 from './components/re4/InventoryRE4';
 import { Tooltip } from 'react-tooltip';
 const isTouchDevice = typeof window !== 'undefined' &&
   (('ontouchstart' in window) || navigator.maxTouchPoints > 0);
@@ -187,6 +189,9 @@ function App() {
   // Estados del personaje
   const [estados, setEstados] = useState([]);
 
+  // Vista elegida por el máster (inventario prototipo u opciones clásicas)
+  const [chosenView, setChosenView] = useState(null);
+
   // Glosario de términos destacados
   const [glossary, setGlossary] = useState([]);
   const [newTerm, setNewTerm] = useState({ word: '', color: '#ffff00', info: '' });
@@ -217,6 +222,7 @@ function App() {
     setUserType(null);
     setAuthenticated(false);
     setShowLogin(false);
+    setChosenView(null);
     setNameEntered(false);
     setPlayerName('');
     setPasswordInput('');
@@ -1615,6 +1621,19 @@ function App() {
   }
 
   // MODO MÁSTER
+  if (userType === 'master' && authenticated && !chosenView) {
+    return <MasterMenu onSelect={setChosenView} />;
+  }
+
+  if (userType === 'master' && authenticated && chosenView === 're4') {
+    return (
+      <div className="min-h-screen bg-gray-900 text-gray-100 p-4">
+        <Boton onClick={() => setChosenView(null)} className="mb-4">Volver</Boton>
+        <InventoryRE4 playerName={playerName} />
+      </div>
+    );
+  }
+
   if (userType === 'master' && authenticated) {
     return (
       <div className="min-h-screen bg-gray-900 text-gray-100 p-4">

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -2,6 +2,8 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import App from './App';
 jest.mock('./components/inventory/Inventory', () => () => <div>Inventory</div>);
+jest.mock('./components/MasterMenu', () => () => <div>MasterMenu</div>);
+jest.mock('./components/re4/InventoryRE4', () => () => <div>InventoryRE4</div>);
 
 test('renders main menu', () => {
   render(<App />);
@@ -9,7 +11,7 @@ test('renders main menu', () => {
   expect(heading).toBeInTheDocument();
 });
 
-test('master login shows refresh button', async () => {
+test('master login shows master menu', async () => {
   render(<App />);
 
   // Acceder al formulario de login de Máster
@@ -22,7 +24,7 @@ test('master login shows refresh button', async () => {
   const enterBtn = screen.getByRole('button', { name: /entrar/i });
   await userEvent.click(enterBtn);
 
-  // Verificar que aparece el botón para refrescar el catálogo
-  const refreshCatalog = await screen.findByRole('button', { name: /refrescar catálogo/i });
-  expect(refreshCatalog).toBeInTheDocument();
+  // Verificar que aparece el menú de selección de vista
+  const menu = await screen.findByText(/MasterMenu/i);
+  expect(menu).toBeInTheDocument();
 });

--- a/src/components/MasterMenu.jsx
+++ b/src/components/MasterMenu.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import Boton from './Boton';
+
+const MasterMenu = ({ onSelect }) => {
+  return (
+    <div className="min-h-screen bg-gray-900 flex flex-col items-center justify-center p-4">
+      <div className="w-full max-w-xs bg-gray-800 rounded-xl shadow-xl p-8 space-y-4">
+        <h2 className="text-xl font-bold text-center text-white">Selecciona vista</h2>
+        <Boton color="green" className="w-full" onClick={() => onSelect('re4')}>
+          🧳 Inventario RE4 (prototipo)
+        </Boton>
+        <Boton color="purple" className="w-full" onClick={() => onSelect('default')}>
+          📋 Herramientas tradicionales
+        </Boton>
+      </div>
+    </div>
+  );
+};
+
+export default MasterMenu;

--- a/src/components/re4/GridCell.jsx
+++ b/src/components/re4/GridCell.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+const GridCell = ({ size }) => (
+  <div
+    style={{ width: size, height: size }}
+    className="border border-gray-700 box-border"
+  />
+);
+
+export default GridCell;

--- a/src/components/re4/InventoryItem.jsx
+++ b/src/components/re4/InventoryItem.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { useDrag } from 'react-dnd';
+
+export const ItemTypes = { ITEM: 'item' };
+
+const InventoryItem = ({ item, cellSize }) => {
+  const [{ isDragging }, drag] = useDrag(() => ({
+    type: ItemTypes.ITEM,
+    item,
+  }), [item]);
+
+  const style = {
+    position: 'absolute',
+    left: item.x * cellSize,
+    top: item.y * cellSize,
+    width: item.width * cellSize,
+    height: item.height * cellSize,
+    backgroundImage: `url(${item.icon})`,
+    backgroundSize: 'cover',
+    opacity: isDragging ? 0.5 : 1,
+    cursor: 'move',
+  };
+
+  return <div ref={drag} style={style} />;
+};
+
+export default InventoryItem;

--- a/src/components/re4/InventoryRE4.jsx
+++ b/src/components/re4/InventoryRE4.jsx
@@ -1,0 +1,99 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import { useDrop } from 'react-dnd';
+import { doc, getDoc, setDoc } from 'firebase/firestore';
+import { db } from '../../firebase';
+import InventoryItem, { ItemTypes } from './InventoryItem';
+import GridCell from './GridCell';
+import { itemTemplates } from './itemTemplates';
+
+const cols = 10;
+const rows = 8;
+const cellSize = 40;
+
+const InventoryRE4 = ({ playerName }) => {
+  const [items, setItems] = useState([]);
+
+  const docRef = playerName ? doc(db, 'inventory_prototype', playerName) : null;
+
+  useEffect(() => {
+    if (!docRef) return;
+    (async () => {
+      const snap = await getDoc(docRef);
+      if (snap.exists()) {
+        setItems(snap.data().items || []);
+      }
+    })();
+  }, [docRef]);
+
+  useEffect(() => {
+    if (docRef) {
+      setDoc(docRef, { items });
+    }
+  }, [items, docRef]);
+
+  const findCollision = useCallback((x, y, width, height, id) => {
+    if (x < 0 || y < 0 || x + width > cols || y + height > rows) return true;
+    return items.some(it => it.id !== id &&
+      x < it.x + it.width && x + width > it.x &&
+      y < it.y + it.height && y + height > it.y);
+  }, [items]);
+
+  const [, drop] = useDrop(() => ({
+    accept: ItemTypes.ITEM,
+    drop: (dragged, monitor) => {
+      const delta = monitor.getDifferenceFromInitialOffset();
+      const nx = Math.round(dragged.x + delta.x / cellSize);
+      const ny = Math.round(dragged.y + delta.y / cellSize);
+      if (!findCollision(nx, ny, dragged.width, dragged.height, dragged.id)) {
+        setItems(it => it.map(i => i.id === dragged.id ? { ...i, x: nx, y: ny } : i));
+      }
+    },
+  }), [findCollision]);
+
+  const addItem = templateId => {
+    const template = itemTemplates.find(t => t.id === templateId);
+    if (!template) return;
+    const id = Date.now();
+    let x = 0, y = 0;
+    while (findCollision(x, y, template.width, template.height, id)) {
+      x++;
+      if (x >= cols) { x = 0; y++; }
+      if (y >= rows) return; // full
+    }
+    setItems([...items, { ...template, id, x, y }]);
+  };
+
+  return (
+    <div className="space-y-4">
+      <div
+        ref={drop}
+        className="relative"
+        style={{ width: cols * cellSize, height: rows * cellSize }}
+      >
+        {[...Array(rows)].map((_, y) => (
+          <div key={y} className="flex">
+            {[...Array(cols)].map((_, x) => (
+              <GridCell key={x} size={cellSize} />
+            ))}
+          </div>
+        ))}
+        {items.map(item => (
+          <InventoryItem key={item.id} item={item} cellSize={cellSize} />
+        ))}
+      </div>
+      <div className="flex gap-2">
+        {itemTemplates.map(t => (
+          <button
+            key={t.id}
+            onClick={() => addItem(t.id)}
+            className="px-2 py-1 bg-gray-700 rounded"
+          >
+            {t.name}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default InventoryRE4;

--- a/src/components/re4/itemTemplates.js
+++ b/src/components/re4/itemTemplates.js
@@ -1,0 +1,17 @@
+export const itemTemplates = [
+  {
+    id: 'potion',
+    name: 'Poción',
+    width: 1,
+    height: 1,
+    icon: 'https://via.placeholder.com/40',
+    stackable: true,
+  },
+  {
+    id: 'gun',
+    name: 'Pistola',
+    width: 2,
+    height: 2,
+    icon: 'https://via.placeholder.com/80',
+  },
+];


### PR DESCRIPTION
## Summary
- add MasterMenu component for master view selection
- implement inventory prototype inspired by RE4 using drag & drop
- persist prototype inventory in Firebase
- update App to show new menu and inventory
- adjust tests for new master flow
- note new prototype in README

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68433f5ddcb88326aaeb38345982cd82