### PR TITLE
Add resizable and rotatable tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,9 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 
 **Resumen de cambios v2.2.19:**
 - Hooks de drag & drop actualizados a la sintaxis de `react-dnd` v14.
+
+**Resumen de cambios v2.2.20:**
+- Tokens redimensionables con snapping a la grid y rotación libre.
 - 
 ### 🛠️ **Características Técnicas**
 - **Interfaz responsive** - Optimizada para móviles y escritorio con TailwindCSS


### PR DESCRIPTION
## Summary
- allow token resizing with snapping to the grid
- add free rotation handle for tokens
- store width, height and angle in token state
- quick rotate via `R`/`Shift+R`
- document the new feature in README

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68685bca99048326a4257092e038d0f5