### PR TITLE
Fix enemy equipment data and clarify versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 
 ### 🎲 **Gestión de Personajes**
 
-> **Versión actual: 2.1.3**
+> **Versión actual: 2.1.6**
 
 **Resumen de cambios v2.1.3:**
 - Corrección de errores críticos de compilación: imports de iconos faltantes (GiFist, FaFire, FaBolt, FaSnowflake, FaRadiationAlt)
@@ -37,6 +37,15 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 - Eliminación de imports no usados: useState en Input.jsx
 - Proyecto ahora compila sin errores ni warnings de ESLint
 - Optimización de rendimiento y mantenibilidad del código
+
+**Resumen de cambios v2.1.5:**
+- Corrección al eliminar equipamiento de enemigos
+
+**Resumen de cambios v2.1.6:**
+- Corrección de equipamiento sin datos al agregar nuevas armas, armaduras o poderes en enemigos
+
+**Resumen de cambios v2.1.4:**
+- Prevención de error al mostrar el icono de daño cuando no se define el tipo
 
 **Resumen de cambios v2.1.2:**
 - Sistema de Píldoras de Equipamiento integrado en el Sistema de Velocidad para uso directo de armas y poderes
@@ -245,6 +254,10 @@ src/
 - Efectos de gradiente animado y brillo pulsante
 
 </details>
