### PR TITLE
Add draggable tokens for battle map

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,10 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 - Miniaturas completas con object-contain y tamaño fijo de 64 px.
 - Previsualización flotante estilo Roll20 al pasar el ratón sobre un asset.
 
+**Resumen de cambios v2.2.18:**
+- Arrastre directo de assets al mapa para crear tokens.
+- Selección y movimiento por teclado con WASD o Delete.
+
 ### 🛠️ **Características Técnicas**
 - **Interfaz responsive** - Optimizada para móviles y escritorio con TailwindCSS
 - **Persistencia en Firebase** - Almacenamiento seguro y sincronización en tiempo real

--- a/src/App.js
+++ b/src/App.js
@@ -338,10 +338,7 @@ function App() {
   // Sistema de Iniciativa
   const [showInitiativeTracker, setShowInitiativeTracker] = useState(false);
   // Tokens para el Mapa de Batalla
-  const [canvasTokens, setCanvasTokens] = useState([
-    { id: 1, x: 50, y: 50, color: 'blue' },
-    { id: 2, x: 200, y: 150, color: 'green' },
-  ]);
+  const [canvasTokens, setCanvasTokens] = useState([]);
   const [canvasBackground, setCanvasBackground] = useState(null);
   // Configuración de la cuadrícula del mapa de batalla
   const [gridSize, setGridSize] = useState(100);

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -2,6 +2,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import App from './App';
 import { ConfirmProvider } from './components/Confirm';
+jest.mock('react-dnd', () => ({ useDrag: () => [{}, () => {}], useDrop: () => [{}, () => {}] }));
 jest.mock('./components/inventory/Inventory', () => () => <div>Inventory</div>);
 jest.mock('./components/MasterMenu', () => () => <div>MasterMenu</div>);
 jest.mock('./components/MapCanvas', () => () => <div>MapCanvas</div>);

--- a/src/components/AssetSidebar.jsx
+++ b/src/components/AssetSidebar.jsx
@@ -3,8 +3,11 @@ import PropTypes from 'prop-types';
 import { nanoid } from 'nanoid';
 import { FiChevronDown, FiChevronRight, FiTrash } from 'react-icons/fi';
 import { motion, AnimatePresence } from 'framer-motion';
+import { useDrag } from 'react-dnd';
 
-const AssetSidebar = ({ onAssetSelect }) => {
+export const AssetTypes = { IMAGE: 'asset-image' };
+
+const AssetSidebar = ({ onAssetSelect, onDragStart }) => {
   const [folders, setFolders] = useState(() => [
     { id: nanoid(), name: 'Enemigos', assets: [], open: true },
   ]);
@@ -136,28 +139,41 @@ const AssetSidebar = ({ onAssetSelect }) => {
                       className="text-sm w-full"
                     />
                     <div className="grid grid-cols-4 gap-2">
-                      {folder.assets.map((asset) => (
-                        <div key={asset.id} className="text-center text-xs">
-                          <div className="relative group">
-                            <img
-                              src={asset.url}
-                              alt={asset.name}
-                              className="w-16 h-16 object-contain rounded cursor-pointer hover:ring-2 hover:ring-blue-500"
-                              onClick={() => onAssetSelect?.(asset)}
-                              onMouseEnter={(e) => showPreview(asset, e)}
-                              onMouseMove={movePreview}
-                              onMouseLeave={hidePreview}
-                            />
-                            <button
-                              onClick={() => removeAsset(folder.id, asset.id)}
-                              className="absolute -top-1 -right-1 bg-gray-800 rounded-full p-0.5 text-gray-300 opacity-0 group-hover:opacity-100 hover:text-red-400"
-                            >
-                              <FiTrash />
-                            </button>
+                      {folder.assets.map((asset) => {
+                        const [{ isDragging }, drag] = useDrag(
+                          () => ({
+                            type: AssetTypes.IMAGE,
+                            item: { url: asset.url, name: asset.name },
+                            collect: (monitor) => ({
+                              isDragging: monitor.isDragging(),
+                            }),
+                            begin: () => onDragStart?.({ url: asset.url, name: asset.name }),
+                          }),
+                          [asset, onDragStart]
+                        );
+                        return (
+                          <div key={asset.id} className="text-center text-xs">
+                            <div ref={drag} className="relative group" style={{ opacity: isDragging ? 0.5 : 1 }}>
+                              <img
+                                src={asset.url}
+                                alt={asset.name}
+                                className="w-16 h-16 object-contain rounded cursor-pointer hover:ring-2 hover:ring-blue-500"
+                                onClick={() => onAssetSelect?.(asset)}
+                                onMouseEnter={(e) => showPreview(asset, e)}
+                                onMouseMove={movePreview}
+                                onMouseLeave={hidePreview}
+                              />
+                              <button
+                                onClick={() => removeAsset(folder.id, asset.id)}
+                                className="absolute -top-1 -right-1 bg-gray-800 rounded-full p-0.5 text-gray-300 opacity-0 group-hover:opacity-100 hover:text-red-400"
+                              >
+                                <FiTrash />
+                              </button>
+                            </div>
+                            <span className="truncate block w-16 mx-auto">{asset.name}</span>
                           </div>
-                          <span className="truncate block w-16 mx-auto">{asset.name}</span>
-                        </div>
-                      ))}
+                        );
+                      })}
                     </div>
                   </motion.div>
                 )}
@@ -184,6 +200,7 @@ const AssetSidebar = ({ onAssetSelect }) => {
 
 AssetSidebar.propTypes = {
   onAssetSelect: PropTypes.func,
+  onDragStart: PropTypes.func,
 };
 
 export default AssetSidebar;

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -1,34 +1,27 @@
-import React, { useRef, useState, useEffect } from 'react';
+import React, { useRef, useState, useEffect, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { Stage, Layer, Rect, Line, Image as KonvaImage, Group } from 'react-konva';
 import useImage from 'use-image';
+import { useDrop } from 'react-dnd';
+import { AssetTypes } from './AssetSidebar';
 
-const Token = ({ id, x, y, size, color, image, onDragEnd }) => {
+const Token = ({ id, x, y, size, color, image, selected, onDragEnd, onClick }) => {
   const [img] = useImage(image);
+  const common = {
+    x,
+    y,
+    width: size,
+    height: size,
+    draggable: true,
+    onDragEnd: (e) => onDragEnd(id, e.target.x(), e.target.y()),
+    onClick: () => onClick?.(id),
+    stroke: selected ? '#e0e0e0' : undefined,
+    strokeWidth: selected ? 3 : 0,
+  };
   if (img) {
-    return (
-      <KonvaImage
-        image={img}
-        x={x}
-        y={y}
-        width={size}
-        height={size}
-        draggable
-        onDragEnd={(e) => onDragEnd(id, e.target.x(), e.target.y())}
-      />
-    );
+    return <KonvaImage image={img} {...common} />;
   }
-  return (
-    <Rect
-      x={x}
-      y={y}
-      width={size}
-      height={size}
-      fill={color || 'red'}
-      draggable
-      onDragEnd={(e) => onDragEnd(id, e.target.x(), e.target.y())}
-    />
-  );
+  return <Rect fill={color || 'red'} {...common} />;
 };
 
 Token.propTypes = {
@@ -38,6 +31,8 @@ Token.propTypes = {
   size: PropTypes.number.isRequired,
   color: PropTypes.string,
   image: PropTypes.string,
+  selected: PropTypes.bool,
+  onClick: PropTypes.func,
   onDragEnd: PropTypes.func.isRequired,
 };
 
@@ -67,12 +62,16 @@ const MapCanvas = ({
   const [zoom, setZoom] = useState(initialZoom);
   const [groupPos, setGroupPos] = useState({ x: 0, y: 0 });
   const [isPanning, setIsPanning] = useState(false);
+  const [selectedId, setSelectedId] = useState(null);
   const panStart = useRef({ x: 0, y: 0 });
   const panOrigin = useRef({ x: 0, y: 0 });
   const [bg] = useImage(backgroundImage, 'anonymous');
 
   // Si se especifica el número de casillas, calculamos el tamaño de cada celda
   const effectiveGridSize = gridCells ? imageSize.width / gridCells : gridSize;
+
+  const pxToCell = (px, offset) => Math.round((px - offset) / effectiveGridSize);
+  const cellToPx = (cell, offset) => cell * effectiveGridSize + offset;
 
   // Tamaño del contenedor para ajustar el stage al redimensionar la ventana
   useEffect(() => {
@@ -128,8 +127,10 @@ const MapCanvas = ({
     return lines;
   };
 
-  const handleDragEnd = (id, x, y) => {
-    const newTokens = tokens.map((t) => (t.id === id ? { ...t, x, y } : t));
+  const handleDragEnd = (id, px, py) => {
+    const cellX = pxToCell(px, gridOffsetX);
+    const cellY = pxToCell(py, gridOffsetY);
+    const newTokens = tokens.map((t) => (t.id === id ? { ...t, x: cellX, y: cellY } : t));
     onTokensChange(newTokens);
   };
 
@@ -179,11 +180,70 @@ const MapCanvas = ({
     if (isPanning) setIsPanning(false);
   };
 
+  const mapWidth = Math.round(imageSize.width / effectiveGridSize);
+  const mapHeight = Math.round(imageSize.height / effectiveGridSize);
+
+  const handleKeyDown = useCallback((e) => {
+    if (selectedId == null) return;
+    const index = tokens.findIndex((t) => t.id === selectedId);
+    if (index === -1) return;
+    let { x, y } = tokens[index];
+    switch (e.key.toLowerCase()) {
+      case 'w':
+        y -= 1;
+        break;
+      case 's':
+        y += 1;
+        break;
+      case 'a':
+        x -= 1;
+        break;
+      case 'd':
+        x += 1;
+        break;
+      case 'delete':
+        onTokensChange(tokens.filter((t) => t.id !== selectedId));
+        setSelectedId(null);
+        return;
+      default:
+        return;
+    }
+    x = Math.max(0, Math.min(mapWidth - 1, x));
+    y = Math.max(0, Math.min(mapHeight - 1, y));
+    const updated = tokens.map((t) => (t.id === selectedId ? { ...t, x, y } : t));
+    onTokensChange(updated);
+  }, [selectedId, tokens, onTokensChange, mapWidth, mapHeight]);
+
+  useEffect(() => {
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [handleKeyDown]);
+
+  const [, drop] = useDrop(
+    () => ({
+      accept: AssetTypes.IMAGE,
+      drop: (item) => {
+        if (!stageRef.current) return;
+        const pointer = stageRef.current.getPointerPosition();
+        const relX = (pointer.x - groupPos.x) / groupScale;
+        const relY = (pointer.y - groupPos.y) / groupScale;
+        const cellX = pxToCell(relX, gridOffsetX);
+        const cellY = pxToCell(relY, gridOffsetY);
+        const x = Math.max(0, Math.min(mapWidth - 1, cellX));
+        const y = Math.max(0, Math.min(mapHeight - 1, cellY));
+        const newToken = { id: Date.now(), x, y, url: item.url, name: item.name };
+        onTokensChange([...tokens, newToken]);
+      },
+    }),
+    [tokens, groupPos, groupScale, mapWidth, mapHeight, gridOffsetX, gridOffsetY]
+  );
+
   const groupScale = baseScale * zoom;
 
   return (
     <div ref={containerRef} className="w-full h-full overflow-hidden">
-      <Stage
+      <div ref={drop}>
+        <Stage
         ref={stageRef}
         width={containerSize.width}
         height={containerSize.height}
@@ -199,11 +259,23 @@ const MapCanvas = ({
             {bg && <KonvaImage image={bg} width={imageSize.width} height={imageSize.height} />}
             {drawGrid()}
             {tokens.map((token) => (
-              <Token key={token.id} {...token} size={effectiveGridSize} onDragEnd={handleDragEnd} />
+              <Token
+                key={token.id}
+                id={token.id}
+                x={cellToPx(token.x, gridOffsetX)}
+                y={cellToPx(token.y, gridOffsetY)}
+                size={effectiveGridSize}
+                image={token.url}
+                color={token.color}
+                selected={token.id === selectedId}
+                onDragEnd={handleDragEnd}
+                onClick={setSelectedId}
+              />
             ))}
           </Group>
         </Layer>
-      </Stage>
+        </Stage>
+      </div>
     </div>
   );
 };
@@ -223,8 +295,9 @@ MapCanvas.propTypes = {
       id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
       x: PropTypes.number.isRequired,
       y: PropTypes.number.isRequired,
+      url: PropTypes.string,
+      name: PropTypes.string,
       color: PropTypes.string,
-      image: PropTypes.string,
     })
   ).isRequired,
   onTokensChange: PropTypes.func.isRequired,


### PR DESCRIPTION
## Summary
- drag images from AssetSidebar onto MapCanvas using react-dnd
- allow selecting a token and moving with WASD or Delete
- highlight selected token
- keep canvas tokens in grid cell coordinates
- update README with recent changes
- mock `react-dnd` in tests

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68673518f518832694b1b59558d99091