### PR TITLE
Add token deselection on click outside

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,9 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 **Resumen de cambios v2.2.25:**
 - Giro con angle snapping: si el ángulo está a ±7° de 0°, 90°, 180° o 270° se ajusta automáticamente.
 
+**Resumen de cambios v2.2.26:**
+- Hacer clic fuera del mapa deselecciona el token activo.
+
 ### 🛠️ **Características Técnicas**
 - **Interfaz responsive** - Optimizada para móviles y escritorio con TailwindCSS
 - **Persistencia en Firebase** - Almacenamiento seguro y sincronización en tiempo real

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -294,13 +294,23 @@ const MapCanvas = ({
     // Líneas verticales
     for (let i = gridOffsetX; i < imageSize.width; i += effectiveGridSize) {
       lines.push(
-        <Line key={`v${i}`} points={[i, 0, i, imageSize.height]} stroke="rgba(255,255,255,0.2)" />
+        <Line
+          key={`v${i}`}
+          points={[i, 0, i, imageSize.height]}
+          stroke="rgba(255,255,255,0.2)"
+          listening={false}
+        />
       );
     }
     // Líneas horizontales
     for (let i = gridOffsetY; i < imageSize.height; i += effectiveGridSize) {
       lines.push(
-        <Line key={`h${i}`} points={[0, i, imageSize.width, i]} stroke="rgba(255,255,255,0.2)" />
+        <Line
+          key={`h${i}`}
+          points={[0, i, imageSize.width, i]}
+          stroke="rgba(255,255,255,0.2)"
+          listening={false}
+        />
       );
     }
     return lines;
@@ -371,6 +381,12 @@ const MapCanvas = ({
 
   const stopPanning = () => {
     if (isPanning) setIsPanning(false);
+  };
+
+  const handleStageClick = (e) => {
+    if (e.target === stageRef.current) {
+      setSelectedId(null);
+    }
   };
 
   const mapWidth = Math.round(imageSize.width / effectiveGridSize);
@@ -453,11 +469,19 @@ const MapCanvas = ({
         onMouseMove={handleMouseMove}
         onMouseUp={stopPanning}
         onMouseLeave={stopPanning}
+        onClick={handleStageClick}
         style={{ background: '#000' }}
       >
         <Layer>
           <Group x={groupPos.x} y={groupPos.y} scaleX={groupScale} scaleY={groupScale}>
-            {bg && <KonvaImage image={bg} width={imageSize.width} height={imageSize.height} />}
+            {bg && (
+              <KonvaImage
+                image={bg}
+                width={imageSize.width}
+                height={imageSize.height}
+                listening={false}
+              />
+            )}
             {drawGrid()}
             {tokens.map((token) => (
               <Token


### PR DESCRIPTION
## Summary
- enable grid and background to pass clicks to the stage
- deselect active token when clicking on empty areas of the map
- document new behavior in the changelog

## Testing
- `npm install --silent`
- `CI=true npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68687b54176c8326978be7d14db88065