### PR TITLE
Agregar nuevo recurso pólvora y limitar stacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 
 ### 🎲 **Gestión de Personajes**
 
-> **Versión actual: 2.2.1**
+> **Versión actual: 2.2.2**
 
 **Resumen de cambios v2.1.1:**
 - Rediseño visual de la vista de enemigos como cartas tipo Magic, con layout responsive y efectos visuales exclusivos.
@@ -93,6 +93,10 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
   Ingenio, Cordura y Armadura con sus colores predeterminados.
 - Dos resistencias configurables: por defecto Vida para carga física e
   Ingenio para carga mental, seleccionables por el jugador.
+
+**Resumen de cambios v2.2.2:**
+- Límite de 5 objetos por ranura en el inventario tradicional.
+- Nuevo recurso "pólvora" con color e icono propios.
 
 ### 🛠️ **Características Técnicas**
 - **Interfaz responsive** - Optimizada para móviles y escritorio con TailwindCSS

--- a/src/components/inventory/Inventory.jsx
+++ b/src/components/inventory/Inventory.jsx
@@ -46,11 +46,13 @@ const Inventory = ({ playerName }) => {
     setNextId(id => id + 1);
   };
 
+  const MAX_STACK = 5;
+
   const handleDrop = (index, dragged) => {
     setSlots(s => s.map((slot, i) => {
       if (i !== index) return slot;
       if (!slot.item) return { ...slot, item: { type: dragged.type, count: 1 } };
-      return { ...slot, item: { ...slot.item, count: Math.min(slot.item.count + 1, 99) } };
+      return { ...slot, item: { ...slot.item, count: Math.min(slot.item.count + 1, MAX_STACK) } };
     }));
   };
 

--- a/src/components/inventory/ItemGenerator.jsx
+++ b/src/components/inventory/ItemGenerator.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import Input from '../Input';
 
-const ITEMS = ['remedio', 'chatarra', 'comida'];
+const ITEMS = ['remedio', 'chatarra', 'comida', 'polvora'];
 
 const ItemGenerator = ({ onGenerate }) => {
   const [query, setQuery] = useState('');

--- a/src/components/inventory/ItemToken.jsx
+++ b/src/components/inventory/ItemToken.jsx
@@ -11,30 +11,35 @@ const icons = {
   remedio: '💊',
   chatarra: '⚙️',
   comida: '🍖',
+  polvora: '💥',
 };
 
 const colors = {
   remedio: 'bg-blue-300',
   chatarra: 'bg-yellow-300',
   comida: 'bg-green-300',
+  polvora: 'bg-gray-400',
 };
 
 const gradients = {
   remedio: 'from-blue-200 via-blue-400 to-blue-200',
   chatarra: 'from-yellow-200 via-yellow-400 to-yellow-200',
   comida: 'from-green-200 via-green-400 to-green-200',
+  polvora: 'from-gray-300 via-gray-500 to-gray-300',
 };
 
 const borders = {
   remedio: 'border-blue-400',
   chatarra: 'border-yellow-400',
   comida: 'border-green-400',
+  polvora: 'border-gray-500',
 };
 
 const descriptions = {
   remedio: 'Un remedio curativo',
   chatarra: 'Partes de recambio variadas',
   comida: 'Provisiones comestibles',
+  polvora: 'Material explosivo en polvo',
 };
 
 const ItemToken = ({ id, type = 'remedio', count = 1, fromSlot = null }) => {

--- a/src/components/inventory/ItemToken.test.js
+++ b/src/components/inventory/ItemToken.test.js
@@ -8,3 +8,9 @@ test('renders icon and count', () => {
   getByText('🍖');
   getByText('2');
 });
+
+test('supports new polvora type', () => {
+  const { getByText } = render(<ItemToken id="2" type="polvora" count={1} />);
+  getByText('💥');
+  getByText('1');
+});

--- a/src/components/inventory/Slot.jsx
+++ b/src/components/inventory/Slot.jsx
@@ -7,12 +7,14 @@ const borderColors = {
   remedio: 'border-blue-400',
   chatarra: 'border-yellow-400',
   comida: 'border-green-400',
+  polvora: 'border-gray-500',
 };
 
 const ringColors = {
   remedio: 'ring-blue-400',
   chatarra: 'ring-yellow-400',
   comida: 'ring-green-400',
+  polvora: 'ring-gray-500',
 };
 
 const Slot = ({ id, item, onDrop, onDelete }) => {


### PR DESCRIPTION
## Summary
- limite de 5 objetos por slot en el inventario
- soporte para nuevo recurso "pólvora" con color e icono
- test actualizado para el nuevo item
- se actualiza README con cambios de la versión 2.2.2

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6865e37de5588326a16defad8be98201