### PR TITLE
Fix rotation handle and grid snapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,16 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 
 **Resumen de cambios v2.2.19:**
 - Hooks de drag & drop actualizados a la sintaxis de `react-dnd` v14.
+
+**Resumen de cambios v2.2.20:**
+- Tokens redimensionables con snapping a la grid y rotación libre.
+
+**Resumen de cambios v2.2.21:**
+- Snapping estricto al mover y redimensionar tokens, con ángulo persistente.
+
+**Resumen de cambios v2.2.22:**
+- Manejo de rotación más preciso y handle que sigue al token.
+- Redimensionado con mínimo de ¼ de celda y drag bloqueado durante el resize.
 - 
 ### 🛠️ **Características Técnicas**
 - **Interfaz responsive** - Optimizada para móviles y escritorio con TailwindCSS


### PR DESCRIPTION
## Summary
- keep rotate handle attached to token during drag and transform
- enforce quarter-cell snapping when resizing and moving
- disable dragging while resizing tokens
- update README with latest improvements

## Testing
- `CI=true npm test --silent`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68685bca99048326a4257092e038d0f5