### PR TITLE
Add backup and reset buttons for player sheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 
 ### 🎲 **Gestión de Personajes**
 
-> **Versión actual: 2.1.10**
+> **Versión actual: 2.1.11**
 
 **Resumen de cambios v2.1.3:**
 - Corrección de errores críticos de compilación: imports de iconos faltantes (GiFist, FaFire, FaBolt, FaSnowflake, FaRadiationAlt)
@@ -56,6 +56,10 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 **Resumen de cambios v2.1.10:**
 - Nuevo botón dorado para aplicar buffs a las estadísticas.
 - El botón verde "+" ahora incrementa el recurso hasta su valor base.
+
+**Resumen de cambios v2.1.11:**
+- Botón **Guardar datos** para respaldar la ficha completa.
+- Botón **RESET** que restaura la ficha al último respaldo guardado.
 - 
 **Resumen de cambios v2.1.4:**
 - Prevención de error al mostrar el icono de daño cuando no se define el tipo

--- a/src/App.js
+++ b/src/App.js
@@ -347,6 +347,27 @@ function App() {
     await deleteDoc(doc(db, 'players', playerName));
     volverAlMenu();
   };
+  const guardarDatosFicha = () => {
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem(
+        `player_${playerName}_backup`,
+        JSON.stringify(playerData)
+      );
+    }
+  };
+  const resetearFichaDesdeBackup = async () => {
+    if (typeof window === 'undefined') return;
+    const backup = window.localStorage.getItem(`player_${playerName}_backup`);
+    if (backup) {
+      const data = JSON.parse(backup);
+      await savePlayer(
+        data,
+        data.resourcesList,
+        data.claves,
+        data.estados
+      );
+    }
+  };
   // ───────────────────────────────────────────────────────────
   // FETCH EXISTING PLAYERS
   // ───────────────────────────────────────────────────────────
@@ -1577,6 +1598,18 @@ function App() {
               className="py-3 px-6 rounded-lg font-extrabold text-base tracking-wide shadow-sm w-full sm:w-auto"
               onClick={eliminarFichaJugador}
             >Eliminar ficha</Boton>
+          </div>
+          <div className="flex flex-col sm:flex-row gap-4 mb-6 w-full justify-center">
+            <Boton
+              color="blue"
+              className="py-3 px-6 rounded-lg font-extrabold text-base tracking-wide shadow-sm w-full sm:w-auto"
+              onClick={guardarDatosFicha}
+            >Guardar datos</Boton>
+            <Boton
+              color="yellow"
+              className="py-3 px-6 rounded-lg font-extrabold text-base tracking-wide shadow-sm w-full sm:w-auto"
+              onClick={resetearFichaDesdeBackup}
+            >RESET</Boton>
           </div>
           {/* ATRIBUTOS */}
           <h2 className="text-xl font-semibold text-center mb-4">Atributos</h2>


### PR DESCRIPTION
## Summary
- add actions to store/restore a backup of player data
- place **Guardar datos** and **RESET** buttons below the menu buttons
- document new behaviour and bump version

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6865c6ae269c8326b9ae1fd01230fd77