### PR TITLE
Implement nested folders with floating windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,15 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 - Solucionado desvío inicial al colocar un token por primera vez: ahora se
   alinea en la casilla correcta sin desplazarse a una adyacente.
 
+**Resumen de cambios v2.2.33:**
+- Carpetas anidadas en **AssetSidebar** con ventanas flotantes arrastrables.
+- Doble clic en una carpeta abre su contenido en primera plana.
+- Posibilidad de crear subcarpetas ilimitadas y arrastrar tokens al mapa.
+
+**Resumen de cambios v2.2.34:**
+- Las ventanas evitan duplicados y se cierran si se elimina la carpeta.
+- Gestión mejorada del z-index para mantenerlas siempre en primer plano.
+
 ### 🛠️ **Características Técnicas**
 - **Interfaz responsive** - Optimizada para móviles y escritorio con TailwindCSS
 - **Persistencia en Firebase** - Almacenamiento seguro y sincronización en tiempo real

--- a/src/components/AssetSidebar.jsx
+++ b/src/components/AssetSidebar.jsx
@@ -1,7 +1,13 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
+import { createPortal } from 'react-dom';
 import PropTypes from 'prop-types';
 import { nanoid } from 'nanoid';
-import { FiChevronDown, FiChevronRight, FiTrash } from 'react-icons/fi';
+import {
+  FiChevronDown,
+  FiChevronRight,
+  FiTrash,
+  FiFolder,
+} from 'react-icons/fi';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useDrag } from 'react-dnd';
 
@@ -9,7 +15,7 @@ export const AssetTypes = { IMAGE: 'asset-image' };
 
 const AssetSidebar = ({ onAssetSelect, onDragStart }) => {
   const [folders, setFolders] = useState(() => [
-    { id: nanoid(), name: 'Enemigos', assets: [], open: true },
+    { id: nanoid(), name: 'Enemigos', assets: [], folders: [], open: true },
   ]);
   
   // Image preview data {url, x, y} shown on hover
@@ -20,7 +26,14 @@ const AssetSidebar = ({ onAssetSelect, onDragStart }) => {
     if (stored) {
       try {
         const parsed = JSON.parse(stored);
-        setFolders(parsed);
+        const normalize = (arr) =>
+          arr.map((f) => ({
+            ...f,
+            assets: f.assets || [],
+            folders: normalize(f.folders || []),
+            open: f.open ?? false,
+          }));
+        setFolders(normalize(parsed));
       } catch {
         // ignore
       }
@@ -31,11 +44,25 @@ const AssetSidebar = ({ onAssetSelect, onDragStart }) => {
     localStorage.setItem('assetSidebar', JSON.stringify(folders));
   }, [folders]);
 
-  const addFolder = () => {
+  const updateFolders = (list, id, updater) =>
+    list.map((f) =>
+      f.id === id
+        ? updater(f)
+        : { ...f, folders: updateFolders(f.folders, id, updater) }
+    );
+
+  const addFolder = (parentId = null) => {
     const name = prompt('Nombre de la carpeta');
-    if (name) {
-      setFolders((fs) => [...fs, { id: nanoid(), name, assets: [], open: true }]);
-    }
+    if (!name) return;
+    const newFolder = { id: nanoid(), name, assets: [], folders: [], open: true };
+    setFolders((fs) => {
+      if (!parentId) return [...fs, newFolder];
+      return updateFolders(fs, parentId, (f) => ({
+        ...f,
+        folders: [...f.folders, newFolder],
+        open: true,
+      }));
+    });
   };
 
   const fileToDataURL = (file) =>
@@ -55,26 +82,34 @@ const AssetSidebar = ({ onAssetSelect, onDragStart }) => {
       })
     );
     setFolders((fs) =>
-      fs.map((f) =>
-        f.id === folderId ? { ...f, assets: [...f.assets, ...uploads] } : f
-      )
+      updateFolders(fs, folderId, (f) => ({
+        ...f,
+        assets: [...f.assets, ...uploads],
+      }))
     );
   };
 
   const toggleFolder = (id) => {
-    setFolders((fs) => fs.map((f) => (f.id === id ? { ...f, open: !f.open } : f)));
+    setFolders((fs) =>
+      updateFolders(fs, id, (f) => ({ ...f, open: !f.open }))
+    );
   };
 
   const removeFolder = (id) => {
-    setFolders((fs) => fs.filter((f) => f.id !== id));
+    const removeRec = (list) =>
+      list
+        .filter((f) => f.id !== id)
+        .map((f) => ({ ...f, folders: removeRec(f.folders) }));
+    setFolders((fs) => removeRec(fs));
+    setWindows((ws) => ws.filter((w) => w.id !== id));
   };
 
   const removeAsset = (folderId, assetId) => {
     setFolders((fs) =>
-      fs.map((f) => {
-        if (f.id !== folderId) return f;
-        return { ...f, assets: f.assets.filter((a) => a.id !== assetId) };
-      })
+      updateFolders(fs, folderId, (f) => ({
+        ...f,
+        assets: f.assets.filter((a) => a.id !== assetId),
+      }))
     );
   };
 
