### PR TITLE
Improve token sheet equipment search

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,9 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 **Resumen de cambios v2.2.56:**
 - Las fichas de token ahora pueden editarse de forma independiente, guardando sus cambios en localStorage.
 
+**Resumen de cambios v2.2.57:**
+- Equipar armas, armaduras y poderes en fichas de token usa el catálogo activo para mostrar todos los datos.
+
 ### 🛠️ **Características Técnicas**
 - **Interfaz responsive** - Optimizada para móviles y escritorio con TailwindCSS
 - **Persistencia en Firebase** - Almacenamiento seguro y sincronización en tiempo real

--- a/src/App.js
+++ b/src/App.js
@@ -3012,6 +3012,9 @@ function App() {
               enemies={enemies}
               onEnemyUpdate={updateEnemyFromToken}
               players={existingPlayers}
+              armas={armas}
+              armaduras={armaduras}
+              habilidades={habilidades}
               highlightText={highlightText}
             />
           </div>

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -291,6 +291,9 @@ const MapCanvas = ({
   enemies = [],
   onEnemyUpdate,
   players = [],
+  armas = [],
+  armaduras = [],
+  habilidades = [],
   highlightText,
 }) => {
   const containerRef = useRef(null);
@@ -666,6 +669,9 @@ const MapCanvas = ({
           key={tk.tokenSheetId}
           token={tokens.find((t) => t.tokenSheetId === tk.tokenSheetId) || tk}
           enemies={enemies}
+          armas={armas}
+          armaduras={armaduras}
+          habilidades={habilidades}
           onClose={() => handleCloseSheet(tk.tokenSheetId)}
           highlightText={highlightText}
         />
@@ -706,6 +712,9 @@ MapCanvas.propTypes = {
   enemies: PropTypes.array,
   onEnemyUpdate: PropTypes.func,
   players: PropTypes.array,
+  armas: PropTypes.array,
+  armaduras: PropTypes.array,
+  habilidades: PropTypes.array,
   highlightText: PropTypes.func,
 };
 

--- a/src/components/TokenSheetModal.jsx
+++ b/src/components/TokenSheetModal.jsx
@@ -3,7 +3,15 @@ import PropTypes from 'prop-types';
 import EnemyViewModal from './EnemyViewModal';
 import TokenSheetEditor from './TokenSheetEditor';
 
-const TokenSheetModal = ({ token, enemies = [], onClose, highlightText }) => {
+const TokenSheetModal = ({
+  token,
+  enemies = [],
+  armas = [],
+  armaduras = [],
+  habilidades = [],
+  onClose,
+  highlightText,
+}) => {
   const sheetId = token?.tokenSheetId;
   const [data, setData] = useState(null);
   const [editing, setEditing] = useState(false);
@@ -49,6 +57,9 @@ const TokenSheetModal = ({ token, enemies = [], onClose, highlightText }) => {
       {editing && (
         <TokenSheetEditor
           sheet={data}
+          armas={armas}
+          armaduras={armaduras}
+          habilidades={habilidades}
           onClose={() => setEditing(false)}
           onSave={handleSave}
         />
@@ -60,6 +71,9 @@ const TokenSheetModal = ({ token, enemies = [], onClose, highlightText }) => {
 TokenSheetModal.propTypes = {
   token: PropTypes.object,
   enemies: PropTypes.array,
+  armas: PropTypes.array,
+  armaduras: PropTypes.array,
+  habilidades: PropTypes.array,
   onClose: PropTypes.func.isRequired,
   highlightText: PropTypes.func,
 };


### PR DESCRIPTION
## Summary
- equip tokens with full item data from catalog
- show suggestions while typing items in token sheet editor
- update MapCanvas and modal props for catalog access
- document new feature in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686c31e84af8832685e27541495558b2