### PR TITLE
Add glossary highlights to token sheet view

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 - **Sincronización en tiempo real** - Cambios instantáneos para todos los participantes
 - **Modo Master y Jugador** - Controles especializados según el rol del usuario
 - **Mapa de Batalla integrado** - VTT sencillo con grid y tokens arrastrables
+- **Fichas de token personalizadas** - Cada token puede tener su propia hoja de personaje
 - **Mapas personalizados** - Sube una imagen como fondo en el Mapa de Batalla
 - **Grid ajustable** - Tamaño y desplazamiento de la cuadrícula configurables
 - **Mapa adaptable** - La imagen se ajusta al viewport manteniendo su proporción
@@ -217,6 +218,18 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 
 **Resumen de cambios v2.2.40:**
 - Engranaje separado del token con la misma distancia que el botón de rotación.
+
+**Resumen de cambios v2.2.41:**
+- Las fichas personalizadas de los tokens se crean usando los datos del enemigo seleccionado.
+
+**Resumen de cambios v2.2.42:**
+- Las fichas de token muestran atributos y equipo como la vista completa de enemigos.
+
+**Resumen de cambios v2.2.43:**
+- Las fichas de token también resaltan términos del glosario en la vista de ficha.
+
+**Resumen de cambios v2.2.44:**
+- Pueden mantenerse varias ventanas de Ajustes de ficha y hojas de token abiertas a la vez.
 
 ### 🛠️ **Características Técnicas**
 - **Interfaz responsive** - Optimizada para móviles y escritorio con TailwindCSS

--- a/src/App.js
+++ b/src/App.js
@@ -22,6 +22,7 @@ import DiceCalculator from './components/DiceCalculator';
 import BarraReflejos from './components/BarraReflejos';
 import InitiativeTracker from './components/InitiativeTracker';
 import MapCanvas from './components/MapCanvas';
+import EnemyViewModal from './components/EnemyViewModal';
 import AssetSidebar from './components/AssetSidebar';
 import useConfirm from './hooks/useConfirm';
 import useResourcesHook from './hooks/useResources';