+
+## 📌 Lógica de Versionado
+
+Se sigue una numeración basada en [Semantic Versioning](https://semver.org/lang/es/). Las actualizaciones de **parche** (2.1.x) corrigen errores y ajustes menores. Las de **minor** (2.x.0) agregan funcionalidades notables sin romper compatibilidad. Un cambio mayor se reserva para modificaciones que alteran significativamente el comportamiento existente.
 
 ## 🤝 Contribución
 

--- a/src/App.js
+++ b/src/App.js
@@ -868,74 +868,125 @@ function App() {
   // FUNCIONES PARA EQUIPAR ITEMS A ENEMIGOS
   // ───────────────────────────────────────────────────────────
   const handleEnemyEquipWeapon = () => {
-    if (loading) return;
-    const f = armas.find(a => a && a.nombre.toLowerCase().includes(enemyInputArma.trim().toLowerCase()));
-    if (!f) return setEnemyArmaError('Arma no encontrada');
-    if (!selectedEnemy.weapons.includes(f.nombre)) {
-      setSelectedEnemy({ ...selectedEnemy, weapons: [...selectedEnemy.weapons, f.nombre] });
-      setEnemyInputArma('');
-      setEnemyArmaError('');
-    }
-  };
+      if (loading) return;
+      const f = armas.find(a => a && a.nombre.toLowerCase().includes(enemyInputArma.trim().toLowerCase()));
+      if (!f) return setEnemyArmaError('Arma no encontrada');
+      if (showEnemyForm) {
+        if (!newEnemy.weapons.some(w => w.nombre === f.nombre)) {
+          setNewEnemy({ ...newEnemy, weapons: [...newEnemy.weapons, f] });
+          setEnemyInputArma('');
+          setEnemyArmaError('');
+        }
+      } else if (selectedEnemy && !selectedEnemy.weapons.some(w => w.nombre === f.nombre)) {
+        setSelectedEnemy({ ...selectedEnemy, weapons: [...selectedEnemy.weapons, f] });
+        setEnemyInputArma('');
+        setEnemyArmaError('');
+      }
+    };
   const handleEnemyEquipWeaponFromSuggestion = (name) => {
-    const w = armas.find(a => a && a.nombre === name);
-    if (!w) return setEnemyArmaError('Arma no encontrada');
-    if (!selectedEnemy.weapons.includes(w.nombre)) {
-      setSelectedEnemy({ ...selectedEnemy, weapons: [...selectedEnemy.weapons, w.nombre] });
-      setEnemyInputArma('');
-      setEnemyArmaError('');
-    }
-  };
+      const w = armas.find(a => a && a.nombre === name);
+      if (!w) return setEnemyArmaError('Arma no encontrada');
+      if (showEnemyForm) {
+        if (!newEnemy.weapons.some(weapon => weapon.nombre === w.nombre)) {
+          setNewEnemy({ ...newEnemy, weapons: [...newEnemy.weapons, w] });
+          setEnemyInputArma('');
+          setEnemyArmaError('');
+        }
+      } else if (selectedEnemy && !selectedEnemy.weapons.some(weapon => weapon.nombre === w.nombre)) {
+        setSelectedEnemy({ ...selectedEnemy, weapons: [...selectedEnemy.weapons, w] });
+        setEnemyInputArma('');
+        setEnemyArmaError('');
+      }
+    };
   const handleEnemyEquipArmor = () => {
-    if (loading) return;
-    const f = armaduras.find(a => a && a.nombre.toLowerCase().includes(enemyInputArmadura.trim().toLowerCase()));
-    if (!f) return setEnemyArmaduraError('Armadura no encontrada');
-    if (!selectedEnemy.armaduras.includes(f.nombre)) {
-      setSelectedEnemy({ ...selectedEnemy, armaduras: [...selectedEnemy.armaduras, f.nombre] });
-      setEnemyInputArmadura('');
-      setEnemyArmaduraError('');
-    }
-  };
+      if (loading) return;
+      const f = armaduras.find(a => a && a.nombre.toLowerCase().includes(enemyInputArmadura.trim().toLowerCase()));
+      if (!f) return setEnemyArmaduraError('Armadura no encontrada');
+      if (showEnemyForm) {
+        if (!newEnemy.armaduras.some(a => a.nombre === f.nombre)) {
+          setNewEnemy({ ...newEnemy, armaduras: [...newEnemy.armaduras, f] });
+          setEnemyInputArmadura('');
+          setEnemyArmaduraError('');
+        }
+      } else if (selectedEnemy && !selectedEnemy.armaduras.some(a => a.nombre === f.nombre)) {
+        setSelectedEnemy({ ...selectedEnemy, armaduras: [...selectedEnemy.armaduras, f] });
+        setEnemyInputArmadura('');
+        setEnemyArmaduraError('');
+      }
+    };
   const handleEnemyEquipArmorFromSuggestion = (name) => {
-    const a = armaduras.find(x => x && x.nombre === name);
-    if (!a) return setEnemyArmaduraError('Armadura no encontrada');
-    if (!selectedEnemy.armaduras.includes(a.nombre)) {
-      setSelectedEnemy({ ...selectedEnemy, armaduras: [...selectedEnemy.armaduras, a.nombre] });
-      setEnemyInputArmadura('');
-      setEnemyArmaduraError('');
-    }
-  };
+      const a = armaduras.find(x => x && x.nombre === name);
+      if (!a) return setEnemyArmaduraError('Armadura no encontrada');
+      if (showEnemyForm) {
+        if (!newEnemy.armaduras.some(armor => armor.nombre === a.nombre)) {
+          setNewEnemy({ ...newEnemy, armaduras: [...newEnemy.armaduras, a] });
+          setEnemyInputArmadura('');
+          setEnemyArmaduraError('');
+        }
+      } else if (selectedEnemy && !selectedEnemy.armaduras.some(armor => armor.nombre === a.nombre)) {
+        setSelectedEnemy({ ...selectedEnemy, armaduras: [...selectedEnemy.armaduras, a] });
+        setEnemyInputArmadura('');
+        setEnemyArmaduraError('');
+      }
+    };
   const handleEnemyEquipPower = () => {
-    if (loading) return;
-    const f = habilidades.find(h => h && h.nombre && h.nombre.toLowerCase().includes(enemyInputPoder.trim().toLowerCase()));
-    if (!f) return setEnemyPoderError('Poder no encontrado');
-    if (!selectedEnemy.poderes.includes(f.nombre)) {
-      setSelectedEnemy({ ...selectedEnemy, poderes: [...selectedEnemy.poderes, f.nombre] });
-      setEnemyInputPoder('');
-      setEnemyPoderError('');
-    }
-  };
+      if (loading) return;
+      const f = habilidades.find(h => h && h.nombre && h.nombre.toLowerCase().includes(enemyInputPoder.trim().toLowerCase()));
+      if (!f) return setEnemyPoderError('Poder no encontrado');
+      if (showEnemyForm) {
+        if (!newEnemy.poderes.some(p => p.nombre === f.nombre)) {
+          setNewEnemy({ ...newEnemy, poderes: [...newEnemy.poderes, f] });
+          setEnemyInputPoder('');
+          setEnemyPoderError('');
+        }
+      } else if (selectedEnemy && !selectedEnemy.poderes.some(p => p.nombre === f.nombre)) {
+        setSelectedEnemy({ ...selectedEnemy, poderes: [...selectedEnemy.poderes, f] });
+        setEnemyInputPoder('');
+        setEnemyPoderError('');
+      }
+    };
   const handleEnemyEquipPowerFromSuggestion = (name) => {
-    const h = habilidades.find(x => x && x.nombre === name);
-    if (!h) return setEnemyPoderError('Poder no encontrado');
-    if (!selectedEnemy.poderes.includes(h.nombre)) {
-      setSelectedEnemy({ ...selectedEnemy, poderes: [...selectedEnemy.poderes, h.nombre] });
-      setEnemyInputPoder('');
-      setEnemyPoderError('');
-    }
-  };
+      const h = habilidades.find(x => x && x.nombre === name);
+      if (!h) return setEnemyPoderError('Poder no encontrado');
+      if (showEnemyForm) {
+        if (!newEnemy.poderes.some(power => power.nombre === h.nombre)) {
+          setNewEnemy({ ...newEnemy, poderes: [...newEnemy.poderes, h] });
+          setEnemyInputPoder('');
+          setEnemyPoderError('');
+        }
+      } else if (selectedEnemy && !selectedEnemy.poderes.some(power => power.nombre === h.nombre)) {
+        setSelectedEnemy({ ...selectedEnemy, poderes: [...selectedEnemy.poderes, h] });
+        setEnemyInputPoder('');
+        setEnemyPoderError('');
+      }
+    };
   const unequipEnemyWeapon = (index) => {
-    const updatedWeapons = selectedEnemy.weapons.filter((_, i) => i !== index);
-    setSelectedEnemy({ ...selectedEnemy, weapons: updatedWeapons });
-  };
+      if (showEnemyForm) {
+        const updatedWeapons = newEnemy.weapons.filter((_, i) => i !== index);
+        setNewEnemy({ ...newEnemy, weapons: updatedWeapons });
+      } else if (selectedEnemy) {
+        const updatedWeapons = selectedEnemy.weapons.filter((_, i) => i !== index);
+        setSelectedEnemy({ ...selectedEnemy, weapons: updatedWeapons });
+      }
+    };
   const unequipEnemyArmor = (index) => {
-    const updatedArmors = selectedEnemy.armaduras.filter((_, i) => i !== index);
-    setSelectedEnemy({ ...selectedEnemy, armaduras: updatedArmors });
-  };
+      if (showEnemyForm) {
+        const updatedArmors = newEnemy.armaduras.filter((_, i) => i !== index);
+        setNewEnemy({ ...newEnemy, armaduras: updatedArmors });
+      } else if (selectedEnemy) {
+        const updatedArmors = selectedEnemy.armaduras.filter((_, i) => i !== index);
+        setSelectedEnemy({ ...selectedEnemy, armaduras: updatedArmors });
+      }
+    };
   const unequipEnemyPower = (index) => {
-    const updatedPowers = selectedEnemy.poderes.filter((_, i) => i !== index);
-    setSelectedEnemy({ ...selectedEnemy, poderes: updatedPowers });
-  };
+      if (showEnemyForm) {
+        const updatedPowers = newEnemy.poderes.filter((_, i) => i !== index);
+        setNewEnemy({ ...newEnemy, poderes: updatedPowers });
+      } else if (selectedEnemy) {
+        const updatedPowers = selectedEnemy.poderes.filter((_, i) => i !== index);
+        setSelectedEnemy({ ...selectedEnemy, poderes: updatedPowers });
+      }
+    };
   // ───────────────────────────────────────────────────────────
   // HANDLERS para Login y Equipo de objetos
   // ───────────────────────────────────────────────────────────
@@ -1180,6 +1231,7 @@ function App() {
 
   const dadoIcono = () => <BsDice6 className="inline" />;
   const iconoDano = tipo => {
+    if (!tipo) return null;
     switch (tipo.toLowerCase()) {
       case 'físico':    return <GiFist className="inline" />;
       case 'fuego':     return <FaFire className="inline" />;
@@ -1259,8 +1311,8 @@ function App() {
           </div>
           {/* Footer minimalista */}
           <div className="text-center space-y-2 border-t border-gray-700 pt-6">
-            <p className="text-sm font-medium text-gray-400">Versión 2.1.2</p>
-            <p className="text-xs text-gray-500">Adición del Sistema de gestión de Velocidad.</p>
+            <p className="text-sm font-medium text-gray-400">Versión 2.1.6</p>
+            <p className="text-xs text-gray-500">Corrección de equipamiento sin datos en enemigos.</p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- prevent weapons, armor and powers from being saved as plain names when editing enemies
- bump version to 2.1.6 and document fix for missing equipment data
- add short section describing the versioning policy

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68646b5cc8e4832686437f0e4aba6c58