### PR TITLE
Fix AssetSidebar hook dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,9 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 - Las ventanas evitan duplicados y se cierran si se elimina la carpeta.
 - Gestión mejorada del z-index para mantenerlas siempre en primer plano.
 
+**Resumen de cambios v2.2.35:**
+- Corrección de warning de dependencia faltante en `AssetSidebar` al mover la ventana.
+
 ### 🛠️ **Características Técnicas**
 - **Interfaz responsive** - Optimizada para móviles y escritorio con TailwindCSS
 - **Persistencia en Firebase** - Almacenamiento seguro y sincronización en tiempo real

--- a/src/components/AssetSidebar.jsx
+++ b/src/components/AssetSidebar.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { createPortal } from 'react-dom';
 import PropTypes from 'prop-types';
 import { nanoid } from 'nanoid';
@@ -405,11 +405,17 @@ const FolderWindow = ({
     offset.current = { x: e.clientX - pos.x, y: e.clientY - pos.y };
     bringToFront(position.id);
   };
-  const handleMouseMove = (e) => {
-    if (!dragging) return;
-    setPos({ x: e.clientX - offset.current.x, y: e.clientY - offset.current.y });
-  };
-  const handleMouseUp = () => setDragging(false);
+  const handleMouseMove = useCallback(
+    (e) => {
+      if (!dragging) return;
+      setPos({
+        x: e.clientX - offset.current.x,
+        y: e.clientY - offset.current.y,
+      });
+    },
+    [dragging]
+  );
+  const handleMouseUp = useCallback(() => setDragging(false), []);
 
   useEffect(() => {
     if (!dragging) return;
@@ -419,7 +425,7 @@ const FolderWindow = ({
       window.removeEventListener('mousemove', handleMouseMove);
       window.removeEventListener('mouseup', handleMouseUp);
     };
-  }, [dragging]);
+  }, [dragging, handleMouseMove]);
 
   if (!folder) return null;
 


### PR DESCRIPTION
## Summary
- stabilize mouse move/up handlers in `AssetSidebar` using `useCallback`
- include the handler in `useEffect` dependencies
- document the fix in the README

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686ac880fdd8832684630c8ddb3a6437