### PR TITLE
Add basic VTT canvas

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,11 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 - **Interfaz color-coded** - Identificación visual por jugador y tipo de equipamiento
 - **Sincronización en tiempo real** - Cambios instantáneos para todos los participantes
 - **Modo Master y Jugador** - Controles especializados según el rol del usuario
+- **Mapa de Batalla integrado** - VTT sencillo con grid y tokens arrastrables
 
 ### 🎲 **Gestión de Personajes**
 
-> **Versión actual: 2.2.8**
+> **Versión actual: 2.2.9**
 
 **Resumen de cambios v2.1.1:**
 - Rediseño visual de la vista de enemigos como cartas tipo Magic, con layout responsive y efectos visuales exclusivos.

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@testing-library/user-event": "^13.5.0",
         "firebase": "^11.8.1",
         "framer-motion": "^12.19.1",
+        "konva": "^9.3.20",
         "react": "^19.1.0",
         "react-dnd": "^16.0.1",
         "react-dnd-html5-backend": "^16.0.1",
@@ -21,6 +22,7 @@
         "react-dom": "^19.1.0",
         "react-flip-move": "^3.0.5",
         "react-icons": "^5.5.0",
+        "react-konva": "^19.0.7",
         "react-scripts": "5.0.1",
         "react-tooltip": "^5.28.1",
         "web-vitals": "^2.1.4"
@@ -4646,6 +4648,25 @@
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
       "license": "MIT"
     },
+    "node_modules/@types/react": {
+      "version": "19.1.8",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.8.tgz",
+      "integrity": "sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/react-reconciler": {
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.32.0.tgz",
+      "integrity": "sha512-+WHarFkJevhH1s655qeeSEf/yxFST0dVRsmSqUgxG8mMOKqycgYBv2wVpyubBY7MX8KiX5FQ03rNIwrxfm7Bmw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*"
+      }
+    },
     "node_modules/@types/resolve": {
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.17.1.tgz",
@@ -7179,6 +7200,13 @@
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
       "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
       "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -10851,6 +10879,27 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/its-fine": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/its-fine/-/its-fine-2.0.0.tgz",
+      "integrity": "sha512-KLViCmWx94zOvpLwSlsx6yOCeMhZYaxrJV87Po5k/FoZzcPSahvK5qJ7fYhS61sZi5ikmh2S3Hz55A2l3U69ng==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/react-reconciler": "^0.28.9"
+      },
+      "peerDependencies": {
+        "react": "^19.0.0"
+      }
+    },
+    "node_modules/its-fine/node_modules/@types/react-reconciler": {
+      "version": "0.28.9",
+      "resolved": "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.28.9.tgz",
+      "integrity": "sha512-HHM3nxyUZ3zAylX8ZEyrDNd2XZOnQ0D5XfunJF5FLQnZbHHYq4UWvW1QfelQNXv1ICNkwYhfxjwfnqivYB6bFg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*"
+      }
+    },
     "node_modules/jackspeak": {
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
@@ -12001,6 +12050,26 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/konva": {
+      "version": "9.3.20",
+      "resolved": "https://registry.npmjs.org/konva/-/konva-9.3.20.tgz",
+      "integrity": "sha512-7XPD/YtgfzC8b1c7z0hhY5TF1IO/pBYNa29zMTA2PeBaqI0n5YplUeo4JRuRcljeAF8lWtW65jePZZF7064c8w==",
+      "funding": [
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/lavrton"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/konva"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/lavrton"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/language-subtag-registry": {
       "version": "0.3.23",
@@ -14992,6 +15061,52 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "license": "MIT"
+    },
+    "node_modules/react-konva": {
+      "version": "19.0.7",
+      "resolved": "https://registry.npmjs.org/react-konva/-/react-konva-19.0.7.tgz",
+      "integrity": "sha512-uYWCpSv4ajLymTh8S8fV9396fHDX7eDTWiLGkYlBuawud5MoNiuGjapPhA5Avdy/Jfh9P2KaWuNf4i9PI1F9HQ==",
+      "funding": [
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/lavrton"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/konva"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/lavrton"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/react-reconciler": "^0.32.0",
+        "its-fine": "^2.0.0",
+        "react-reconciler": "0.32.0",
+        "scheduler": "0.26.0"
+      },
+      "peerDependencies": {
+        "konva": "^8.0.1 || ^7.2.5 || ^9.0.0",
+        "react": "^18.3.1 || ^19.0.0",
+        "react-dom": "^18.3.1 || ^19.0.0"
+      }
+    },
+    "node_modules/react-reconciler": {
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.32.0.tgz",
+      "integrity": "sha512-2NPMOzgTlG0ZWdIf3qG+dcbLSoAc/uLfOwckc3ofy5sSK0pLJqnQLpUFxvGcN2rlXSjnVtGeeFLNimCQEj5gOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.26.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "peerDependencies": {
+        "react": "^19.1.0"
+      }
     },
     "node_modules/react-refresh": {
       "version": "0.11.0",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "@testing-library/user-event": "^13.5.0",
     "firebase": "^11.8.1",
     "framer-motion": "^12.19.1",
+    "konva": "^9.3.20",
     "react": "^19.1.0",
     "react-dnd": "^16.0.1",
     "react-dnd-html5-backend": "^16.0.1",
@@ -16,6 +17,7 @@
     "react-dom": "^19.1.0",
     "react-flip-move": "^3.0.5",
     "react-icons": "^5.5.0",
+    "react-konva": "^19.0.7",
     "react-scripts": "5.0.1",
     "react-tooltip": "^5.28.1",
     "web-vitals": "^2.1.4"
@@ -42,12 +44,12 @@
   },
   "devDependencies": {
     "autoprefixer": "^10.4.21",
-    "postcss": "^8.5.3",
-    "tailwindcss": "^3.4.17",
     "eslint": "^8.57.1",
-    "eslint-plugin-react": "^7.33.2",
-    "eslint-plugin-prettier": "^5.1.3",
     "eslint-config-prettier": "^9.1.0",
-    "prettier": "^3.2.5"
+    "eslint-plugin-prettier": "^5.1.3",
+    "eslint-plugin-react": "^7.33.2",
+    "postcss": "^8.5.3",
+    "prettier": "^3.2.5",
+    "tailwindcss": "^3.4.17"
   }
 }

