### PR TITLE
Improve token snapping on drag end

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,9 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 **Resumen de cambios v2.2.26:**
 - Hacer clic fuera del mapa deselecciona el token activo.
 
+**Resumen de cambios v2.2.27:**
+- Snapping preciso de tokens tras el drag usando la posición real del puntero.
+
 ### 🛠️ **Características Técnicas**
 - **Interfaz responsive** - Optimizada para móviles y escritorio con TailwindCSS
 - **Persistencia en Firebase** - Almacenamiento seguro y sincronización en tiempo real


### PR DESCRIPTION
## Summary
- remove dragBoundFunc from tokens
- snap token to grid on drag end using real pointer position
- document update in README

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68688375efd4832681a05bcf9c87d94d