### PR TITLE
Add adjustable grid to battle map

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,11 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 - **Modo Master y Jugador** - Controles especializados según el rol del usuario
 - **Mapa de Batalla integrado** - VTT sencillo con grid y tokens arrastrables
 - **Mapas personalizados** - Sube una imagen como fondo en el Mapa de Batalla
+- **Grid ajustable** - Tamaño y desplazamiento de la cuadrícula configurables
 
 ### 🎲 **Gestión de Personajes**
 
-> **Versión actual: 2.2.10**
+> **Versión actual: 2.2.11**
 
 **Resumen de cambios v2.1.1:**
 - Rediseño visual de la vista de enemigos como cartas tipo Magic, con layout responsive y efectos visuales exclusivos.
@@ -103,6 +104,9 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 
 **Resumen de cambios v2.2.8:**
 - Postura solo suma su buff a la resistencia física o mental de Álvaro.
+
+**Resumen de cambios v2.2.11:**
+- Grid del Mapa de Batalla ahora puede escalarse y desplazarse para ajustarse al fondo.
 - 
 ### 🛠️ **Características Técnicas**
 - **Interfaz responsive** - Optimizada para móviles y escritorio con TailwindCSS

--- a/src/App.js
+++ b/src/App.js
@@ -342,6 +342,10 @@ function App() {
     { id: 2, x: 200, y: 150, color: 'green' },
   ]);
   const [canvasBackground, setCanvasBackground] = useState(null);
+  // Configuración de la cuadrícula del mapa de batalla
+  const [gridSize, setGridSize] = useState(100);
+  const [gridOffsetX, setGridOffsetX] = useState(0);
+  const [gridOffsetY, setGridOffsetY] = useState(0);
 
   const handleBackgroundUpload = (e) => {
     const file = e.target.files[0];
@@ -3118,10 +3122,35 @@ function App() {
         <div className="mb-4">
           <input type="file" accept="image/*" onChange={handleBackgroundUpload} />
         </div>
+        <div className="flex flex-wrap gap-4 mb-4">
+          <Input
+            type="number"
+            label="Tamaño de celda"
+            className="w-28"
+            value={gridSize}
+            onChange={e => setGridSize(parseInt(e.target.value, 10) || 1)}
+          />
+          <Input
+            type="number"
+            label="Offset X"
+            className="w-28"
+            value={gridOffsetX}
+            onChange={e => setGridOffsetX(parseInt(e.target.value, 10) || 0)}
+          />
+          <Input
+            type="number"
+            label="Offset Y"
+            className="w-28"
+            value={gridOffsetY}
+            onChange={e => setGridOffsetY(parseInt(e.target.value, 10) || 0)}
+          />
+        </div>
         <div className="w-full h-[80vh]">
           <MapCanvas
             backgroundImage={canvasBackground || 'https://via.placeholder.com/800x600'}
-            gridSize={100}
+            gridSize={gridSize}
+            gridOffsetX={gridOffsetX}
+            gridOffsetY={gridOffsetY}
             tokens={canvasTokens}
             onTokensChange={setCanvasTokens}
           />

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -41,7 +41,19 @@ Token.propTypes = {
   onDragEnd: PropTypes.func.isRequired,
 };
 
-const MapCanvas = ({ backgroundImage, gridSize = 100, tokens, onTokensChange }) => {
+/**
+ * Canvas que muestra un mapa con una cuadrícula ajustable.
+ * Permite definir tamaño de celda y desplazamiento para
+ * alinear la grid con la imagen de fondo.
+ */
+const MapCanvas = ({
+  backgroundImage,
+  gridSize = 100,
+  gridOffsetX = 0,
+  gridOffsetY = 0,
+  tokens,
+  onTokensChange,
+}) => {
   const containerRef = useRef(null);
   const [stageSize, setStageSize] = useState({ width: 300, height: 300 });
   const [bg] = useImage(backgroundImage);
@@ -62,12 +74,14 @@ const MapCanvas = ({ backgroundImage, gridSize = 100, tokens, onTokensChange }) 
 
   const drawGrid = () => {
     const lines = [];
-    for (let i = gridSize; i < stageSize.width; i += gridSize) {
+    // Líneas verticales
+    for (let i = gridOffsetX; i < stageSize.width; i += gridSize) {
       lines.push(
         <Line key={`v${i}`} points={[i, 0, i, stageSize.height]} stroke="rgba(255,255,255,0.2)" />
       );
     }
-    for (let i = gridSize; i < stageSize.height; i += gridSize) {
+    // Líneas horizontales
+    for (let i = gridOffsetY; i < stageSize.height; i += gridSize) {
       lines.push(
         <Line key={`h${i}`} points={[0, i, stageSize.width, i]} stroke="rgba(255,255,255,0.2)" />
       );
@@ -100,6 +114,8 @@ const MapCanvas = ({ backgroundImage, gridSize = 100, tokens, onTokensChange }) 
 MapCanvas.propTypes = {
   backgroundImage: PropTypes.string,
   gridSize: PropTypes.number,
+  gridOffsetX: PropTypes.number,
+  gridOffsetY: PropTypes.number,
   tokens: PropTypes.arrayOf(
     PropTypes.shape({
       id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,


### PR DESCRIPTION
## Summary
- allow grid size and offset to be configured in `MapCanvas`
- add UI controls in the battle map view to edit grid size and offsets
- document adjustable grid option in README
- bump app version to 2.2.11

## Testing
- `npm test --silent -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_686706423b5883268334fb54092ea265