--- a/src/App.js
+++ b/src/App.js
@@ -21,6 +21,7 @@ import { ToastProvider } from './components/Toast';
 import DiceCalculator from './components/DiceCalculator';
 import BarraReflejos from './components/BarraReflejos';
 import InitiativeTracker from './components/InitiativeTracker';
+import MapCanvas from './components/MapCanvas';
 import useConfirm from './hooks/useConfirm';
 import useResourcesHook from './hooks/useResources';
 import useGlossary from './hooks/useGlossary';
@@ -335,6 +336,11 @@ function App() {
   const [showBarraReflejos, setShowBarraReflejos] = useState(false);
   // Sistema de Iniciativa
   const [showInitiativeTracker, setShowInitiativeTracker] = useState(false);
+  // Tokens para el Mapa de Batalla
+  const [canvasTokens, setCanvasTokens] = useState([
+    { id: 1, x: 50, y: 50, color: 'blue' },
+    { id: 2, x: 200, y: 150, color: 'green' },
+  ]);
   // Sugerencias dinámicas para inputs de equipo
   const armaSugerencias = playerInputArma
     ? armas.filter(a =>
@@ -3088,6 +3094,26 @@ function App() {
             </div>
           </div>
         )}
+      </div>
+    );
+  }
+  if (userType === 'master' && authenticated && chosenView === 'canvas') {
+    return (
+      <div className="min-h-screen bg-gray-900 text-gray-100 p-4">
+        <div className="flex items-center justify-between mb-4">
+          <h1 className="text-2xl font-bold">🗺️ Mapa de Batalla</h1>
+          <Boton onClick={() => setChosenView(null)} className="bg-gray-700 hover:bg-gray-600">
+            ← Volver al Menú
+          </Boton>
+        </div>
+        <div className="w-full h-[80vh]">
+          <MapCanvas
+            backgroundImage="https://via.placeholder.com/800x600"
+            gridSize={100}
+            tokens={canvasTokens}
+            onTokensChange={setCanvasTokens}
+          />
+        </div>
       </div>
     );
   }

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -4,6 +4,7 @@ import App from './App';
 import { ConfirmProvider } from './components/Confirm';
 jest.mock('./components/inventory/Inventory', () => () => <div>Inventory</div>);
 jest.mock('./components/MasterMenu', () => () => <div>MasterMenu</div>);