@@ -339,6 +340,10 @@ function App() {
   const [showInitiativeTracker, setShowInitiativeTracker] = useState(false);
   // Tokens para el Mapa de Batalla
   const [canvasTokens, setCanvasTokens] = useState([]);
+  const [tokenSheets, setTokenSheets] = useState(() => {
+    const stored = localStorage.getItem('tokenSheets');
+    return stored ? JSON.parse(stored) : {};
+  });
   const [canvasBackground, setCanvasBackground] = useState(null);
   // Configuración de la cuadrícula del mapa de batalla
   const [gridSize, setGridSize] = useState(100);
@@ -2911,210 +2916,12 @@ function App() {
         )}
         {/* Modal para ver ficha completa */}
         {selectedEnemy && (
-          <div
-            className="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50"
-            onClick={() => setSelectedEnemy(null)}
-          >
-            <div
-              className="bg-gray-800 rounded-xl p-6 max-w-6xl w-full max-h-[90vh] overflow-y-auto"
-              onClick={(e) => e.stopPropagation()}
-            >
-              <div className="flex items-center justify-between mb-4">
-                <h2 className="text-xl font-bold">Ficha de {selectedEnemy.name}</h2>
-                <div className="flex gap-2">
-                  <Boton
-                    color="blue"
-                    onClick={() => editEnemy(selectedEnemy)}
-                  >
-                    Editar
-                  </Boton>
-                  <Boton
-                    color="gray"
-                    onClick={() => setSelectedEnemy(null)}
-                  >
-                    ✕
-                  </Boton>
-                </div>
-              </div>
-              <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-                {/* Columna 1: Retrato e información básica */}
-                <div className="space-y-4">
-                  {selectedEnemy.portrait && (
-                    <div className="w-full aspect-square max-w-xs mx-auto rounded-lg overflow-hidden bg-gray-700 flex items-center justify-center">
-                      <img
-                        src={selectedEnemy.portrait}
-                        alt={selectedEnemy.name}
-                        className="w-full h-full object-cover object-center rounded-lg shadow-md border border-gray-800"
-                        style={{ background: '#222' }}
-                      />
-                    </div>
-                  )}
-                  <div className="bg-gray-700 rounded-lg p-4 space-y-2">
-                    <h3 className="font-semibold text-lg">Información Básica</h3>
-                    <div className="text-sm space-y-1">
-                      <p><span className="font-medium">Nivel:</span> {selectedEnemy.nivel || 1}</p>
-                      <p><span className="font-medium">Experiencia:</span> {selectedEnemy.experiencia || 0}</p>
-                      <p><span className="font-medium">Dinero:</span> {selectedEnemy.dinero || 0}</p>
-                    </div>
-                  </div>
-                  {selectedEnemy.description && (
-                    <div className="bg-gray-700 rounded-lg p-4">
-                      <h3 className="font-semibold mb-2">Descripción</h3>
-                      <p className="text-gray-300 text-sm">{selectedEnemy.description}</p>
-                    </div>
-                  )}
-                  {selectedEnemy.notas && (
-                    <div className="bg-gray-700 rounded-lg p-4">
-                      <h3 className="font-semibold mb-2">Notas</h3>
-                      <p className="text-gray-300 text-sm">{selectedEnemy.notas}</p>
-                    </div>
-                  )}
-                </div>
-                {/* Columna 2: Atributos y Estadísticas */}
-                <div className="space-y-4">
-                  {/* Atributos */}
-                  <div className="bg-gray-700 rounded-lg p-4">
-                    <h3 className="font-semibold mb-3">Atributos</h3>
-                    <div className="grid grid-cols-2 gap-2 text-sm">
-                      {atributos.map(attr => (
-                        <div key={attr} className="flex justify-between">
-                          <span className="font-medium">{attr}:</span>
-                          <span className="text-blue-400">{selectedEnemy.atributos?.[attr] || 'D4'}</span>
-                        </div>
-                      ))}
-                    </div>
-                  </div>
-                  {/* Estadísticas */}
-                  <div className="bg-gray-700 rounded-lg p-4">
-                    <h3 className="font-semibold mb-3">Estadísticas</h3>
-                    <div className="space-y-3 text-sm">
-                      {defaultRecursos.map(recurso => {
-                        const stat = selectedEnemy.stats?.[recurso] || { base: 0, total: 0, actual: 0, buff: 0 };
-                        const color = recursoColor[recurso] || '#ffffff';
-                        return (
-                          <div key={recurso} className="space-y-1">
-                            {/* Línea minimalista como en fichas de jugador */}
-                            <div className="flex items-center justify-between">
-                              <span className="font-medium capitalize" style={{ color }}>{recurso}</span>
-                              <div className="flex gap-2 text-xs">
-                                <span className="text-gray-400">Base: {stat.base}</span>
-                                <span className="text-green-400">+{stat.buff}</span>
-                                <span className="text-blue-400">= {stat.total}</span>
-                                <span className="text-yellow-400">({stat.actual})</span>
-                              </div>
-                            </div>
-                          </div>
-                        );
-                      })}
-                    </div>
-                  </div>
-                </div>
-                {/* Columna 3: Equipo */}
-                <div className="space-y-4">
-                  {/* Armas */}
-                  <div className="bg-gray-700 rounded-lg p-4">
-                    <h3 className="font-semibold mb-3">Armas Equipadas</h3>
-                    {selectedEnemy.weapons?.length > 0 ? (
-                      <div className="space-y-2">
-                        {selectedEnemy.weapons.map((weapon, index) => (
-                          <Tarjeta key={index} variant="weapon" className="text-xs">
-                            <div className="flex items-center gap-2 mb-2">
-                              <span className="text-lg">⚔️</span>
-                              <p className="font-bold text-sm">{weapon.nombre}</p>
-                            </div>
-                            <p className="mb-1">
-                              <span className="font-medium">Daño:</span> {dadoIcono()} {weapon.dano} {iconoDano(weapon.tipoDano)}
-                            </p>
-                            <p className="mb-1">
-                              <span className="font-medium">Alcance:</span> {weapon.alcance}
-                            </p>
-                            <p className="mb-1">
-                              <span className="font-medium">Consumo:</span> {weapon.consumo}
-                            </p>
-                            {weapon.rasgos && weapon.rasgos.length > 0 && (
-                              <p className="mb-1">
-                                <span className="font-medium">Rasgos:</span> {highlightText(weapon.rasgos.join(', '))}
-                              </p>
-                            )}
-                            {weapon.descripcion && (
-                              <p className="text-gray-300 italic">
-                                <span className="font-medium">Descripción:</span> {highlightText(weapon.descripcion)}
-                              </p>
-                            )}
-                          </Tarjeta>
-                        ))}
-                      </div>
-                    ) : (
-                      <p className="text-gray-400 text-sm">Sin armas equipadas</p>
-                    )}
-                  </div>
-                  {/* Armaduras */}
-                  <div className="bg-gray-700 rounded-lg p-4">
-                    <h3 className="font-semibold mb-3">Armaduras Equipadas</h3>
-                    {selectedEnemy.armaduras?.length > 0 ? (
-                      <div className="space-y-2">
-                        {selectedEnemy.armaduras.map((armor, index) => (
-                          <Tarjeta key={index} variant="armor" className="text-xs">
-                            <div className="flex items-center gap-2 mb-2">
-                              <span className="text-lg">🛡️</span>
-                              <p className="font-bold text-sm">{armor.nombre}</p>
-                            </div>
-                            <p className="mb-1">
-                              <span className="font-medium">Defensa:</span> {armor.defensa}
-                            </p>
-                            {armor.rasgos && armor.rasgos.length > 0 && (
-                              <p className="mb-1">
-                                <span className="font-medium">Rasgos:</span> {highlightText(armor.rasgos.join(', '))}
-                              </p>
-                            )}
-                            {armor.descripcion && (
-                              <p className="text-gray-300 italic">
-                                <span className="font-medium">Descripción:</span> {highlightText(armor.descripcion)}
-                              </p>
-                            )}
-                          </Tarjeta>
-                        ))}
-                      </div>
-                    ) : (
-                      <p className="text-gray-400 text-sm">Sin armaduras equipadas</p>
-                    )}
-                  </div>
-                  {/* Poderes */}
-                  <div className="bg-gray-700 rounded-lg p-4">
-                    <h3 className="font-semibold mb-3">Poderes Equipados</h3>
-                    {selectedEnemy.poderes?.length > 0 ? (
-                      <div className="space-y-2">
-                        {selectedEnemy.poderes.map((power, index) => (
-                          <Tarjeta key={index} variant="power" className="text-xs">
-                            <div className="flex items-center gap-2 mb-2">
-                              <span className="text-lg">💪</span>
-                              <p className="font-bold text-sm">{power.nombre}</p>
-                            </div>
-                            <p className="mb-1">
-                              <span className="font-medium">Alcance:</span> {power.alcance}
-                            </p>
-                            <p className="mb-1">
-                              <span className="font-medium">Consumo:</span> {power.consumo}
-                            </p>
-                            <p className="mb-1">
-                              <span className="font-medium">Poder:</span> {power.poder}
-                            </p>
-                            {power.descripcion && (
-                              <p className="text-gray-300 italic">
-                                <span className="font-medium">Descripción:</span> {highlightText(power.descripcion)}
-                              </p>
-                            )}
-                          </Tarjeta>
-                        ))}
-                      </div>
-                    ) : (
-                      <p className="text-gray-400 text-sm">Sin poderes equipados</p>
-                    )}
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
+          <EnemyViewModal
+            enemy={selectedEnemy}
+            onClose={() => setSelectedEnemy(null)}
+            onEdit={editEnemy}
+            highlightText={highlightText}
+          />
         )}
       </div>
     );
