### PR TITLE
Add sticky header on battle map

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,12 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 - El Mapa de Batalla incluye accesos rápidos a las Fichas de Enemigos,
   el Sistema de Velocidad y las herramientas del máster.
 
+**Resumen de cambios v2.2.48:**
+- Las Fichas de Enemigos ahora incluyen un acceso directo al Mapa de Batalla.
+
+**Resumen de cambios v2.2.49:**
+- En el Mapa de Batalla el encabezado queda fijo y muestra el botón al Sistema de Velocidad del máster.
+
 ### 🛠️ **Características Técnicas**
 - **Interfaz responsive** - Optimizada para móviles y escritorio con TailwindCSS
 - **Persistencia en Firebase** - Almacenamiento seguro y sincronización en tiempo real

--- a/src/App.js
+++ b/src/App.js
@@ -2408,9 +2408,12 @@ function App() {
         <div className="sticky top-0 bg-gray-900 pb-2 z-10">
           <div className="flex items-center justify-between mb-4">
             <h1 className="text-2xl font-bold text-white">👹 Fichas de Enemigos</h1>
-            <Boton onClick={() => setChosenView(null)} className="bg-gray-700 hover:bg-gray-600">
-              ← Volver al Menú
-            </Boton>
+            <div className="flex gap-2">
+              <Boton color="indigo" onClick={() => setChosenView('canvas')}>Mapa de Batalla</Boton>
+              <Boton onClick={() => setChosenView(null)} className="bg-gray-700 hover:bg-gray-600">
+                ← Volver al Menú
+              </Boton>
+            </div>
           </div>
           <div className="flex flex-wrap gap-2 mb-4">
             <Boton color="green" onClick={createNewEnemy}>Crear Nuevo Enemigo</Boton>
@@ -2929,16 +2932,17 @@ function App() {
   if (userType === 'master' && authenticated && chosenView === 'canvas') {
     return (
       <div className="min-h-screen bg-gray-900 text-gray-100 p-4">
-        <div className="flex items-center justify-between mb-4">
-          <h1 className="text-2xl font-bold">🗺️ Mapa de Batalla</h1>
-          <div className="flex flex-wrap gap-2">
-            <Boton
-              size="sm"
-              onClick={() => setChosenView(null)}
-              className="bg-gray-700 hover:bg-gray-600"
-            >
-              ← Menú Máster
-            </Boton>
+        <div className="sticky top-0 bg-gray-900 pb-2 z-10">
+          <div className="flex items-center justify-between mb-4">
+            <h1 className="text-2xl font-bold">🗺️ Mapa de Batalla</h1>
+            <div className="flex flex-wrap gap-2">
+              <Boton
+                size="sm"
+                onClick={() => setChosenView(null)}
+                className="bg-gray-700 hover:bg-gray-600"
+              >
+                ← Menú Máster
+              </Boton>
             <Boton
               size="sm"
               color="red"
@@ -2961,6 +2965,7 @@ function App() {
               Herramientas
             </Boton>
           </div>
+        </div>
         </div>
         <div className="mb-4">
           <input type="file" accept="image/*" onChange={handleBackgroundUpload} />


### PR DESCRIPTION
## Summary
- keep battle map header fixed so shortcut buttons stay visible
- note improvement in README changelog

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_686bf66b3fac8326a1e0347e8a56475e