### PR TITLE
Add automatic battle map scaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,12 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 - **Modo Master y Jugador** - Controles especializados según el rol del usuario
 - **Mapa de Batalla integrado** - VTT sencillo con grid y tokens arrastrables
 - **Mapas personalizados** - Sube una imagen como fondo en el Mapa de Batalla
+- **Grid ajustable** - Tamaño y desplazamiento de la cuadrícula configurables
+- **Mapa adaptable** - La imagen se ajusta al viewport manteniendo su proporción
 
 ### 🎲 **Gestión de Personajes**
 
-> **Versión actual: 2.2.10**
+> **Versión actual: 2.2.12**
 
 **Resumen de cambios v2.1.1:**
 - Rediseño visual de la vista de enemigos como cartas tipo Magic, con layout responsive y efectos visuales exclusivos.
@@ -103,6 +105,13 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 
 **Resumen de cambios v2.2.8:**
 - Postura solo suma su buff a la resistencia física o mental de Álvaro.
+
+**Resumen de cambios v2.2.11:**
+- Grid del Mapa de Batalla ahora puede escalarse y desplazarse para ajustarse al fondo.
+
+**Resumen de cambios v2.2.12:**
+- Imagen del mapa se escala automáticamente al contenedor sin perder la relación de aspecto.
+- Opción para indicar el número de casillas y ajustar la grid al mapa cargado.
 - 
 ### 🛠️ **Características Técnicas**
 - **Interfaz responsive** - Optimizada para móviles y escritorio con TailwindCSS

--- a/src/App.js
+++ b/src/App.js
@@ -342,6 +342,11 @@ function App() {
     { id: 2, x: 200, y: 150, color: 'green' },
   ]);
   const [canvasBackground, setCanvasBackground] = useState(null);
