### PR TITLE
Add default base stats on new sheet creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 
 ### 🎲 **Gestión de Personajes**
 
-> **Versión actual: 2.2.0**
+> **Versión actual: 2.2.1**
 
 **Resumen de cambios v2.1.1:**
 - Rediseño visual de la vista de enemigos como cartas tipo Magic, con layout responsive y efectos visuales exclusivos.
@@ -87,6 +87,10 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 - **Carga física y mental** - Sistema automático de penalizaciones por peso
 - **Estados del personaje** - Seguimiento de efectos activos con iconos
 - **Inventario tradicional** - Sistema de slots drag & drop para objetos básicos
+
+**Resumen de cambios v2.2.1:**
+- Las fichas nuevas ahora incluyen las estadísticas base de Postura, Vida,
+  Ingenio, Cordura y Armadura con sus colores predeterminados.
 
 ### 🛠️ **Características Técnicas**
 - **Interfaz responsive** - Optimizada para móviles y escritorio con TailwindCSS

--- a/src/App.js
+++ b/src/App.js
@@ -53,6 +53,18 @@ const recursoInfo = {
   armadura: 'Explicación de Armadura',
 };
 
+const defaultStats = defaultRecursos.reduce((acc, r) => {
+  acc[r] = { base: 0, buff: 0, total: 0, actual: 0 };
+  return acc;
+}, {});
+
+const defaultResourcesList = defaultRecursos.map(name => ({
+  id: name,
+  name,
+  color: recursoColor[name] || '#ffffff',
+  info: recursoInfo[name] || ''
+}));
+
 const RESOURCE_MAX = 20;
 const CLAVE_MAX = 10;
 const dadoImgUrl = dado => `/dados/${dado}.png`;
@@ -195,12 +207,7 @@ function App() {
     agregarRecurso,
     eliminarRecurso,
   } = useResourcesHook(
-    defaultRecursos.map(name => ({
-      id: name,
-      name,
-      color: recursoColor[name] || '#ffffff',
-      info: recursoInfo[name] || ''
-    })),
+    defaultResourcesList,
     (data, list) => savePlayer(data, list),
     playerData
   );
@@ -550,17 +557,13 @@ function App() {
           claves: [],
           estados: [],
           atributos: { fuerza: 0, destreza: 0, constitucion: 0, inteligencia: 0, sabiduria: 0, carisma: 0 },
-          stats: {
-            vida: { base: 0, buff: 0, total: 0, actual: 0 },
-            postura: { base: 0, buff: 0, total: 0, actual: 0 },
-            cordura: { base: 0, buff: 0, total: 0, actual: 0 }
-          },
+          stats: { ...defaultStats },
           cargaAcumulada: { fisica: 0, mental: 0 },
-          resourcesList: [],
+          resourcesList: defaultResourcesList,
           updatedAt: new Date()
         };
         setPlayerData(defaultData);
-        setResourcesList([]);
+        setResourcesList(defaultResourcesList);
         setClaves([]);
         setEstados([]);
       }
@@ -573,17 +576,13 @@ function App() {
         claves: [],
         estados: [],
         atributos: { fuerza: 0, destreza: 0, constitucion: 0, inteligencia: 0, sabiduria: 0, carisma: 0 },
-        stats: {
-          vida: { base: 0, buff: 0, total: 0, actual: 0 },
-          postura: { base: 0, buff: 0, total: 0, actual: 0 },
-          cordura: { base: 0, buff: 0, total: 0, actual: 0 }
-        },
+        stats: { ...defaultStats },
         cargaAcumulada: { fisica: 0, mental: 0 },
-        resourcesList: [],
+        resourcesList: defaultResourcesList,
         updatedAt: new Date()
       };
       setPlayerData(defaultData);
-      setResourcesList([]);
+      setResourcesList(defaultResourcesList);
       setClaves([]);
       setEstados([]);
     }
@@ -786,10 +785,7 @@ function App() {
   const createNewEnemy = () => {
     const baseAtributos = {};
     atributos.forEach(k => (baseAtributos[k] = 'D4'));
-    const baseStats = {};
-    defaultRecursos.forEach(r => {
-      baseStats[r] = { base: 0, total: 0, actual: 0, buff: 0 };
-    });
+    const baseStats = { ...defaultStats };
     setNewEnemy({
       name: '',
       portrait: '',


### PR DESCRIPTION
## Summary
- initialize default stats and resource list in `App.js`
- ensure new sheets start with all base stats
- keep enemy creation consistent with new constants
- update README to version 2.2.1

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6865d6203f188326838df63de7479aca