### PR TITLE
Fix enemy sheet initialization bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,15 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 - Iconos de subcarpeta sin borde amarillo para un aspecto más limpio.
 - Tokens del mapa pueden abrir la ficha de enemigo con un nuevo icono de engranaje.
 
+**Resumen de cambios v2.2.38:**
+- Corregido error al abrir la ficha de un enemigo recién asignado al token.
+
+**Resumen de cambios v2.2.39:**
+- Icono de engranaje se sitúa en la esquina inferior izquierda del token y abre la ficha al pulsarlo.
+
+**Resumen de cambios v2.2.40:**
+- Engranaje separado del token con la misma distancia que el botón de rotación.
+
 ### 🛠️ **Características Técnicas**
 - **Interfaz responsive** - Optimizada para móviles y escritorio con TailwindCSS
 - **Persistencia en Firebase** - Almacenamiento seguro y sincronización en tiempo real

--- a/src/components/EnemySheet.jsx
+++ b/src/components/EnemySheet.jsx
@@ -6,13 +6,13 @@ import Input from './Input';
 
 const EnemySheet = ({ enemy, onClose, onSave }) => {
   const [isEditing, setIsEditing] = useState(false);
-  const [data, setData] = useState(enemy);
+  const [data, setData] = useState(enemy || null);
 
   useEffect(() => {
-    setData(enemy);
+    setData(enemy || null);
   }, [enemy]);
 
-  if (!enemy) return null;
+  if (!enemy || !data) return null;
 
   const updateStat = (stat, field, value) => {
     setData(prev => ({

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -44,14 +44,26 @@ const Token = ({
   const shapeRef = useRef();
   const trRef = useRef();
   const rotateRef = useRef();
+  const gearRef = useRef();
+  const HANDLE_OFFSET = 12;
   const SNAP = gridSize / 4;
 
   const updateHandle = () => {
     const node = shapeRef.current;
     const handle = rotateRef.current;
+    const gear = gearRef.current;
     if (!node || !handle) return;
     const box = node.getClientRect({ relativeTo: node.getParent() });
-    handle.position({ x: box.x + box.width + 12, y: box.y - 12 });
+    handle.position({
+      x: box.x + box.width + HANDLE_OFFSET,
+      y: box.y - HANDLE_OFFSET,
+    });
+    if (gear) {
+      gear.position({
+        x: box.x - HANDLE_OFFSET,
+        y: box.y + box.height + HANDLE_OFFSET,
+      });
+    }
     handle.getLayer().batchDraw();
   };
   useEffect(() => {
@@ -204,10 +216,9 @@ const Token = ({
             onDragEnd={handleRotateEnd}
           />
           <Text
+            ref={gearRef}
             text="⚙️"
             fontSize={24}
-            x={(width * gridSize) / 2 - 12}
-            y={-40}
             listening
             onClick={() => onSettings?.(id)}
           />


### PR DESCRIPTION
## Summary
- prevent EnemySheet from rendering before enemy data is ready
- move token gear inside group and position at bottom-left
- add spacing offset so gear sits away from token
- document patch note in README

## Testing
- `npm test --silent`
- `CI=true npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_686ad958a3b08326b4a88a02fbe92024