### PR TITLE
Fix Álvaro buff detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 
 ### 🎲 **Gestión de Personajes**
 
-> **Versión actual: 2.2.2**
+> **Versión actual: 2.2.5**
 
 **Resumen de cambios v2.1.1:**
 - Rediseño visual de la vista de enemigos como cartas tipo Magic, con layout responsive y efectos visuales exclusivos.
@@ -97,6 +97,10 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 **Resumen de cambios v2.2.2:**
 - Límite de 5 objetos por ranura en el inventario tradicional.
 - Nuevo recurso "pólvora" con color e icono propios.
+
+**Resumen de cambios v2.2.5:**
+- Ajuste exclusivo: los buffs de Álvaro siempre cuentan como base cuando se usan para la resistencia física o mental.
+- Detección mejorada de la ficha de Álvaro para aplicar la regla solo a él.
 
 ### 🛠️ **Características Técnicas**
 - **Interfaz responsive** - Optimizada para móviles y escritorio con TailwindCSS

--- a/src/App.js
+++ b/src/App.js
@@ -88,7 +88,17 @@ const cargaMentalIcon = (v) => {
   const n = parseCargaValue(v);
   return n > 0 ? '🧠'.repeat(n) : '❌';
 };
-const applyCargaPenalties = (data, armas, armaduras) => {
+const normalizeName = (name) =>
+  name
+    ? name
+        .normalize('NFD')
+        .replace(/[\u0300-\u036f]/g, '')
+        .toLowerCase()
+        .replace(/\s+/g, '')
+    : '';
+const ALVARO_KEY = 'alvaro';
+
+const applyCargaPenalties = (data, armas, armaduras, currentPlayerName = '') => {
   let fisica = 0;
   let mental = 0;
   data.weapons?.forEach(n => {
@@ -106,11 +116,28 @@ const applyCargaPenalties = (data, armas, armaduras) => {
     }
   });
   
-  const resistenciaFisica =
-    data.stats?.[data.resistenciaFisica || 'vida']?.total ?? 0;
-  const resistenciaMental =
-    data.stats?.[data.resistenciaMental || 'ingenio']?.total ?? 0;
+  const isAlvaro = normalizeName(currentPlayerName).includes(ALVARO_KEY);
+  const rfId = data.resistenciaFisica || 'vida';
+  const rmId = data.resistenciaMental || 'ingenio';
   const newStats = { ...data.stats };
+  if (isAlvaro) {
+    if (newStats[rfId]) {
+      const base = newStats[rfId].base || 0;
+      const buff = newStats[rfId].buff || 0;
+      const total = Math.min(base + buff, RESOURCE_MAX);
+      newStats[rfId].total = total;
+      if (newStats[rfId].actual > total) newStats[rfId].actual = total;
+    }
+    if (newStats[rmId]) {
+      const base = newStats[rmId].base || 0;
+      const buff = newStats[rmId].buff || 0;
+      const total = Math.min(base + buff, RESOURCE_MAX);
+      newStats[rmId].total = total;
+      if (newStats[rmId].actual > total) newStats[rmId].actual = total;
+    }
+  }
+  const resistenciaFisica = newStats[rfId]?.total || 0;
+  const resistenciaMental = newStats[rmId]?.total || 0;
   if (newStats.postura) {
     const base = newStats.postura.base || 0;
     const buff = newStats.postura.buff || 0;
@@ -569,7 +596,12 @@ function App() {
       
       if (docSnap.exists()) {
         const data = docSnap.data();
-        const recalculated = applyCargaPenalties(data, armas, armaduras);
+        const recalculated = applyCargaPenalties(
+          data,
+          armas,
+          armaduras,
+          playerName
+        );
         setPlayerData(recalculated);
         setResourcesList(recalculated.resourcesList || []);
         setClaves(recalculated.claves || []);
@@ -657,7 +689,12 @@ function App() {
     clavesParaGuardar = claves,
     estadosParaGuardar = estados
   ) => {
-    const recalculated = applyCargaPenalties(data, armas, armaduras);
+    const recalculated = applyCargaPenalties(
+      data,
+      armas,
+      armaduras,
+      playerName
+    );
     const fullData = {
       ...recalculated,
       resourcesList: listaParaGuardar,


### PR DESCRIPTION
## Summary
- improve Álvaro sheet detection so buffs only apply to him
- bump docs to version 2.2.5

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68666a2b664483268de6a34717512a5b