+jest.mock('./components/MapCanvas', () => () => <div>MapCanvas</div>);
 
 test('renders main menu', () => {
   render(

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -1,0 +1,115 @@
+import React, { useRef, useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
+import { Stage, Layer, Rect, Line, Image as KonvaImage } from 'react-konva';
+import useImage from 'use-image';
+
+const Token = ({ id, x, y, size, color, image, onDragEnd }) => {
+  const [img] = useImage(image);
+  if (img) {
+    return (
+      <KonvaImage
+        image={img}
+        x={x}
+        y={y}
+        width={size}
+        height={size}
+        draggable
+        onDragEnd={(e) => onDragEnd(id, e.target.x(), e.target.y())}
+      />
+    );
+  }
+  return (
+    <Rect
+      x={x}
+      y={y}
+      width={size}
+      height={size}
+      fill={color || 'red'}
+      draggable
+      onDragEnd={(e) => onDragEnd(id, e.target.x(), e.target.y())}
+    />
+  );
+};
+
+Token.propTypes = {
+  id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+  x: PropTypes.number.isRequired,
+  y: PropTypes.number.isRequired,
+  size: PropTypes.number.isRequired,
+  color: PropTypes.string,
+  image: PropTypes.string,
+  onDragEnd: PropTypes.func.isRequired,
+};
+
+const MapCanvas = ({ backgroundImage, gridSize = 100, tokens, onTokensChange }) => {
+  const containerRef = useRef(null);
+  const [stageSize, setStageSize] = useState({ width: 300, height: 300 });
+  const [bg] = useImage(backgroundImage);
+
+  useEffect(() => {
+    const updateSize = () => {
+      if (containerRef.current) {
+        setStageSize({
+          width: containerRef.current.offsetWidth,
+          height: containerRef.current.offsetHeight,
+        });
+      }
+    };
+    updateSize();
+    window.addEventListener('resize', updateSize);
+    return () => window.removeEventListener('resize', updateSize);
+  }, []);
+
+  const drawGrid = () => {
+    const lines = [];
+    for (let i = gridSize; i < stageSize.width; i += gridSize) {
+      lines.push(
+        <Line key={`v${i}`} points={[i, 0, i, stageSize.height]} stroke="rgba(255,255,255,0.2)" />
+      );
+    }
+    for (let i = gridSize; i < stageSize.height; i += gridSize) {
+      lines.push(
+        <Line key={`h${i}`} points={[0, i, stageSize.width, i]} stroke="rgba(255,255,255,0.2)" />
+      );
+    }
+    return lines;
+  };
+
+  const handleDragEnd = (id, x, y) => {
+    const newTokens = tokens.map((t) => (t.id === id ? { ...t, x, y } : t));
+    onTokensChange(newTokens);
+  };
+
+  return (
+    <div ref={containerRef} className="w-full h-full">
+      <Stage width={stageSize.width} height={stageSize.height} style={{ background: '#000' }}>
+        <Layer>
+          {bg && <KonvaImage image={bg} width={stageSize.width} height={stageSize.height} />}
+        </Layer>
+        <Layer>{drawGrid()}</Layer>
+        <Layer>
+          {tokens.map((token) => (
+            <Token key={token.id} {...token} size={gridSize} onDragEnd={handleDragEnd} />
+          ))}
+        </Layer>
+      </Stage>
+    </div>
+  );
+};
+
+MapCanvas.propTypes = {
+  backgroundImage: PropTypes.string,
+  gridSize: PropTypes.number,
+  tokens: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+      x: PropTypes.number.isRequired,
+      y: PropTypes.number.isRequired,
+      color: PropTypes.string,
+      image: PropTypes.string,
+    })
+  ).isRequired,
+  onTokensChange: PropTypes.func.isRequired,
+};
+
+export default MapCanvas;

--- a/src/components/MasterMenu.jsx
+++ b/src/components/MasterMenu.jsx
@@ -41,6 +41,14 @@ const MasterMenu = ({ onSelect, onBackToMain }) => {
       isNew: true,
     },
     {
+      id: 'canvas',
+      title: 'Mapa de Batalla',
+      description: 'Tablero virtual sencillo con grid y tokens',
+      color: 'indigo',
+      features: ['Mapa', 'Tokens', 'Grid'],
+      isNew: true,
+    },
+    {
       id: 'default',
       title: 'Herramientas Tradicionales',
       description: 'Gestión de catálogo, habilidades y glosario',


### PR DESCRIPTION
## Summary
- install `react-konva`
- create `MapCanvas` for a simple virtual tabletop
- allow master to open the new canvas from MasterMenu
- show example tokens on canvas
- document new feature in README

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6866fd5607d88326b717ff692dbcdc9b