### PR TITLE
Add heal and buff buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 
 **Resumen de cambios v2.2.3:**
 - Carga de enemigos ahora usa datos locales en lugar de una petición `/api`
+- Botón verde "+" ahora incrementa el recurso hasta el máximo base
+- Nuevo botón dorado "+" permite aplicar buffs temporales
 - 
 **Resumen de cambios v2.1.9:**
 - Animación de dados ahora se desliza en la dirección del control

--- a/src/App.js
+++ b/src/App.js
@@ -619,6 +619,13 @@ function App() {
     const newStats = { ...playerData.stats, [r]: s };
     savePlayer({ ...playerData, stats: newStats });
   };
+  const handleIncrease = (r) => {
+    const s = { ...playerData.stats[r] };
+    const baseLimit = Math.max(0, (s.total || 0) - (s.buff || 0));
+    s.actual = Math.min(baseLimit, s.actual + 1);
+    const newStats = { ...playerData.stats, [r]: s };
+    savePlayer({ ...playerData, stats: newStats });
+  };
   const handleAddBuff = (r) => {
     const s = { ...playerData.stats[r] };
     s.buff = (s.buff || 0) + 1;
@@ -1706,6 +1713,13 @@ function App() {
                       />
                       <Boton
                         color="green"
+                        className="w-8 h-8 p-0 flex items-center justify-center font-extrabold rounded"
+                        onClick={() => handleIncrease(r)}
+                      >
+                        +
+                      </Boton>
+                      <Boton
+                        color="yellow"
                         className="w-8 h-8 p-0 flex items-center justify-center font-extrabold rounded"
                         onClick={() => handleAddBuff(r)}
                       >


### PR DESCRIPTION
## Summary
- adjust stats controls
- normal plus button now heals instead of buffing
- add new yellow plus to buff stats
- document changes in README

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6865b78f64f08326b7ea8cbaa80ba381