@@ -3173,6 +2980,8 @@ function App() {
               onTokensChange={setCanvasTokens}
               enemies={enemies}
               onEnemyUpdate={updateEnemyFromToken}
+              players={existingPlayers}
+              highlightText={highlightText}
             />
           </div>
           <AssetSidebar />

--- a/src/components/EnemyViewModal.jsx
+++ b/src/components/EnemyViewModal.jsx
@@ -1,0 +1,274 @@
+import React, { useState, useRef, useEffect } from 'react';
+import PropTypes from 'prop-types';
+import { createPortal } from 'react-dom';
+import { BsDice6 } from 'react-icons/bs';
+import { GiFist } from 'react-icons/gi';
+import { FaFire, FaBolt, FaSnowflake, FaRadiationAlt } from 'react-icons/fa';
+import Tarjeta from './Tarjeta';
+import Boton from './Boton';
+
+const atributos = ['destreza', 'vigor', 'intelecto', 'voluntad'];
+const defaultRecursos = ['postura', 'vida', 'ingenio', 'cordura', 'armadura'];
+const recursoColor = {
+  postura: '#34d399',
+  vida: '#f87171',
+  ingenio: '#60a5fa',
+  cordura: '#a78bfa',
+  armadura: '#9ca3af',
+};
+
+const EnemyViewModal = ({ enemy, onClose, onEdit, highlightText = (t) => t }) => {
+  const modalRef = useRef(null);
+  const [pos, setPos] = useState({ x: window.innerWidth / 2 - 300, y: window.innerHeight / 2 - 250 });
+  const [dragging, setDragging] = useState(false);
+  const offset = useRef({ x: 0, y: 0 });
+
+  useEffect(() => {
+    if (modalRef.current) {
+      const rect = modalRef.current.getBoundingClientRect();
+      setPos({
+        x: window.innerWidth / 2 - rect.width / 2,
+        y: window.innerHeight / 2 - rect.height / 2,
+      });
+    }
+  }, [enemy]);
+
+  const handleMouseDown = (e) => {
+    setDragging(true);
+    offset.current = { x: e.clientX - pos.x, y: e.clientY - pos.y };
+  };
+  const handleMouseMove = (e) => {
+    if (!dragging) return;
+    setPos({ x: e.clientX - offset.current.x, y: e.clientY - offset.current.y });
+  };
+  const handleMouseUp = () => setDragging(false);
+  useEffect(() => {
+    if (!dragging) return;
+    window.addEventListener('mousemove', handleMouseMove);
+    window.addEventListener('mouseup', handleMouseUp);
+    return () => {
+      window.removeEventListener('mousemove', handleMouseMove);
+      window.removeEventListener('mouseup', handleMouseUp);
+    };
+  }, [dragging]);
+
+  if (!enemy) return null;
+
+  const dadoIcono = () => <BsDice6 className="inline" />;
+  const iconoDano = (tipo) => {
+    if (!tipo) return null;
+    switch (tipo.toLowerCase()) {
+      case 'físico': return <GiFist className="inline" />;
+      case 'fuego': return <FaFire className="inline" />;
+      case 'eléctrico': return <FaBolt className="inline" />;
+      case 'hielo': return <FaSnowflake className="inline" />;
+      case 'radiación': return <FaRadiationAlt className="inline" />;
+      default: return null;
+    }
+  };
+
+  const content = (
+    <div className="fixed inset-0 bg-black/50 z-50" onClick={onClose}>
+      <div
+        ref={modalRef}
+        className="absolute bg-gray-800 rounded-xl p-6 max-w-6xl w-full max-h-[90vh] overflow-y-auto select-none"
+        style={{ top: pos.y, left: pos.x }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between mb-4 cursor-move" onMouseDown={handleMouseDown}>
+          <h2 className="text-xl font-bold">Ficha de {enemy.name}</h2>
+          <div className="flex gap-2">
+            {onEdit && (
+              <Boton color="blue" onClick={() => onEdit(enemy)}>
+                Editar
+              </Boton>
+            )}
+            <Boton color="gray" onClick={onClose}>✕</Boton>
+          </div>
+        </div>
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+          {/* Columna 1 */}
+          <div className="space-y-4">
+            {enemy.portrait && (
+              <div className="w-full aspect-square max-w-xs mx-auto rounded-lg overflow-hidden bg-gray-700 flex items-center justify-center">
+                <img
+                  src={enemy.portrait}
+                  alt={enemy.name}
+                  className="w-full h-full object-cover object-center rounded-lg shadow-md border border-gray-800"
+                  style={{ background: '#222' }}
+                />
+              </div>
+            )}
+            <div className="bg-gray-700 rounded-lg p-4 space-y-2">
+              <h3 className="font-semibold text-lg">Información Básica</h3>
+              <div className="text-sm space-y-1">
+                <p><span className="font-medium">Nivel:</span> {enemy.nivel || 1}</p>
+                <p><span className="font-medium">Experiencia:</span> {enemy.experiencia || 0}</p>
+                <p><span className="font-medium">Dinero:</span> {enemy.dinero || 0}</p>
+              </div>
+            </div>
+            {enemy.description && (
+              <div className="bg-gray-700 rounded-lg p-4">
+                <h3 className="font-semibold mb-2">Descripción</h3>
+                <p className="text-gray-300 text-sm">{highlightText(enemy.description)}</p>
+              </div>
+            )}
+            {enemy.notas && (
+              <div className="bg-gray-700 rounded-lg p-4">
+                <h3 className="font-semibold mb-2">Notas</h3>
+                <p className="text-gray-300 text-sm">{highlightText(enemy.notas)}</p>
+              </div>
+            )}
+          </div>
+          {/* Columna 2 */}
+          <div className="space-y-4">
+            <div className="bg-gray-700 rounded-lg p-4">
+              <h3 className="font-semibold mb-3">Atributos</h3>
+              <div className="grid grid-cols-2 gap-2 text-sm">
+                {atributos.map((attr) => (
+                  <div key={attr} className="flex justify-between">
+                    <span className="font-medium">{attr}:</span>
+                    <span className="text-blue-400">{enemy.atributos?.[attr] || 'D4'}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+            <div className="bg-gray-700 rounded-lg p-4">
+              <h3 className="font-semibold mb-3">Estadísticas</h3>
+              <div className="space-y-3 text-sm">
+                {defaultRecursos.map((recurso) => {
+                  const stat = enemy.stats?.[recurso] || { base: 0, total: 0, actual: 0, buff: 0 };
+                  const color = recursoColor[recurso] || '#ffffff';
+                  return (
+                    <div key={recurso} className="space-y-1">
+                      <div className="flex items-center justify-between">
+                        <span className="font-medium capitalize" style={{ color }}>{recurso}</span>
+                        <div className="flex gap-2 text-xs">
+                          <span className="text-gray-400">Base: {stat.base}</span>
+                          <span className="text-green-400">+{stat.buff}</span>
+                          <span className="text-blue-400">= {stat.total}</span>
+                          <span className="text-yellow-400">({stat.actual})</span>
+                        </div>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          </div>
+          {/* Columna 3 */}
+          <div className="space-y-4">
+            <div className="bg-gray-700 rounded-lg p-4">
+              <h3 className="font-semibold mb-3">Armas Equipadas</h3>
+              {enemy.weapons?.length > 0 ? (
+                <div className="space-y-2">
+                  {enemy.weapons.map((weapon, index) => (
+                    <Tarjeta key={index} variant="weapon" className="text-xs">
+                      <div className="flex items-center gap-2 mb-2">
+                        <span className="text-lg">⚔️</span>
+                        <p className="font-bold text-sm">{weapon.nombre}</p>
+                      </div>
+                      <p className="mb-1">
+                        <span className="font-medium">Daño:</span> {dadoIcono()} {weapon.dano} {iconoDano(weapon.tipoDano)}
+                      </p>
+                      <p className="mb-1">
+                        <span className="font-medium">Alcance:</span> {weapon.alcance}
+                      </p>
+                      <p className="mb-1">
+                        <span className="font-medium">Consumo:</span> {weapon.consumo}
+                      </p>
+                      {weapon.rasgos && weapon.rasgos.length > 0 && (
+                        <p className="mb-1">
+                          <span className="font-medium">Rasgos:</span> {highlightText(weapon.rasgos.join(', '))}
+                        </p>
+                      )}
+                      {weapon.descripcion && (
+                        <p className="text-gray-300 italic">
+                          <span className="font-medium">Descripción:</span> {highlightText(weapon.descripcion)}
+                        </p>
+                      )}
+                    </Tarjeta>
+                  ))}
+                </div>
+              ) : (
+                <p className="text-gray-400 text-sm">Sin armas equipadas</p>
+              )}
+            </div>
+            <div className="bg-gray-700 rounded-lg p-4">
+              <h3 className="font-semibold mb-3">Armaduras Equipadas</h3>
+              {enemy.armaduras?.length > 0 ? (
+                <div className="space-y-2">
+                  {enemy.armaduras.map((armor, index) => (
+                    <Tarjeta key={index} variant="armor" className="text-xs">
+                      <div className="flex items-center gap-2 mb-2">
+                        <span className="text-lg">🛡️</span>
+                        <p className="font-bold text-sm">{armor.nombre}</p>
+                      </div>
+                      <p className="mb-1">
+                        <span className="font-medium">Defensa:</span> {armor.defensa}
+                      </p>
+                      {armor.rasgos && armor.rasgos.length > 0 && (
+                        <p className="mb-1">
+                          <span className="font-medium">Rasgos:</span> {highlightText(armor.rasgos.join(', '))}
+                        </p>
+                      )}
+                      {armor.descripcion && (
+                        <p className="text-gray-300 italic">
+                          <span className="font-medium">Descripción:</span> {highlightText(armor.descripcion)}
+                        </p>
+                      )}
+                    </Tarjeta>
+                  ))}
+                </div>
+              ) : (
+                <p className="text-gray-400 text-sm">Sin armaduras equipadas</p>
+              )}
+            </div>
+            <div className="bg-gray-700 rounded-lg p-4">
+              <h3 className="font-semibold mb-3">Poderes Equipados</h3>
+              {enemy.poderes?.length > 0 ? (
+                <div className="space-y-2">
+                  {enemy.poderes.map((power, index) => (
+                    <Tarjeta key={index} variant="power" className="text-xs">
+                      <div className="flex items-center gap-2 mb-2">
+                        <span className="text-lg">💪</span>
+                        <p className="font-bold text-sm">{power.nombre}</p>
+                      </div>
+                      <p className="mb-1">
+                        <span className="font-medium">Alcance:</span> {power.alcance}
+                      </p>
+                      <p className="mb-1">
+                        <span className="font-medium">Consumo:</span> {power.consumo}
+                      </p>
+                      <p className="mb-1">
+                        <span className="font-medium">Poder:</span> {power.poder}
+                      </p>
+                      {power.descripcion && (
+                        <p className="text-gray-300 italic">
+                          <span className="font-medium">Descripción:</span> {highlightText(power.descripcion)}
+                        </p>
+                      )}
+                    </Tarjeta>
+                  ))}
+                </div>
+              ) : (
+                <p className="text-gray-400 text-sm">Sin poderes equipados</p>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+
+  return createPortal(content, document.body);
+};
+
+EnemyViewModal.propTypes = {
+  enemy: PropTypes.object,
+  onClose: PropTypes.func.isRequired,
+  onEdit: PropTypes.func,
+  highlightText: PropTypes.func,
+};
+
+export default EnemyViewModal;

--- a/src/components/TokenSettings.jsx
+++ b/src/components/TokenSettings.jsx
@@ -1,0 +1,135 @@
+import React, { useState, useEffect, useRef } from 'react';
+import PropTypes from 'prop-types';
+import { createPortal } from 'react-dom';
+import { FiX } from 'react-icons/fi';
+import Boton from './Boton';
+import Input from './Input';
+
+const TokenSettings = ({ token, enemies = [], players = [], onClose, onUpdate, onOpenSheet }) => {
+  const [tab, setTab] = useState('details');
+  const [pos, setPos] = useState({ x: window.innerWidth / 2 - 160, y: window.innerHeight / 2 - 140 });
+  const [dragging, setDragging] = useState(false);
+  const offset = useRef({ x: 0, y: 0 });
+
+  const handleMouseDown = (e) => {
+    setDragging(true);
+    offset.current = { x: e.clientX - pos.x, y: e.clientY - pos.y };
+  };
+  const handleMouseMove = (e) => {
+    if (!dragging) return;
+    setPos({ x: e.clientX - offset.current.x, y: e.clientY - offset.current.y });
+  };
+  const handleMouseUp = () => setDragging(false);
+  useEffect(() => {
+    if (!dragging) return;
+    window.addEventListener('mousemove', handleMouseMove);
+    window.addEventListener('mouseup', handleMouseUp);
+    return () => {
+      window.removeEventListener('mousemove', handleMouseMove);
+      window.removeEventListener('mouseup', handleMouseUp);
+    };
+  }, [dragging]);
+
+  const [enemyId, setEnemyId] = useState(token.enemyId || '');
+  const [name, setName] = useState(token.customName || '');
+  const [showName, setShowName] = useState(token.showName || false);
+  const [controlledBy, setControlledBy] = useState(token.controlledBy || 'master');
+
+  const applyChanges = () => {
+    const enemy = enemies.find((e) => e.id === enemyId);
+    onUpdate({
+      ...token,
+      enemyId: enemyId || null,
+      url: enemyId ? enemy?.portrait || token.url : token.url,
+      name: enemyId ? enemy?.name : token.name,
+      customName: showName ? name : '',
+      showName,
+      controlledBy,
+    });
+  };
+
+  if (!token) return null;
+
+  const content = (
+    <div className="fixed select-none" style={{ top: pos.y, left: pos.x, zIndex: 1000 }}>
+      <div className="bg-gray-800 border border-gray-700 rounded shadow-xl w-80">
+        <div className="flex justify-between items-center bg-gray-700 px-2 py-1 cursor-move" onMouseDown={handleMouseDown}>
+          <span className="font-bold">Ajustes de ficha</span>
+          <button onClick={() => { applyChanges(); onClose(); }} className="text-gray-400 hover:text-red-400">
+            <FiX />
+          </button>
+        </div>
+        <div className="flex border-b border-gray-600 text-sm">
+          <button onClick={() => setTab('details')} className={`flex-1 p-2 ${tab==='details' ? 'bg-gray-800' : 'bg-gray-700'}`}>Detalles</button>
+          <button onClick={() => setTab('notes')} className={`flex-1 p-2 ${tab==='notes' ? 'bg-gray-800' : 'bg-gray-700'}`}>Notas</button>
+          <button onClick={() => setTab('light')} className={`flex-1 p-2 ${tab==='light' ? 'bg-gray-800' : 'bg-gray-700'}`}>Iluminación</button>
+        </div>
+        <div className="p-3 space-y-3 text-sm">
+          {tab === 'details' && (
+            <>
+              <div>
+                <label className="block mb-1">Representa a un personaje</label>
+                <select value={enemyId} onChange={(e) => setEnemyId(e.target.value)} className="w-full bg-gray-700 text-white">
+                  <option value="">Ninguno / Ficha genérica</option>
+                  {enemies.map((e) => (
+                    <option key={e.id} value={e.id}>{e.name}</option>
+                  ))}
+                </select>
+              </div>
+              <div className="flex items-center gap-2">
+                <input id="showName" type="checkbox" checked={showName} onChange={e => setShowName(e.target.checked)} />
+                <label htmlFor="showName">Nombre</label>
+                <Input className="flex-1" value={name} onChange={e => setName(e.target.value)} />
+              </div>
+              <div>
+                <label className="block mb-1">Controlado por</label>
+                <select value={controlledBy} onChange={e => setControlledBy(e.target.value)} className="w-full bg-gray-700 text-white">
+                  <option value="master">Máster</option>
+                  {players.map((p) => (
+                    <option key={p} value={p}>{p}</option>
+                  ))}
+                </select>
+              </div>
+              <div className="text-center">
+                <Boton
+                  onClick={() => {
+                    const enemy = enemies.find((e) => e.id === enemyId);
+                    const updated = {
+                      ...token,
+                      enemyId: enemyId || null,
+                      url: enemyId ? enemy?.portrait || token.url : token.url,
+                      name: enemyId ? enemy?.name : token.name,
+                      customName: showName ? name : '',
+                      showName,
+                      controlledBy,
+                    };
+                    onUpdate(updated);
+                    onOpenSheet(updated);
+                  }}
+                >
+                  Abrir ficha de personaje
+                </Boton>
+              </div>
+            </>
+          )}
+          {tab !== 'details' && (
+            <div className="text-gray-400">(Sin contenido)</div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+
+  return createPortal(content, document.body);
+};
+
+TokenSettings.propTypes = {
+  token: PropTypes.object,
+  enemies: PropTypes.array,
+  players: PropTypes.array,
+  onClose: PropTypes.func.isRequired,
+  onUpdate: PropTypes.func.isRequired,
+  onOpenSheet: PropTypes.func.isRequired,
+};
+
+export default TokenSettings;

--- a/src/components/TokenSheetModal.jsx
+++ b/src/components/TokenSheetModal.jsx
@@ -1,0 +1,45 @@
+import React, { useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
+import EnemyViewModal from './EnemyViewModal';
+
+const TokenSheetModal = ({ token, enemies = [], onClose, highlightText }) => {
+  const sheetId = token?.tokenSheetId;
+  const [data, setData] = useState(null);
+
+  useEffect(() => {
+    if (!sheetId) return;
+    const stored = localStorage.getItem('tokenSheets');
+    const sheets = stored ? JSON.parse(stored) : {};
+    let sheet = sheets[sheetId];
+    if (!sheet) {
+      if (token.enemyId) {
+        const enemy = enemies.find((e) => e.id === token.enemyId);
+        if (enemy) {
+          sheet = JSON.parse(JSON.stringify(enemy));
+          sheet.id = sheetId;
+        }
+      }
+      if (!sheet) sheet = { id: sheetId, name: '', stats: {} };
+    }
+    setData(sheet);
+  }, [sheetId, token, enemies]);
+
+  if (!token || !data) return null;
+
+  return (
+    <EnemyViewModal
+      enemy={data}
+      onClose={onClose}
+      highlightText={highlightText}
+    />
+  );
+};
+
+TokenSheetModal.propTypes = {
+  token: PropTypes.object,
+  enemies: PropTypes.array,
+  onClose: PropTypes.func.isRequired,
+  highlightText: PropTypes.func,
+};
+
+export default TokenSheetModal;


### PR DESCRIPTION
## Summary
- pass glossary highlight function to MapCanvas and TokenSheetModal
- ensure EnemyViewModal in token sheets uses `highlightText`
- document this improvement in the changelog
- allow multiple token windows on the map

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686b8d5321f08326a059a78ae6bb35a5