### PR TITLE
Center lockpicking instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Minijuegos
 
     Calculadora de dados integrada.
     Cerrajería con diana decreciente y niveles de dificultad revisados.
+    Texto centrado en las instrucciones de la cerrajería.
     Arreglos menores: constante DADOS exportada y validación PropTypes en MasterMenu.
     Configuración Firebase mejorada: usa variables de entorno o credenciales por defecto.
 

--- a/src/components/BarraReflejos.jsx
+++ b/src/components/BarraReflejos.jsx
@@ -206,7 +206,7 @@ const BarraReflejos = ({ playerName, onBack }) => {
             {/* Instrucciones */}
             <div className="bg-gray-800 rounded-lg p-4 border border-gray-700">
               <h3 className="text-lg font-semibold text-white mb-3 text-center">Cómo Jugar</h3>
-              <div className="text-sm text-gray-300 space-y-2">
+              <div className="text-sm text-gray-300 space-y-2 text-center">
                 <p>• Toca la pantalla cuando el círculo esté en la zona diana</p>
                 <p>• La diana se reduce cada segundo que pases</p>
                 <p>• Cuanto más difícil, más pequeña la diana y más rápida la bola</p>


### PR DESCRIPTION
## Summary
- center the text inside the lockpicking minigame instructions
- note the change in README

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*
- `npm install` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685d1602c99483268f11f9a09ee0e2f5