### PR TITLE
Add drag shadow for map tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 - **Mapa adaptable** - La imagen se ajusta al viewport manteniendo su proporción
 - **Zoom interactivo** - Acerca y aleja el mapa con la rueda del ratón
 - **Paneo con botón central** - Desplaza el mapa arrastrando con la rueda
+- **Sombra de arrastre** - Mientras arrastras un token queda una copia semitransparente en su casilla original
 
 ### 🎲 **Gestión de Personajes**
 


### PR DESCRIPTION
## Summary
- add optional props to `Token` component (draggable, listening, opacity, onDragStart)
- store a `dragShadow` token while dragging and render it with reduced opacity
- update README with new drag shadow feature

## Testing
- `CI=true npm test -- -u`

------
https://chatgpt.com/codex/tasks/task_e_686ab686414c832689993a293dd38e13