### PR TITLE
Adjust map scaling and add zoom

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,13 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 - **Modo Master y Jugador** - Controles especializados según el rol del usuario
 - **Mapa de Batalla integrado** - VTT sencillo con grid y tokens arrastrables
 - **Mapas personalizados** - Sube una imagen como fondo en el Mapa de Batalla
+- **Grid ajustable** - Tamaño y desplazamiento de la cuadrícula configurables
+- **Mapa adaptable** - La imagen se ajusta al viewport manteniendo su proporción
+- **Zoom interactivo** - Acerca y aleja el mapa con la rueda del ratón
 
 ### 🎲 **Gestión de Personajes**
 
-> **Versión actual: 2.2.10**
+> **Versión actual: 2.2.13**
 
 **Resumen de cambios v2.1.1:**
 - Rediseño visual de la vista de enemigos como cartas tipo Magic, con layout responsive y efectos visuales exclusivos.
@@ -103,7 +106,17 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 
 **Resumen de cambios v2.2.8:**
 - Postura solo suma su buff a la resistencia física o mental de Álvaro.
-- 
+
+**Resumen de cambios v2.2.11:**
+- Grid del Mapa de Batalla ahora puede escalarse y desplazarse para ajustarse al fondo.
+
+**Resumen de cambios v2.2.12:**
+- Imagen del mapa se escala automáticamente al contenedor sin perder la relación de aspecto.
+- Opción para indicar el número de casillas y ajustar la grid al mapa cargado.
+
+**Resumen de cambios v2.2.13:**
+- Mapa sin bordes negros utilizando escalado tipo cover o contain.
+- Zoom interactivo con la rueda del ratón en el Mapa de Batalla.
 ### 🛠️ **Características Técnicas**
 - **Interfaz responsive** - Optimizada para móviles y escritorio con TailwindCSS
 - **Persistencia en Firebase** - Almacenamiento seguro y sincronización en tiempo real

--- a/src/App.js
+++ b/src/App.js
@@ -342,6 +342,11 @@ function App() {
     { id: 2, x: 200, y: 150, color: 'green' },
   ]);
   const [canvasBackground, setCanvasBackground] = useState(null);