+  // Configuración de la cuadrícula del mapa de batalla
+  const [gridSize, setGridSize] = useState(100);
+  const [gridCells, setGridCells] = useState(30);
+  const [gridOffsetX, setGridOffsetX] = useState(0);
+  const [gridOffsetY, setGridOffsetY] = useState(0);
 
   const handleBackgroundUpload = (e) => {
     const file = e.target.files[0];
@@ -3118,10 +3123,43 @@ function App() {
         <div className="mb-4">
           <input type="file" accept="image/*" onChange={handleBackgroundUpload} />
         </div>
+        <div className="flex flex-wrap gap-4 mb-4">
+          <Input
+            type="number"
+            label="Tamaño de celda"
+            className="w-28"
+            value={gridSize}
+            onChange={e => setGridSize(parseInt(e.target.value, 10) || 1)}
+          />
+          <Input
+            type="number"
+            label="Nº casillas"
+            className="w-28"
+            value={gridCells}
+            onChange={e => setGridCells(parseInt(e.target.value, 10) || 1)}
+          />
+          <Input
+            type="number"
+            label="Offset X"
+            className="w-28"
+            value={gridOffsetX}
+            onChange={e => setGridOffsetX(parseInt(e.target.value, 10) || 0)}
+          />
+          <Input
+            type="number"
+            label="Offset Y"
+            className="w-28"
+            value={gridOffsetY}
+            onChange={e => setGridOffsetY(parseInt(e.target.value, 10) || 0)}
+          />
+        </div>
         <div className="w-full h-[80vh]">
           <MapCanvas
             backgroundImage={canvasBackground || 'https://via.placeholder.com/800x600'}
-            gridSize={100}
+            gridSize={gridSize}
+            gridCells={gridCells}
+            gridOffsetX={gridOffsetX}
+            gridOffsetY={gridOffsetY}
             tokens={canvasTokens}
             onTokensChange={setCanvasTokens}
           />

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -41,15 +41,35 @@ Token.propTypes = {
   onDragEnd: PropTypes.func.isRequired,
 };
 
-const MapCanvas = ({ backgroundImage, gridSize = 100, tokens, onTokensChange }) => {
+/**
+ * Canvas que muestra un mapa con una cuadrícula ajustable.
+ * Permite definir tamaño de celda y desplazamiento para
+ * alinear la grid con la imagen de fondo.
+ */
+const MapCanvas = ({
+  backgroundImage,
+  gridSize = 100,
+  gridCells,
+  gridOffsetX = 0,
+  gridOffsetY = 0,
+  tokens,
+  onTokensChange,
+}) => {
   const containerRef = useRef(null);
-  const [stageSize, setStageSize] = useState({ width: 300, height: 300 });
-  const [bg] = useImage(backgroundImage);
+  const [containerSize, setContainerSize] = useState({ width: 300, height: 300 });
+  const [imageSize, setImageSize] = useState({ width: 300, height: 300 });
+  const [stageScale, setStageScale] = useState(1);
+  const [bg] = useImage(backgroundImage, 'anonymous');
 
+  // Si se especifica el número de casillas, calculamos el tamaño de cada celda
+  const effectiveGridSize = gridCells ? imageSize.width / gridCells : gridSize;
+
+  // Tamaño del contenedor y escala del stage para que la imagen
+  // siempre se vea completa manteniendo la proporción.
   useEffect(() => {
     const updateSize = () => {
       if (containerRef.current) {
-        setStageSize({
+        setContainerSize({
           width: containerRef.current.offsetWidth,
           height: containerRef.current.offsetHeight,
         });
@@ -60,16 +80,33 @@ const MapCanvas = ({ backgroundImage, gridSize = 100, tokens, onTokensChange }) 
     return () => window.removeEventListener('resize', updateSize);
   }, []);
 
+  // Cuando cargue la imagen guardamos sus dimensiones reales
+  useEffect(() => {
+    if (bg) {
+      setImageSize({ width: bg.width, height: bg.height });
+    }
+  }, [bg]);
+
+  // Calcula la escala para ajustar el stage al contenedor manteniendo aspecto
+  useEffect(() => {
+    if (!imageSize.width) return;
+    const scaleX = containerSize.width / imageSize.width;
+    const scaleY = containerSize.height / imageSize.height;
+    setStageScale(Math.min(scaleX, scaleY));
+  }, [containerSize, imageSize]);
+
   const drawGrid = () => {
     const lines = [];
-    for (let i = gridSize; i < stageSize.width; i += gridSize) {
+    // Líneas verticales
+    for (let i = gridOffsetX; i < imageSize.width; i += effectiveGridSize) {
       lines.push(
-        <Line key={`v${i}`} points={[i, 0, i, stageSize.height]} stroke="rgba(255,255,255,0.2)" />
+        <Line key={`v${i}`} points={[i, 0, i, imageSize.height]} stroke="rgba(255,255,255,0.2)" />
       );
     }
-    for (let i = gridSize; i < stageSize.height; i += gridSize) {
+    // Líneas horizontales
+    for (let i = gridOffsetY; i < imageSize.height; i += effectiveGridSize) {
       lines.push(
-        <Line key={`h${i}`} points={[0, i, stageSize.width, i]} stroke="rgba(255,255,255,0.2)" />
+        <Line key={`h${i}`} points={[0, i, imageSize.width, i]} stroke="rgba(255,255,255,0.2)" />
       );
     }
     return lines;
@@ -81,15 +118,21 @@ const MapCanvas = ({ backgroundImage, gridSize = 100, tokens, onTokensChange }) 
   };
 
   return (
-    <div ref={containerRef} className="w-full h-full">
-      <Stage width={stageSize.width} height={stageSize.height} style={{ background: '#000' }}>
+    <div ref={containerRef} className="w-full h-full overflow-hidden flex items-center justify-center">
+      <Stage
+        width={imageSize.width}
+        height={imageSize.height}
+        scaleX={stageScale}
+        scaleY={stageScale}
+        style={{ background: '#000' }}
+      >
         <Layer>
-          {bg && <KonvaImage image={bg} width={stageSize.width} height={stageSize.height} />}
+          {bg && <KonvaImage image={bg} width={imageSize.width} height={imageSize.height} />}
         </Layer>
         <Layer>{drawGrid()}</Layer>
         <Layer>
           {tokens.map((token) => (
-            <Token key={token.id} {...token} size={gridSize} onDragEnd={handleDragEnd} />
+            <Token key={token.id} {...token} size={effectiveGridSize} onDragEnd={handleDragEnd} />
           ))}
         </Layer>
       </Stage>
@@ -100,6 +143,9 @@ const MapCanvas = ({ backgroundImage, gridSize = 100, tokens, onTokensChange }) 
 MapCanvas.propTypes = {
   backgroundImage: PropTypes.string,
   gridSize: PropTypes.number,
+  gridCells: PropTypes.number,
+  gridOffsetX: PropTypes.number,
+  gridOffsetY: PropTypes.number,
   tokens: PropTypes.arrayOf(
     PropTypes.shape({
       id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,


### PR DESCRIPTION
## Summary
- scale battle map to fit container and keep aspect ratio
- compute grid cell size from number of cells if provided
- allow setting number of grid cells in battle map screen
- document new adaptive map feature and bump version to 2.2.12

## Testing
- `npm test --silent -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_686706423b5883268334fb54092ea265