### PR TITLE
Shift asset sidebar below quick access bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,18 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 - El Mapa de Batalla incluye accesos rápidos a las Fichas de Enemigos,
   el Sistema de Velocidad y las herramientas del máster.
 
+**Resumen de cambios v2.2.48:**
+- Las Fichas de Enemigos ahora incluyen un acceso directo al Mapa de Batalla.
+
+**Resumen de cambios v2.2.49:**
+- En el Mapa de Batalla el encabezado queda fijo y muestra el botón al Sistema de Velocidad del máster.
+
+**Resumen de cambios v2.2.50:**
+- El encabezado del Mapa de Batalla deja espacio al sidebar de assets para que sus botones no queden tapados.
+
+**Resumen de cambios v2.2.51:**
+- La Asset Sidebar y el lienzo del Mapa se desplazan 56 px para no solapar la barra de accesos rápidos.
+
 ### 🛠️ **Características Técnicas**
 - **Interfaz responsive** - Optimizada para móviles y escritorio con TailwindCSS
 - **Persistencia en Firebase** - Almacenamiento seguro y sincronización en tiempo real

--- a/src/App.js
+++ b/src/App.js
@@ -2408,9 +2408,12 @@ function App() {
         <div className="sticky top-0 bg-gray-900 pb-2 z-10">
           <div className="flex items-center justify-between mb-4">
             <h1 className="text-2xl font-bold text-white">👹 Fichas de Enemigos</h1>
-            <Boton onClick={() => setChosenView(null)} className="bg-gray-700 hover:bg-gray-600">
-              ← Volver al Menú
-            </Boton>
+            <div className="flex gap-2">
+              <Boton color="indigo" onClick={() => setChosenView('canvas')}>Mapa de Batalla</Boton>
+              <Boton onClick={() => setChosenView(null)} className="bg-gray-700 hover:bg-gray-600">
+                ← Volver al Menú
+              </Boton>
+            </div>
           </div>
           <div className="flex flex-wrap gap-2 mb-4">
             <Boton color="green" onClick={createNewEnemy}>Crear Nuevo Enemigo</Boton>
@@ -2929,16 +2932,16 @@ function App() {
   if (userType === 'master' && authenticated && chosenView === 'canvas') {
     return (
       <div className="min-h-screen bg-gray-900 text-gray-100 p-4">
-        <div className="flex items-center justify-between mb-4">
+        <div className="sticky top-0 bg-gray-900 z-10 h-14 flex items-center justify-between mb-4">
           <h1 className="text-2xl font-bold">🗺️ Mapa de Batalla</h1>
           <div className="flex flex-wrap gap-2">
-            <Boton
-              size="sm"
-              onClick={() => setChosenView(null)}
-              className="bg-gray-700 hover:bg-gray-600"
-            >
-              ← Menú Máster
-            </Boton>
+              <Boton
+                size="sm"
+                onClick={() => setChosenView(null)}
+                className="bg-gray-700 hover:bg-gray-600"
+              >
+                ← Menú Máster
+              </Boton>
             <Boton
               size="sm"
               color="red"
@@ -2995,7 +2998,7 @@ function App() {
             onChange={e => setGridOffsetY(parseInt(e.target.value, 10) || 0)}
           />
         </div>
-        <div className="relative">
+        <div className="relative pt-14">
           <div className="h-[80vh] mr-80">
             <MapCanvas
               backgroundImage={canvasBackground || 'https://via.placeholder.com/800x600'}
@@ -3011,7 +3014,7 @@ function App() {
               highlightText={highlightText}
             />
           </div>
-          <AssetSidebar />
+          <AssetSidebar className="top-14" />
         </div>
       </div>
     );

--- a/src/components/AssetSidebar.jsx
+++ b/src/components/AssetSidebar.jsx
@@ -15,7 +15,7 @@ import { useDrag } from 'react-dnd';
 
 export const AssetTypes = { IMAGE: 'asset-image' };
 
-const AssetSidebar = ({ onAssetSelect, onDragStart }) => {
+const AssetSidebar = ({ onAssetSelect, onDragStart, className = '' }) => {
   const [folders, setFolders] = useState(() => [
     { id: nanoid(), name: 'Enemigos', assets: [], folders: [], open: true },
   ]);
@@ -265,7 +265,7 @@ const AssetSidebar = ({ onAssetSelect, onDragStart }) => {
   );
 
   return (
-    <div className="fixed right-0 top-0 h-screen w-[320px] bg-[#1f2937] border-l border-[#2d3748] p-3 flex flex-col overflow-y-auto overscroll-y-contain scrollbar-thin scrollbar-thumb-gray-600 scrollbar-track-transparent">
+    <div className={`fixed right-0 top-0 h-screen w-[320px] bg-[#1f2937] border-l border-[#2d3748] p-3 flex flex-col overflow-y-auto overscroll-y-contain scrollbar-thin scrollbar-thumb-gray-600 scrollbar-track-transparent ${className}`}>
       <div className="mb-3">
         <button
           onClick={addFolder}
@@ -317,6 +317,7 @@ const AssetSidebar = ({ onAssetSelect, onDragStart }) => {
 AssetSidebar.propTypes = {
   onAssetSelect: PropTypes.func,
   onDragStart: PropTypes.func,
+  className: PropTypes.string,
 };
 
 const DraggableAssetItem = ({


### PR DESCRIPTION
## Summary
- reserve 56px for quick-access buttons on the battle map
- offset AssetSidebar and map canvas so nothing overlaps
- document fix in README

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_686bf66b3fac8326a1e0347e8a56475e