### PR TITLE
Add navigation buttons for master tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 
 ### 🎲 **Gestión de Personajes**
 
-> **Versión actual: 2.2.14**
+> **Versión actual: 2.2.54**
 
 **Resumen de cambios v2.1.1:**
 - Rediseño visual de la vista de enemigos como cartas tipo Magic, con layout responsive y efectos visuales exclusivos.
@@ -257,6 +257,10 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 - Nueva dependencia `use-image` para cargar imágenes en el Mapa de Batalla.
 **Resumen de cambios v2.2.53:**
 - Corrige error de compilación por cierre extra de `div` en `App.js`.
+
+**Resumen de cambios v2.2.54:**
+- Nuevo botón para volver al Menú Máster desde Herramientas.
+- Acceso directo a Herramientas en la vista de Fichas de Enemigos.
 
 ### 🛠️ **Características Técnicas**
 - **Interfaz responsive** - Optimizada para móviles y escritorio con TailwindCSS

--- a/src/App.js
+++ b/src/App.js
@@ -2410,6 +2410,7 @@ function App() {
             <h1 className="text-2xl font-bold text-white">👹 Fichas de Enemigos</h1>
             <div className="flex gap-2">
               <Boton color="indigo" onClick={() => setChosenView('canvas')}>Mapa de Batalla</Boton>
+              <Boton color="purple" onClick={() => setChosenView('tools')}>Herramientas</Boton>
               <Boton onClick={() => setChosenView(null)} className="bg-gray-700 hover:bg-gray-600">
                 ← Volver al Menú
               </Boton>
@@ -3025,6 +3026,9 @@ function App() {
         <div className="sticky top-0 bg-gray-900 pb-2 z-10">
           <h1 className="text-2xl font-bold mb-2">Modo Máster</h1>
           <div className="flex flex-wrap gap-2 mb-2">
+            <Boton onClick={() => setChosenView(null)}>
+              ← Menú Máster
+            </Boton>
             <Boton onClick={volverAlMenu}>Volver al menú principal</Boton>
             <Boton onClick={refreshCatalog}>Refrescar catálogo</Boton>
           </div>


### PR DESCRIPTION
## Summary
- allow returning to the Master Menu from Tools
- link to Tools from the Enemies view
- document the new buttons in the changelog

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686c0bcc60c083269f312daee7a7dde5