### PR TITLE
Add selectable resistances for load

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 **Resumen de cambios v2.2.1:**
 - Las fichas nuevas ahora incluyen las estadísticas base de Postura, Vida,
   Ingenio, Cordura y Armadura con sus colores predeterminados.
+- Dos resistencias configurables: por defecto Vida para carga física e
+  Ingenio para carga mental, seleccionables por el jugador.
 
 ### 🛠️ **Características Técnicas**
 - **Interfaz responsive** - Optimizada para móviles y escritorio con TailwindCSS


### PR DESCRIPTION
## Summary
- let each character pick a stat for physical and mental resistance
- display resistance selectors and values in the UI
- update load calculations to use both resistance stats
- document new feature in README

## Testing
- `npm install --silent`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6865da6215b08326b8684db4fd841c17