+  // Configuración de la cuadrícula del mapa de batalla
+  const [gridSize, setGridSize] = useState(100);
+  const [gridCells, setGridCells] = useState(30);
+  const [gridOffsetX, setGridOffsetX] = useState(0);
+  const [gridOffsetY, setGridOffsetY] = useState(0);
 
   const handleBackgroundUpload = (e) => {
     const file = e.target.files[0];
@@ -3118,10 +3123,43 @@ function App() {
         <div className="mb-4">
           <input type="file" accept="image/*" onChange={handleBackgroundUpload} />
         </div>
+        <div className="flex flex-wrap gap-4 mb-4">
+          <Input
+            type="number"
+            label="Tamaño de celda"
+            className="w-28"
+            value={gridSize}
+            onChange={e => setGridSize(parseInt(e.target.value, 10) || 1)}
+          />
+          <Input
+            type="number"
+            label="Nº casillas"
+            className="w-28"
+            value={gridCells}
+            onChange={e => setGridCells(parseInt(e.target.value, 10) || 1)}
+          />
+          <Input
+            type="number"
+            label="Offset X"
+            className="w-28"
+            value={gridOffsetX}
+            onChange={e => setGridOffsetX(parseInt(e.target.value, 10) || 0)}
+          />
+          <Input
+            type="number"
+            label="Offset Y"
+            className="w-28"
+            value={gridOffsetY}
+            onChange={e => setGridOffsetY(parseInt(e.target.value, 10) || 0)}
+          />
+        </div>
         <div className="w-full h-[80vh]">
           <MapCanvas
             backgroundImage={canvasBackground || 'https://via.placeholder.com/800x600'}
-            gridSize={100}
+            gridSize={gridSize}
+            gridCells={gridCells}
+            gridOffsetX={gridOffsetX}
+            gridOffsetY={gridOffsetY}
             tokens={canvasTokens}
             onTokensChange={setCanvasTokens}
           />

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -1,6 +1,6 @@
 import React, { useRef, useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { Stage, Layer, Rect, Line, Image as KonvaImage } from 'react-konva';
+import { Stage, Layer, Rect, Line, Image as KonvaImage, Group } from 'react-konva';
 import useImage from 'use-image';
 
 const Token = ({ id, x, y, size, color, image, onDragEnd }) => {
@@ -41,15 +41,41 @@ Token.propTypes = {
   onDragEnd: PropTypes.func.isRequired,
 };
 
-const MapCanvas = ({ backgroundImage, gridSize = 100, tokens, onTokensChange }) => {
+/**
+ * Canvas que muestra un mapa con una cuadrícula ajustable.
+ * Permite definir tamaño de celda y desplazamiento para
+ * alinear la grid con la imagen de fondo.
+ */
+const MapCanvas = ({
+  backgroundImage,
+  gridSize = 100,
+  gridCells,
+  gridOffsetX = 0,
+  gridOffsetY = 0,
+  minZoom = 0.5,
+  maxZoom = 4,
+  initialZoom = 1,
+  scaleMode = 'contain',
+  tokens,
+  onTokensChange,
+}) => {
   const containerRef = useRef(null);
-  const [stageSize, setStageSize] = useState({ width: 300, height: 300 });
-  const [bg] = useImage(backgroundImage);
+  const stageRef = useRef(null);
+  const [containerSize, setContainerSize] = useState({ width: 300, height: 300 });
+  const [imageSize, setImageSize] = useState({ width: 300, height: 300 });
+  const [baseScale, setBaseScale] = useState(1);
+  const [zoom, setZoom] = useState(initialZoom);
+  const [groupPos, setGroupPos] = useState({ x: 0, y: 0 });
+  const [bg] = useImage(backgroundImage, 'anonymous');
 
+  // Si se especifica el número de casillas, calculamos el tamaño de cada celda
+  const effectiveGridSize = gridCells ? imageSize.width / gridCells : gridSize;
+
+  // Tamaño del contenedor para ajustar el stage al redimensionar la ventana
   useEffect(() => {
     const updateSize = () => {
       if (containerRef.current) {
-        setStageSize({
+        setContainerSize({
           width: containerRef.current.offsetWidth,
           height: containerRef.current.offsetHeight,
         });
@@ -60,16 +86,40 @@ const MapCanvas = ({ backgroundImage, gridSize = 100, tokens, onTokensChange }) 
     return () => window.removeEventListener('resize', updateSize);
   }, []);
 
+  // Cuando cargue la imagen guardamos sus dimensiones reales
+  useEffect(() => {
+    if (bg) {
+      setImageSize({ width: bg.width, height: bg.height });
+    }
+  }, [bg]);
+
+  // Calcula la escala base según el modo seleccionado y centra el mapa
+  useEffect(() => {
+    if (!imageSize.width) return;
+    const scaleX = containerSize.width / imageSize.width;
+    const scaleY = containerSize.height / imageSize.height;
+    const scale = scaleMode === 'cover' ? Math.max(scaleX, scaleY) : Math.min(scaleX, scaleY);
+    setBaseScale(scale);
+    const displayWidth = imageSize.width * scale;
+    const displayHeight = imageSize.height * scale;
+    setGroupPos({
+      x: (containerSize.width - displayWidth) / 2,
+      y: (containerSize.height - displayHeight) / 2,
+    });
+  }, [containerSize, imageSize, scaleMode]);
+
   const drawGrid = () => {
     const lines = [];
-    for (let i = gridSize; i < stageSize.width; i += gridSize) {
+    // Líneas verticales
+    for (let i = gridOffsetX; i < imageSize.width; i += effectiveGridSize) {
       lines.push(
-        <Line key={`v${i}`} points={[i, 0, i, stageSize.height]} stroke="rgba(255,255,255,0.2)" />
+        <Line key={`v${i}`} points={[i, 0, i, imageSize.height]} stroke="rgba(255,255,255,0.2)" />
       );
     }
-    for (let i = gridSize; i < stageSize.height; i += gridSize) {
+    // Líneas horizontales
+    for (let i = gridOffsetY; i < imageSize.height; i += effectiveGridSize) {
       lines.push(
-        <Line key={`h${i}`} points={[0, i, stageSize.width, i]} stroke="rgba(255,255,255,0.2)" />
+        <Line key={`h${i}`} points={[0, i, imageSize.width, i]} stroke="rgba(255,255,255,0.2)" />
       );
     }
     return lines;
@@ -80,17 +130,47 @@ const MapCanvas = ({ backgroundImage, gridSize = 100, tokens, onTokensChange }) 
     onTokensChange(newTokens);
   };
 
+  // Zoom interactivo con la rueda del ratón
+  const handleWheel = (e) => {
+    e.evt.preventDefault();
+    if (!stageRef.current) return;
+    const stage = stageRef.current;
+    const pointer = stage.getPointerPosition();
+    const scaleBy = e.evt.deltaY > 0 ? 1 / 1.2 : 1.2;
+    const newZoom = Math.min(maxZoom, Math.max(minZoom, zoom * scaleBy));
+    if (newZoom === zoom) return;
+    const oldScale = baseScale * zoom;
+    const mousePoint = {
+      x: (pointer.x - groupPos.x) / oldScale,
+      y: (pointer.y - groupPos.y) / oldScale,
+    };
+    const newScale = baseScale * newZoom;
+    setZoom(newZoom);
+    setGroupPos({
+      x: pointer.x - mousePoint.x * newScale,
+      y: pointer.y - mousePoint.y * newScale,
+    });
+  };
+
+  const groupScale = baseScale * zoom;
+
   return (
-    <div ref={containerRef} className="w-full h-full">
-      <Stage width={stageSize.width} height={stageSize.height} style={{ background: '#000' }}>
+    <div ref={containerRef} className="w-full h-full overflow-hidden">
+      <Stage
+        ref={stageRef}
+        width={containerSize.width}
+        height={containerSize.height}
+        onWheel={handleWheel}
+        style={{ background: '#000' }}
+      >
         <Layer>
-          {bg && <KonvaImage image={bg} width={stageSize.width} height={stageSize.height} />}
-        </Layer>
-        <Layer>{drawGrid()}</Layer>
-        <Layer>
-          {tokens.map((token) => (
-            <Token key={token.id} {...token} size={gridSize} onDragEnd={handleDragEnd} />
-          ))}
+          <Group x={groupPos.x} y={groupPos.y} scaleX={groupScale} scaleY={groupScale}>
+            {bg && <KonvaImage image={bg} width={imageSize.width} height={imageSize.height} />}
+            {drawGrid()}
+            {tokens.map((token) => (
+              <Token key={token.id} {...token} size={effectiveGridSize} onDragEnd={handleDragEnd} />
+            ))}
+          </Group>
         </Layer>
       </Stage>
     </div>
@@ -100,6 +180,13 @@ const MapCanvas = ({ backgroundImage, gridSize = 100, tokens, onTokensChange }) 
 MapCanvas.propTypes = {
   backgroundImage: PropTypes.string,
   gridSize: PropTypes.number,
+  gridCells: PropTypes.number,
+  gridOffsetX: PropTypes.number,
+  gridOffsetY: PropTypes.number,
+  minZoom: PropTypes.number,
+  maxZoom: PropTypes.number,
+  initialZoom: PropTypes.number,
+  scaleMode: PropTypes.oneOf(['contain', 'cover']),
   tokens: PropTypes.arrayOf(
     PropTypes.shape({
       id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,


### PR DESCRIPTION
## Summary
- allow selecting cover or contain mode for battle maps
- implement mouse wheel zoom centered on pointer
- document the interactive zoom feature and bump version to 2.2.13

## Testing
- `npm test --silent -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_686706423b5883268334fb54092ea265