### PR TITLE
Add backup and restore for entire player sheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 
 ### 🎲 **Gestión de Personajes**
 
-> **Versión actual: 2.1.10**
+> **Versión actual: 2.1.12**
 
 **Resumen de cambios v2.1.3:**
 - Corrección de errores críticos de compilación: imports de iconos faltantes (GiFist, FaFire, FaBolt, FaSnowflake, FaRadiationAlt)
@@ -56,6 +56,12 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 **Resumen de cambios v2.1.10:**
 - Nuevo botón dorado para aplicar buffs a las estadísticas.
 - El botón verde "+" ahora incrementa el recurso hasta su valor base.
+
+**Resumen de cambios v2.1.11:**
+- Botón **Guardar datos** para respaldar la ficha completa.
+- Botón **RESET** que restaura la ficha al último respaldo guardado.
+- Copia de seguridad ahora también incluye estadísticas eliminadas, claves,
+  estados e inventario.
 - 
 **Resumen de cambios v2.1.4:**
 - Prevención de error al mostrar el icono de daño cuando no se define el tipo

--- a/src/App.js
+++ b/src/App.js
@@ -347,6 +347,40 @@ function App() {
     await deleteDoc(doc(db, 'players', playerName));
     volverAlMenu();
   };
+  const guardarDatosFicha = async () => {
+    if (typeof window === 'undefined') return;
+    const invSnap = await getDoc(doc(db, 'inventory', playerName));
+    const snapshot = {
+      playerData,
+      resourcesList,
+      claves,
+      estados,
+      inventory: invSnap.exists() ? invSnap.data() : null,
+    };
+    window.localStorage.setItem(
+      `player_${playerName}_backup`,
+      JSON.stringify(snapshot)
+    );
+  };
+  const resetearFichaDesdeBackup = async () => {
+    if (typeof window === 'undefined') return;
+    const backup = window.localStorage.getItem(`player_${playerName}_backup`);
+    if (backup) {
+      const data = JSON.parse(backup);
+      await savePlayer(
+        data.playerData,
+        data.resourcesList,
+        data.claves,
+        data.estados
+      );
+      setResourcesList(data.resourcesList || []);
+      setClaves(data.claves || []);
+      setEstados(data.estados || []);
+      if (data.inventory) {
+        await setDoc(doc(db, 'inventory', playerName), data.inventory);
+      }
+    }
+  };
   // ───────────────────────────────────────────────────────────
   // FETCH EXISTING PLAYERS
   // ───────────────────────────────────────────────────────────
@@ -1577,6 +1611,18 @@ function App() {
               className="py-3 px-6 rounded-lg font-extrabold text-base tracking-wide shadow-sm w-full sm:w-auto"
               onClick={eliminarFichaJugador}
             >Eliminar ficha</Boton>
+          </div>
+          <div className="flex flex-col sm:flex-row gap-4 mb-6 w-full justify-center">
+            <Boton
+              color="blue"
+              className="py-3 px-6 rounded-lg font-extrabold text-base tracking-wide shadow-sm w-full sm:w-auto"
+              onClick={guardarDatosFicha}
+            >Guardar datos</Boton>
+            <Boton
+              color="yellow"
+              className="py-3 px-6 rounded-lg font-extrabold text-base tracking-wide shadow-sm w-full sm:w-auto"
+              onClick={resetearFichaDesdeBackup}
+            >RESET</Boton>
           </div>
           {/* ATRIBUTOS */}
           <h2 className="text-xl font-semibold text-center mb-4">Atributos</h2>


### PR DESCRIPTION
## Summary
- include resources, keys, states and inventory in backup snapshot
- restoring from backup now recovers stats and inventory
- update README to version 2.1.12

## Testing
- `CI=true npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6865c6ae269c8326b9ae1fd01230fd77