### PR TITLE
Improve token snapping on drag end

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,17 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 **Resumen de cambios v2.2.26:**
 - Hacer clic fuera del mapa deselecciona el token activo.
 
+**Resumen de cambios v2.2.27:**
+- Snapping preciso de tokens tras el drag usando la posición real del puntero.
+
+**Resumen de cambios v2.2.28:**
+- Nueva lógica de snap basada en la esquina superior-izquierda del token para
+  alinearlo siempre con la celda inferior/izquierda.
+
+**Resumen de cambios v2.2.29:**
+- Simplificación del drag: el token se mueve libremente y se corrige con
+  bounding-box al soltar el ratón.
+
 ### 🛠️ **Características Técnicas**
 - **Interfaz responsive** - Optimizada para móviles y escritorio con TailwindCSS
 - **Persistencia en Firebase** - Almacenamiento seguro y sincronización en tiempo real

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -152,19 +152,8 @@ const Token = ({
     offsetY: offY,
     rotation: angle,
     draggable: true,
-    dragBoundFunc: (pos) => ({
-      x:
-        Math.round((pos.x - offX - gridOffsetX) / gridSize) * gridSize +
-        offX +
-        gridOffsetX,
-      y:
-        Math.round((pos.y - offY - gridOffsetY) / gridSize) * gridSize +
-        offY +
-        gridOffsetY,
-    }),
-    
     onDragMove: updateHandle,
-    onDragEnd: (e) => onDragEnd(id, e.target.x() - offX, e.target.y() - offY),
+    onDragEnd: (e) => onDragEnd(id, e),
     onClick: () => onClick?.(id),
     stroke: selected ? '#e0e0e0' : undefined,
     strokeWidth: selected ? 3 : 0,
@@ -326,10 +315,25 @@ const MapCanvas = ({
     return lines;
   };
 
-  const handleDragEnd = (id, px, py) => {
-    const cellX = pxToCell(px, gridOffsetX);
-    const cellY = pxToCell(py, gridOffsetY);
-    const newTokens = tokens.map((t) => (t.id === id ? { ...t, x: cellX, y: cellY } : t));
+  const handleDragEnd = (id, evt) => {
+    const node = evt?.target;
+    if (!node) return;
+    const offX = node.offsetX();
+    const offY = node.offsetY();
+    const topLeftX = node.x() + offX;
+    const topLeftY = node.y() + offY;
+    const cellX = Math.floor((topLeftX - gridOffsetX) / effectiveGridSize);
+    const cellY = Math.floor((topLeftY - gridOffsetY) / effectiveGridSize);
+    node.position({
+      x: cellX * effectiveGridSize - offX + gridOffsetX,
+      y: cellY * effectiveGridSize - offY + gridOffsetY,
+    });
+    updateHandle();
+    node.getLayer().batchDraw();
+
+    const newTokens = tokens.map((t) =>
+      t.id === id ? { ...t, x: cellX, y: cellY } : t
+    );
     onTokensChange(newTokens);
   };
 


### PR DESCRIPTION
## Summary
- remove extra rotation handle update from token
- snap token to grid on drag end using bounding box
- update README with drag simplification notes

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68688375efd4832681a05bcf9c87d94d