@@ -86,6 +121,125 @@ const AssetSidebar = ({ onAssetSelect, onDragStart }) => {
     setPreview((p) => (p ? { ...p, x: e.clientX, y: e.clientY } : null));
   };
   const hidePreview = () => setPreview(null);
+  const findFolder = (list, id) => {
+    for (const f of list) {
+      if (f.id === id) return f;
+      const found = findFolder(f.folders, id);
+      if (found) return found;
+    }
+    return null;
+  };
+
+  const [windows, setWindows] = useState([]);
+  const [zMax, setZMax] = useState(1000);
+
+  const openWindow = (id) => {
+    const folder = findFolder(folders, id);
+    if (!folder) return;
+    setWindows((ws) => {
+      const topZ = Math.max(zMax, ...ws.map((w) => w.z));
+      const newZ = topZ + 1;
+      setZMax(newZ);
+      const existing = ws.find((w) => w.id === id);
+      if (existing) {
+        return ws.map((w) => (w.id === id ? { ...w, z: newZ } : w));
+      }
+      return [
+        ...ws,
+        { id, x: 100 + ws.length * 20, y: 100 + ws.length * 20, z: newZ },
+      ];
+    });
+  };
+
+  const closeWindow = (id) => {
+    setWindows((ws) => ws.filter((w) => w.id !== id));
+  };
+
+  const bringToFront = (id) => {
+    setWindows((ws) => {
+      const maxZ = Math.max(...ws.map((w) => w.z), zMax);
+      return ws.map((w) => (w.id === id ? { ...w, z: maxZ + 1 } : w));
+    });
+    setZMax((z) => z + 1);
+  };
+
+  const renderFolder = (folder) => (
+    <motion.div
+      key={folder.id}
+      initial={{ opacity: 0, scale: 0.95 }}
+      animate={{ opacity: 1, scale: 1 }}
+      exit={{ opacity: 0, scale: 0.95 }}
+      className="bg-gray-700 rounded"
+    >
+      <div
+        className="flex items-center justify-between px-2 py-1 hover:bg-gray-600"
+        onDoubleClick={() => openWindow(folder.id)}
+      >
+        <button
+          onClick={() => toggleFolder(folder.id)}
+          className="flex-1 text-left truncate flex items-center gap-1"
+        >
+          {folder.open ? <FiChevronDown /> : <FiChevronRight />}
+          <span className="truncate">{folder.name}</span>
+        </button>
+        <button
+          onClick={() => removeFolder(folder.id)}
+          className="text-gray-400 hover:text-red-400"
+        >
+          <FiTrash />
+        </button>
+      </div>
+      <AnimatePresence initial={false}>
+        {folder.open && (
+          <motion.div
+            key="content"
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: 'auto', opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={{ duration: 0.2 }}
+            className="overflow-hidden p-2 space-y-2"
+          >
+            <div className="flex gap-2">
+              <button
+                onClick={() => addFolder(folder.id)}
+                className="bg-gray-700 hover:bg-gray-600 text-xs px-2 rounded"
+              >
+                + Carpeta
+              </button>
+              <input
+                type="file"
+                accept="image/*"
+                multiple
+                onChange={(e) => handleFilesUpload(folder.id, e.target.files)}
+                className="text-xs"
+              />
+            </div>
+            {folder.folders.length > 0 && (
+              <div className="space-y-2">
+                {folder.folders.map((sub) => renderFolder(sub))}
+              </div>
+            )}
+            <div className="grid grid-cols-4 gap-2">
+              {folder.assets.map((asset) => (
+                <DraggableAssetItem
+                  key={asset.id}
+                  asset={asset}
+                  folderId={folder.id}
+                  onAssetSelect={onAssetSelect}
+                  onDragStart={onDragStart}
+                  onRemove={removeAsset}
+                  showPreview={showPreview}
+                  movePreview={movePreview}
+                  hidePreview={hidePreview}
+                />
+              ))}
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </motion.div>
+  );
+
   return (
     <div className="fixed right-0 top-0 h-screen w-80 bg-gray-800 flex flex-col">
       <div className="p-2 border-b border-gray-700">
@@ -98,66 +252,7 @@ const AssetSidebar = ({ onAssetSelect, onDragStart }) => {
       </div>
       <div className="flex-1 overflow-y-auto p-2 space-y-2">
         <AnimatePresence>
-          {folders.map((folder) => (
-            <motion.div
-              key={folder.id}
-              initial={{ opacity: 0, scale: 0.95 }}
-              animate={{ opacity: 1, scale: 1 }}
-              exit={{ opacity: 0, scale: 0.95 }}
-              className="bg-gray-700 rounded"
-            >
-              <div className="flex items-center justify-between px-2 py-1 hover:bg-gray-600">
-                <button
-                  onClick={() => toggleFolder(folder.id)}
-                  className="flex-1 text-left truncate flex items-center gap-1"
-                >
-                  {folder.open ? <FiChevronDown /> : <FiChevronRight />}
-                  <span className="truncate">{folder.name}</span>
-                </button>
-                <button
-                  onClick={() => removeFolder(folder.id)}
-                  className="text-gray-400 hover:text-red-400"
-                >
-                  <FiTrash />
-                </button>
-              </div>
-              <AnimatePresence initial={false}>
-                {folder.open && (
-                  <motion.div
-                    key="content"
-                    initial={{ height: 0, opacity: 0 }}
-                    animate={{ height: 'auto', opacity: 1 }}
-                    exit={{ height: 0, opacity: 0 }}
-                    transition={{ duration: 0.2 }}
-                    className="overflow-hidden p-2 space-y-2"
-                  >
-                    <input
-                      type="file"
-                      accept="image/*"
-                      multiple
-                      onChange={(e) => handleFilesUpload(folder.id, e.target.files)}
-                      className="text-sm w-full"
-                    />
-                    <div className="grid grid-cols-4 gap-2">
-                      {folder.assets.map((asset) => (
-                        <DraggableAssetItem
-                          key={asset.id}
-                          asset={asset}
-                          folderId={folder.id}
-                          onAssetSelect={onAssetSelect}
-                          onDragStart={onDragStart}
-                          onRemove={removeAsset}
-                          showPreview={showPreview}
-                          movePreview={movePreview}
-                          hidePreview={hidePreview}
-                        />
-                      ))}
-                    </div>
-                  </motion.div>
-                )}
-              </AnimatePresence>
-            </motion.div>
-          ))}
+          {folders.map((folder) => renderFolder(folder))}
         </AnimatePresence>
       </div>
       {preview && (
@@ -172,6 +267,25 @@ const AssetSidebar = ({ onAssetSelect, onDragStart }) => {
           />
         </div>
       )}
+      {windows.map((w) => (
+        <FolderWindow
+          key={w.id}
+          folder={findFolder(folders, w.id)}
+          position={w}
+          bringToFront={bringToFront}
+          onClose={closeWindow}
+          onAddFolder={addFolder}
+          onUpload={handleFilesUpload}
+          onRemoveFolder={removeFolder}
+          onRemoveAsset={removeAsset}
+          onOpenFolder={openWindow}
+          onAssetSelect={onAssetSelect}
+          onDragStart={onDragStart}
+          showPreview={showPreview}
+          movePreview={movePreview}
+          hidePreview={hidePreview}
+        />
+      ))}
     </div>
   );
 };
@@ -241,6 +355,150 @@ DraggableAssetItem.propTypes = {
   onAssetSelect: PropTypes.func,
   onDragStart: PropTypes.func,
   onRemove: PropTypes.func.isRequired,
+  showPreview: PropTypes.func.isRequired,
+  movePreview: PropTypes.func.isRequired,
+  hidePreview: PropTypes.func.isRequired,
+};
+
+const FolderIcon = ({ folder, onOpen }) => (
+  <div
+    className="text-center text-xs cursor-pointer"
+    onDoubleClick={() => onOpen(folder.id)}
+  >
+    <div className="relative group">
+      <FiFolder className="w-12 h-12 mx-auto text-yellow-400" />
+    </div>
+    <span className="truncate block w-16 mx-auto">{folder.name}</span>
+  </div>
+);
+
+FolderIcon.propTypes = {
+  folder: PropTypes.shape({
+    id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+    name: PropTypes.string.isRequired,
+  }).isRequired,
+  onOpen: PropTypes.func.isRequired,
+};
+
+const FolderWindow = ({
+  folder,
+  position,
+  bringToFront,
+  onClose,
+  onAddFolder,
+  onUpload,
+  onRemoveFolder,
+  onRemoveAsset,
+  onOpenFolder,
+  onAssetSelect,
+  onDragStart,
+  showPreview,
+  movePreview,
+  hidePreview,
+}) => {
+  const [pos, setPos] = useState({ x: position.x, y: position.y });
+  const [dragging, setDragging] = useState(false);
+  const offset = useRef({ x: 0, y: 0 });
+
+  const handleMouseDown = (e) => {
+    setDragging(true);
+    offset.current = { x: e.clientX - pos.x, y: e.clientY - pos.y };
+    bringToFront(position.id);
+  };
+  const handleMouseMove = (e) => {
+    if (!dragging) return;
+    setPos({ x: e.clientX - offset.current.x, y: e.clientY - offset.current.y });
+  };
+  const handleMouseUp = () => setDragging(false);
+
+  useEffect(() => {
+    if (!dragging) return;
+    window.addEventListener('mousemove', handleMouseMove);
+    window.addEventListener('mouseup', handleMouseUp);
+    return () => {
+      window.removeEventListener('mousemove', handleMouseMove);
+      window.removeEventListener('mouseup', handleMouseUp);
+    };
+  }, [dragging]);
+
+  if (!folder) return null;
+
+  return createPortal(
+    <div
+      className="fixed select-none"
+      style={{ top: pos.y, left: pos.x, zIndex: position.z }}
+    >
+      <div className="w-64 bg-gray-800 border border-gray-700 rounded shadow-xl">
+        <div
+          className="flex justify-between items-center bg-gray-700 px-2 py-1 cursor-move"
+          onMouseDown={handleMouseDown}
+        >
+          <span className="font-bold truncate">{folder.name}</span>
+          <button
+            onClick={() => onClose(position.id)}
+            className="text-gray-400 hover:text-red-400"
+          >
+            <FiTrash />
+          </button>
+        </div>
+        <div className="p-2 space-y-2">
+          <div className="flex gap-2">
+            <button
+              onClick={() => onAddFolder(folder.id)}
+              className="bg-gray-700 hover:bg-gray-600 text-xs px-2 rounded"
+            >
+              + Carpeta
+            </button>
+            <input
+              type="file"
+              accept="image/*"
+              multiple
+              onChange={(e) => onUpload(folder.id, e.target.files)}
+              className="text-xs"
+            />
+          </div>
+          <div className="grid grid-cols-4 gap-2">
+            {folder.folders.map((sub) => (
+              <FolderIcon key={sub.id} folder={sub} onOpen={onOpenFolder} />
+            ))}
+            {folder.assets.map((asset) => (
+              <DraggableAssetItem
+                key={asset.id}
+                asset={asset}
+                folderId={folder.id}
+                onAssetSelect={onAssetSelect}
+                onDragStart={onDragStart}
+                onRemove={onRemoveAsset}
+                showPreview={showPreview}
+                movePreview={movePreview}
+                hidePreview={hidePreview}
+              />
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+};
+
+FolderWindow.propTypes = {
+  folder: PropTypes.object,
+  position: PropTypes.shape({
+    id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+    x: PropTypes.number.isRequired,
+    y: PropTypes.number.isRequired,
+    z: PropTypes.number.isRequired,
+  }).isRequired,
+  bringToFront: PropTypes.func.isRequired,
+  onClose: PropTypes.func.isRequired,
+  onAddFolder: PropTypes.func.isRequired,
+  onUpload: PropTypes.func.isRequired,
+  onRemoveFolder: PropTypes.func.isRequired,
+  onRemoveAsset: PropTypes.func.isRequired,
+  onOpenFolder: PropTypes.func.isRequired,
+  onAssetSelect: PropTypes.func,
+  onDragStart: PropTypes.func,
   showPreview: PropTypes.func.isRequired,
   movePreview: PropTypes.func.isRequired,
   hidePreview: PropTypes.func.isRequired,


### PR DESCRIPTION
## Summary
- enable unlimited nested folders in AssetSidebar
- open folders in draggable floating windows
- avoid duplicate windows and close them if the folder is removed
- persist folder hierarchy in localStorage
- update README with new feature notes

## Testing
- `npm install`
- `npm test -- -u --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_686ac17649808326b2e94bf704e466fa