### PR TITLE
Fix Álvaro buff detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 
 ### 🎲 **Gestión de Personajes**
 
-> **Versión actual: 2.2.2**
+> **Versión actual: 2.2.7**
 
 **Resumen de cambios v2.1.1:**
 - Rediseño visual de la vista de enemigos como cartas tipo Magic, con layout responsive y efectos visuales exclusivos.
@@ -97,6 +97,17 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 **Resumen de cambios v2.2.2:**
 - Límite de 5 objetos por ranura en el inventario tradicional.
 - Nuevo recurso "pólvora" con color e icono propios.
+
+**Resumen de cambios v2.2.5:**
+- Ajuste exclusivo: los buffs de Álvaro siempre cuentan como base cuando se usan para la resistencia física o mental.
+- Detección mejorada de la ficha de Álvaro para aplicar la regla solo a él.
+
+**Resumen de cambios v2.2.6:**
+- Corrección: los buffs de Postura solo cuentan para la resistencia en la ficha de Álvaro.
+
+**Resumen de cambios v2.2.7:**
+- Se corrige la penalización de Postura para que otras fichas ignoren el buff al calcular la resistencia.
+
 
 ### 🛠️ **Características Técnicas**
 - **Interfaz responsive** - Optimizada para móviles y escritorio con TailwindCSS


### PR DESCRIPTION
## Summary
- improve Álvaro sheet detection so buffs only apply to him
- bump docs to version 2.2.7
- fix posture buff so only Álvaro gets resistance boost

## Testing
- `npm install --silent`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68666a2b664483268de6a34717512a5b