### PR TITLE
Improve token snap rounding

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,25 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 **Resumen de cambios v2.2.26:**
 - Hacer clic fuera del mapa deselecciona el token activo.
 
+**Resumen de cambios v2.2.27:**
+- Snapping preciso de tokens tras el drag usando la posición real del puntero.
+
+**Resumen de cambios v2.2.28:**
+- Nueva lógica de snap basada en la esquina superior-izquierda del token para
+  alinearlo siempre con la celda inferior/izquierda.
+
+**Resumen de cambios v2.2.29:**
+- Simplificación del drag: el token se mueve libremente y se corrige con
+  bounding-box al soltar el ratón.
+
+**Resumen de cambios v2.2.30:**
+- Snap definitivo calculado con el centro del token y Math.round para
+  garantizar el centrado perfecto.
+
+**Resumen de cambios v2.2.31:**
+- Corrección de error al soltar un token: el handle de rotación se actualiza
+  correctamente sin fallos de referencia.
+
 ### 🛠️ **Características Técnicas**
 - **Interfaz responsive** - Optimizada para móviles y escritorio con TailwindCSS
 - **Persistencia en Firebase** - Almacenamiento seguro y sincronización en tiempo real

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -152,19 +152,11 @@ const Token = ({
     offsetY: offY,
     rotation: angle,
     draggable: true,
-    dragBoundFunc: (pos) => ({
-      x:
-        Math.round((pos.x - offX - gridOffsetX) / gridSize) * gridSize +
-        offX +
-        gridOffsetX,
-      y:
-        Math.round((pos.y - offY - gridOffsetY) / gridSize) * gridSize +
-        offY +
-        gridOffsetY,
-    }),
-    
     onDragMove: updateHandle,
-    onDragEnd: (e) => onDragEnd(id, e.target.x() - offX, e.target.y() - offY),
+    onDragEnd: (e) => {
+      onDragEnd(id, e);
+      updateHandle();
+    },
     onClick: () => onClick?.(id),
     stroke: selected ? '#e0e0e0' : undefined,
     strokeWidth: selected ? 3 : 0,
@@ -326,10 +318,24 @@ const MapCanvas = ({
     return lines;
   };
 
-  const handleDragEnd = (id, px, py) => {
-    const cellX = pxToCell(px, gridOffsetX);
-    const cellY = pxToCell(py, gridOffsetY);
-    const newTokens = tokens.map((t) => (t.id === id ? { ...t, x: cellX, y: cellY } : t));
+  const handleDragEnd = (id, evt) => {
+    const node = evt?.target;
+    if (!node) return;
+    const offX = node.offsetX();
+    const offY = node.offsetY();
+    const centerX = node.x() + offX;
+    const centerY = node.y() + offY;
+    const col = Math.round((centerX - gridOffsetX) / effectiveGridSize);
+    const row = Math.round((centerY - gridOffsetY) / effectiveGridSize);
+    node.position({
+      x: col * effectiveGridSize - offX + gridOffsetX,
+      y: row * effectiveGridSize - offY + gridOffsetY,
+    });
+    node.getLayer().batchDraw();
+
+    const newTokens = tokens.map((t) =>
+      t.id === id ? { ...t, x: col, y: row } : t
+    );
     onTokensChange(newTokens);
   };
 


### PR DESCRIPTION
## Summary
- update drag end logic to snap using token center with Math.round
- document new snapping method
- fix missing rotation handle update on drop

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68688375efd4832681a05bcf9c87d94d