### PR TITLE
Add token settings modal

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 - **Sincronización en tiempo real** - Cambios instantáneos para todos los participantes
 - **Modo Master y Jugador** - Controles especializados según el rol del usuario
 - **Mapa de Batalla integrado** - VTT sencillo con grid y tokens arrastrables
+- **Fichas de token personalizadas** - Cada token puede tener su propia hoja de personaje
 - **Mapas personalizados** - Sube una imagen como fondo en el Mapa de Batalla
 - **Grid ajustable** - Tamaño y desplazamiento de la cuadrícula configurables
 - **Mapa adaptable** - La imagen se ajusta al viewport manteniendo su proporción

--- a/src/App.js
+++ b/src/App.js
@@ -339,6 +339,10 @@ function App() {
   const [showInitiativeTracker, setShowInitiativeTracker] = useState(false);
   // Tokens para el Mapa de Batalla
   const [canvasTokens, setCanvasTokens] = useState([]);
+  const [tokenSheets, setTokenSheets] = useState(() => {
+    const stored = localStorage.getItem('tokenSheets');
+    return stored ? JSON.parse(stored) : {};
+  });
   const [canvasBackground, setCanvasBackground] = useState(null);
   // Configuración de la cuadrícula del mapa de batalla
   const [gridSize, setGridSize] = useState(100);
@@ -3173,6 +3177,7 @@ function App() {
               onTokensChange={setCanvasTokens}
               enemies={enemies}
               onEnemyUpdate={updateEnemyFromToken}
+              players={existingPlayers}
             />
           </div>
           <AssetSidebar />

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -14,8 +14,9 @@ import {
 import useImage from 'use-image';
 import { useDrop } from 'react-dnd';
 import { AssetTypes } from './AssetSidebar';
-import EnemySheet from './EnemySheet';
-import Boton from './Boton';
+import TokenSettings from './TokenSettings';
+import TokenSheetModal from './TokenSheetModal';
+import { nanoid } from 'nanoid';
 
 const Token = ({
   id,
@@ -26,6 +27,8 @@ const Token = ({
   angle,
   color,
   image,
+  customName,
+  showName,
   gridSize,
   gridOffsetX,
   gridOffsetY,
@@ -46,6 +49,7 @@ const Token = ({
   const rotateRef = useRef();
   const gearRef = useRef();
   const HANDLE_OFFSET = 12;
+  const [hover, setHover] = useState(false);
 
   const SNAP = gridSize / 4;
 
@@ -187,11 +191,23 @@ const Token = ({
   };
 
   return (
-    <Group>
+    <Group onMouseEnter={() => setHover(true)} onMouseLeave={() => setHover(false)}>
       {img ? (
         <KonvaImage ref={shapeRef} image={img} onTransform={updateHandle} {...common} />
       ) : (
         <Rect ref={shapeRef} fill={color || 'red'} onTransform={updateHandle} {...common} />
+      )}
+      {showName && customName && hover && (
+        <Text
+          text={customName}
+          x={(width * gridSize) / 2}
+          y={-20}
+          offsetX={(width * gridSize) / 2}
+          fontSize={14}
+          fill="#fff"
+          align="center"
+          listening={false}
+        />
       )}
       {selected && (
         <>
@@ -245,6 +261,8 @@ Token.propTypes = {
   draggable: PropTypes.bool,
   listening: PropTypes.bool,
   opacity: PropTypes.number,
+  customName: PropTypes.string,
+  showName: PropTypes.bool,
   onClick: PropTypes.func,
   onDragStart: PropTypes.func,
   onDragEnd: PropTypes.func.isRequired,
@@ -272,6 +290,7 @@ const MapCanvas = ({
   onTokensChange,
   enemies = [],
   onEnemyUpdate,
+  players = [],
 }) => {
   const containerRef = useRef(null);
   const stageRef = useRef(null);
@@ -284,7 +303,7 @@ const MapCanvas = ({
   const [selectedId, setSelectedId] = useState(null);
   const [dragShadow, setDragShadow] = useState(null);
   const [settingsTokenId, setSettingsTokenId] = useState(null);
-  const [pendingEnemyIdToken, setPendingEnemyIdToken] = useState(null);
+  const [openSheetId, setOpenSheetId] = useState(null);
   const panStart = useRef({ x: 0, y: 0 });
   const panOrigin = useRef({ x: 0, y: 0 });
   const [bg] = useImage(backgroundImage, 'anonymous');
@@ -402,31 +421,6 @@ const MapCanvas = ({
 
   const handleOpenSettings = (id) => {
     setSettingsTokenId(id);
-    const token = tokens.find((t) => t.id === id);
-    if (token && !token.enemyId) {
-      setPendingEnemyIdToken(id);
-    }
-  };
-
-  const confirmEnemyForToken = (enemyId) => {
-    if (!pendingEnemyIdToken) return;
-    const enemy = enemies.find((e) => e.id === enemyId);
-    if (!enemy) {
-      setPendingEnemyIdToken(null);
-      return;
-    }
-    const updated = tokens.map((t) =>
-      t.id === pendingEnemyIdToken
-        ? { ...t, enemyId: enemy.id, url: enemy.portrait || t.url, name: enemy.name }
-        : t
-    );
-    onTokensChange(updated);
-    setPendingEnemyIdToken(null);
-  };
-
-  const handleSaveEnemy = async (data) => {
-    await onEnemyUpdate?.(data);
-    setSettingsTokenId(null);
   };
 
   // Zoom interactivo con la rueda del ratón
@@ -552,6 +546,10 @@ const MapCanvas = ({
           url: item.url,
           name: item.name,
           enemyId: item.enemyId,
+          tokenSheetId: nanoid(),
+          customName: '',
+          showName: false,
+          controlledBy: 'master',
         };
         onTokensChange([...tokens, newToken]);
       },
@@ -633,24 +631,20 @@ const MapCanvas = ({
         </Stage>
       </div>
       {settingsTokenId && (
-        <EnemySheet
-          enemy={enemies.find((e) => e.id === tokens.find((t) => t.id === settingsTokenId)?.enemyId)}
+        <TokenSettings
+          token={tokens.find((t) => t.id === settingsTokenId)}
+          enemies={enemies}
+          players={players}
           onClose={() => setSettingsTokenId(null)}
-          onSave={handleSaveEnemy}
+          onUpdate={(tk) => {
+            const updated = tokens.map((t) => (t.id === tk.id ? tk : t));
+            onTokensChange(updated);
+          }}
+          onOpenSheet={(id) => setOpenSheetId(id)}
         />
       )}
-      {pendingEnemyIdToken && (
-        <div className="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50" onClick={() => setPendingEnemyIdToken(null)}>
-          <div className="bg-gray-800 p-4 rounded" onClick={(e) => e.stopPropagation()}>
-            <select id="enemySelect" className="mb-4 w-60 bg-gray-700 text-white" onChange={(e) => confirmEnemyForToken(e.target.value)} defaultValue="">
-              <option value="" disabled>Selecciona enemigo</option>
-              {enemies.map((e) => (
-                <option key={e.id} value={e.id}>{e.name}</option>
-              ))}
-            </select>
-            <Boton onClick={() => setPendingEnemyIdToken(null)}>Cancelar</Boton>
-          </div>
-        </div>
+      {openSheetId && (
+        <TokenSheetModal sheetId={openSheetId} onClose={() => setOpenSheetId(null)} />
       )}
     </div>
   );
@@ -675,6 +669,10 @@ MapCanvas.propTypes = {
       name: PropTypes.string,
       color: PropTypes.string,
       enemyId: PropTypes.string,
+      tokenSheetId: PropTypes.string,
+      customName: PropTypes.string,
+      showName: PropTypes.bool,
+      controlledBy: PropTypes.string,
       w: PropTypes.number,
       h: PropTypes.number,
       angle: PropTypes.number,
@@ -683,6 +681,7 @@ MapCanvas.propTypes = {
   onTokensChange: PropTypes.func.isRequired,
   enemies: PropTypes.array,
   onEnemyUpdate: PropTypes.func,
+  players: PropTypes.array,
 };
 
 export default MapCanvas;

--- a/src/components/TokenSettings.jsx
+++ b/src/components/TokenSettings.jsx
@@ -1,0 +1,118 @@
+import React, { useState, useEffect, useRef } from 'react';
+import PropTypes from 'prop-types';
+import { createPortal } from 'react-dom';
+import { FiX } from 'react-icons/fi';
+import Boton from './Boton';
+import Input from './Input';
+
+const TokenSettings = ({ token, enemies = [], players = [], onClose, onUpdate, onOpenSheet }) => {
+  const [tab, setTab] = useState('details');
+  const [pos, setPos] = useState({ x: window.innerWidth / 2 - 160, y: window.innerHeight / 2 - 140 });
+  const [dragging, setDragging] = useState(false);
+  const offset = useRef({ x: 0, y: 0 });
+
+  const handleMouseDown = (e) => {
+    setDragging(true);
+    offset.current = { x: e.clientX - pos.x, y: e.clientY - pos.y };
+  };
+  const handleMouseMove = (e) => {
+    if (!dragging) return;
+    setPos({ x: e.clientX - offset.current.x, y: e.clientY - offset.current.y });
+  };
+  const handleMouseUp = () => setDragging(false);
+  useEffect(() => {
+    if (!dragging) return;
+    window.addEventListener('mousemove', handleMouseMove);
+    window.addEventListener('mouseup', handleMouseUp);
+    return () => {
+      window.removeEventListener('mousemove', handleMouseMove);
+      window.removeEventListener('mouseup', handleMouseUp);
+    };
+  }, [dragging]);
+
+  const [enemyId, setEnemyId] = useState(token.enemyId || '');
+  const [name, setName] = useState(token.customName || '');
+  const [showName, setShowName] = useState(token.showName || false);
+  const [controlledBy, setControlledBy] = useState(token.controlledBy || 'master');
+
+  const applyChanges = () => {
+    const enemy = enemies.find((e) => e.id === enemyId);
+    onUpdate({
+      ...token,
+      enemyId: enemyId || null,
+      url: enemyId ? enemy?.portrait || token.url : token.url,
+      name: enemyId ? enemy?.name : token.name,
+      customName: showName ? name : '',
+      showName,
+      controlledBy,
+    });
+  };
+
+  if (!token) return null;
+
+  const content = (
+    <div className="fixed select-none" style={{ top: pos.y, left: pos.x, zIndex: 1000 }}>
+      <div className="bg-gray-800 border border-gray-700 rounded shadow-xl w-80">
+        <div className="flex justify-between items-center bg-gray-700 px-2 py-1 cursor-move" onMouseDown={handleMouseDown}>
+          <span className="font-bold">Ajustes de ficha</span>
+          <button onClick={() => { applyChanges(); onClose(); }} className="text-gray-400 hover:text-red-400">
+            <FiX />
+          </button>
+        </div>
+        <div className="flex border-b border-gray-600 text-sm">
+          <button onClick={() => setTab('details')} className={`flex-1 p-2 ${tab==='details' ? 'bg-gray-800' : 'bg-gray-700'}`}>Detalles</button>
+          <button onClick={() => setTab('notes')} className={`flex-1 p-2 ${tab==='notes' ? 'bg-gray-800' : 'bg-gray-700'}`}>Notas</button>
+          <button onClick={() => setTab('light')} className={`flex-1 p-2 ${tab==='light' ? 'bg-gray-800' : 'bg-gray-700'}`}>Iluminación</button>
+        </div>
+        <div className="p-3 space-y-3 text-sm">
+          {tab === 'details' && (
+            <>
+              <div>
+                <label className="block mb-1">Representa a un personaje</label>
+                <select value={enemyId} onChange={(e) => setEnemyId(e.target.value)} className="w-full bg-gray-700 text-white">
+                  <option value="">Ninguno / Ficha genérica</option>
+                  {enemies.map((e) => (
+                    <option key={e.id} value={e.id}>{e.name}</option>
+                  ))}
+                </select>
+              </div>
+              <div className="flex items-center gap-2">
+                <input id="showName" type="checkbox" checked={showName} onChange={e => setShowName(e.target.checked)} />
+                <label htmlFor="showName">Nombre</label>
+                <Input className="flex-1" value={name} onChange={e => setName(e.target.value)} />
+              </div>
+              <div>
+                <label className="block mb-1">Controlado por</label>
+                <select value={controlledBy} onChange={e => setControlledBy(e.target.value)} className="w-full bg-gray-700 text-white">
+                  <option value="master">Máster</option>
+                  {players.map((p) => (
+                    <option key={p} value={p}>{p}</option>
+                  ))}
+                </select>
+              </div>
+              <div className="text-center">
+                <Boton onClick={() => onOpenSheet(token.tokenSheetId)}>Abrir ficha de personaje</Boton>
+              </div>
+            </>
+          )}
+          {tab !== 'details' && (
+            <div className="text-gray-400">(Sin contenido)</div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+
+  return createPortal(content, document.body);
+};
+
+TokenSettings.propTypes = {
+  token: PropTypes.object,
+  enemies: PropTypes.array,
+  players: PropTypes.array,
+  onClose: PropTypes.func.isRequired,
+  onUpdate: PropTypes.func.isRequired,
+  onOpenSheet: PropTypes.func.isRequired,
+};
+
+export default TokenSettings;

--- a/src/components/TokenSheetModal.jsx
+++ b/src/components/TokenSheetModal.jsx
@@ -1,0 +1,32 @@
+import React, { useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
+import EnemySheet from './EnemySheet';
+
+const TokenSheetModal = ({ sheetId, onClose }) => {
+  const [data, setData] = useState(null);
+
+  useEffect(() => {
+    const stored = localStorage.getItem('tokenSheets');
+    const sheets = stored ? JSON.parse(stored) : {};
+    setData(sheets[sheetId] || { id: sheetId, name: '', stats: {} });
+  }, [sheetId]);
+
+  const handleSave = (d) => {
+    const stored = localStorage.getItem('tokenSheets');
+    const sheets = stored ? JSON.parse(stored) : {};
+    sheets[sheetId] = d;
+    localStorage.setItem('tokenSheets', JSON.stringify(sheets));
+    setData(d);
+  };
+
+  if (!data) return null;
+
+  return <EnemySheet enemy={data} onClose={onClose} onSave={handleSave} />;
+};
+
+TokenSheetModal.propTypes = {
+  sheetId: PropTypes.string.isRequired,
+  onClose: PropTypes.func.isRequired,
+};
+
+export default TokenSheetModal;


### PR DESCRIPTION
## Summary
- add per-token settings window with own character sheet
- generate tokenSheetId and custom data when dropping tokens
- show token name on hover
- update battle map to use new modal
- document token sheet capability in README

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686b8d5321f08326a059a78ae6bb35a5