### PR TITLE
Add custom background to battle map

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,11 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 - **Sincronización en tiempo real** - Cambios instantáneos para todos los participantes
 - **Modo Master y Jugador** - Controles especializados según el rol del usuario
 - **Mapa de Batalla integrado** - VTT sencillo con grid y tokens arrastrables
+- **Mapas personalizados** - Sube una imagen como fondo en el Mapa de Batalla
 
 ### 🎲 **Gestión de Personajes**
 
-> **Versión actual: 2.2.9**
+> **Versión actual: 2.2.10**
 
 **Resumen de cambios v2.1.1:**
 - Rediseño visual de la vista de enemigos como cartas tipo Magic, con layout responsive y efectos visuales exclusivos.

--- a/src/App.js
+++ b/src/App.js
@@ -341,6 +341,15 @@ function App() {
     { id: 1, x: 50, y: 50, color: 'blue' },
     { id: 2, x: 200, y: 150, color: 'green' },
   ]);
+  const [canvasBackground, setCanvasBackground] = useState(null);
+
+  const handleBackgroundUpload = (e) => {
+    const file = e.target.files[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onloadend = () => setCanvasBackground(reader.result);
+    reader.readAsDataURL(file);
+  };
   // Sugerencias dinámicas para inputs de equipo
   const armaSugerencias = playerInputArma
     ? armas.filter(a =>
@@ -3106,9 +3115,12 @@ function App() {
             ← Volver al Menú
           </Boton>
         </div>
+        <div className="mb-4">
+          <input type="file" accept="image/*" onChange={handleBackgroundUpload} />
+        </div>
         <div className="w-full h-[80vh]">
           <MapCanvas
-            backgroundImage="https://via.placeholder.com/800x600"
+            backgroundImage={canvasBackground || 'https://via.placeholder.com/800x600'}
             gridSize={100}
             tokens={canvasTokens}
             onTokensChange={setCanvasTokens}


### PR DESCRIPTION
## Summary
- allow uploading an image to use as the Battle Map background
- document custom map backgrounds in README

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686703381a24832690bd39a7b98ea92a