### PR TITLE
Add item library and icons to RE4 prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,4 +100,5 @@ A lo largo del proyecto se han añadido numerosas mejoras, entre ellas:
 - Comprobación de colisiones con `canPlaceItem()` y creación de objetos mediante `addItem()`.
 - Arrastre con vista previa de validación y rotación de objetos.
 - Controles de usuario para añadir ítems aleatorios, rotar y organizar, con estadísticas y tooltips.
+- Biblioteca de objetos interactiva con iconos y botones para añadir ítems al inventario.
 

--- a/public/inventario-re4.html
+++ b/public/inventario-re4.html
@@ -99,6 +99,13 @@
       transition: transform 0.2s, filter 0.2s;
     }
 
+    .item img {
+      width: 100%;
+      height: 100%;
+      object-fit: contain;
+      pointer-events: none;
+    }
+
     .item:hover {
       filter: brightness(1.1);
     }
@@ -205,9 +212,33 @@
     const GRID_WIDTH = 10, GRID_HEIGHT = 8, CELL_SIZE = 48;
     let inventory = [], selectedItem = null, draggedItem = null, dragOffset = { x: 0, y: 0 };
     const itemTemplates = [
-      { id: 'sword', width: 2, height: 1, name: 'Espada', category: 'weapon', rarity: 'common' },
-      { id: 'potion_health', width: 1, height: 1, name: 'Poción de salud', category: 'consumable', rarity: 'common' },
-      { id: 'shield', width: 2, height: 2, name: 'Escudo', category: 'armor', rarity: 'rare' }
+      {
+        id: 'sword',
+        width: 2,
+        height: 1,
+        name: 'Espada',
+        category: 'weapon',
+        rarity: 'common',
+        icon: 'marcas/Espada.png'
+      },
+      {
+        id: 'potion_health',
+        width: 1,
+        height: 1,
+        name: 'Poción de salud',
+        category: 'consumable',
+        rarity: 'common',
+        icon: 'https://via.placeholder.com/40'
+      },
+      {
+        id: 'shield',
+        width: 2,
+        height: 2,
+        name: 'Escudo',
+        category: 'armor',
+        rarity: 'rare',
+        icon: 'marcas/Armadura.png'
+      }
       // ...otros objetos...
     ];
 
@@ -317,7 +348,15 @@
       el.style.width = `${item.width * CELL_SIZE}px`;
       el.style.height = `${item.height * CELL_SIZE}px`;
       el.style.transform = `translate(${item.x * CELL_SIZE}px, ${item.y * CELL_SIZE}px)`;
-      el.textContent = item.name;
+      if (item.icon) {
+        const img = document.createElement('img');
+        img.src = item.icon;
+        img.alt = item.name;
+        img.className = 'w-full h-full object-contain pointer-events-none';
+        el.appendChild(img);
+      } else {
+        el.textContent = item.name;
+      }
       el.dataset.id = item.id;
 
       if (item.quantity > 1) {
@@ -344,6 +383,43 @@
 
       document.getElementById('inventoryGrid').appendChild(el);
       item.el = el;
+
+    }
+
+    function createLibrary() {
+      const lib = document.getElementById('itemLibrary');
+      if (!lib) return;
+      lib.innerHTML = '';
+      itemTemplates.forEach(t => {
+        const btn = document.createElement('div');
+        btn.className = `item rarity-${t.rarity} category-${t.category}`;
+        btn.style.width = `${t.width * CELL_SIZE}px`;
+        btn.style.height = `${t.height * CELL_SIZE}px`;
+        if (t.icon) {
+          const img = document.createElement('img');
+          img.src = t.icon;
+          img.alt = t.name;
+          img.className = 'w-full h-full object-contain pointer-events-none';
+          btn.appendChild(img);
+        } else {
+          btn.textContent = t.name;
+        }
+        btn.title = t.name;
+        btn.addEventListener('click', () => {
+          for (let y = 0; y < GRID_HEIGHT; y++) {
+            for (let x = 0; x < GRID_WIDTH; x++) {
+              if (canPlaceItem(x, y, t.width, t.height)) {
+                addItem(t.id, x, y, 1);
+                updateStats();
+                return;
+              }
+            }
+          }
+          alert('Inventario lleno');
+        });
+        lib.appendChild(btn);
+      });
+    }
 
     function selectItem(item) {
       if (selectedItem && selectedItem.el) selectedItem.el.classList.remove('item-selected');
@@ -460,11 +536,8 @@
     document.addEventListener('DOMContentLoaded', initInventory);
   </script>
 
-  <style>/* CSS irá aquí */</style>
 </head>
 <body>
-  <!-- HTML irá aquí -->
-  <script>/* JS irá aquí */</script>
 
 </body>
 </html>


### PR DESCRIPTION
## Summary
- enhance `inventario-re4.html` with item icons
- add missing closing brace for `renderItem`
- implement `createLibrary` to add items from a library
- remove leftover placeholders from the prototype
- document new feature in README

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6844c5938f148326933a652e78bad9cc