### PR TITLE
Add editable token attributes and fix image cropping

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,10 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 **Resumen de cambios v2.2.57:**
 - Equipar armas, armaduras y poderes en fichas de token usa el catálogo activo para mostrar todos los datos.
 
+**Resumen de cambios v2.2.58:**
+- Ahora las fichas de token permiten editar sus atributos básicos.
+- Las imágenes dentro de las fichas se muestran completas con `object-contain`.
+
 ### 🛠️ **Características Técnicas**
 - **Interfaz responsive** - Optimizada para móviles y escritorio con TailwindCSS
 - **Persistencia en Firebase** - Almacenamiento seguro y sincronización en tiempo real

--- a/src/App.js
+++ b/src/App.js
@@ -2432,7 +2432,7 @@ function App() {
                     <img
                       src={enemy.portrait}
                       alt={enemy.name}
-                      className="w-full h-full object-cover object-center"
+                      className="w-full h-full object-contain object-center"
                       style={{ background: '#222' }}
                     />
                   ) : (
@@ -2535,7 +2535,7 @@ function App() {
                         <img
                           src={newEnemy.portrait}
                           alt="Preview"
-                          className="w-full h-full object-cover object-center rounded-lg shadow border border-gray-800"
+                          className="w-full h-full object-contain object-center rounded-lg shadow border border-gray-800"
                           style={{ background: '#222' }}
                         />
                       </div>

--- a/src/components/EnemySheet.jsx
+++ b/src/components/EnemySheet.jsx
@@ -45,7 +45,7 @@ const EnemySheet = ({ enemy, onClose, onSave }) => {
         <div className="space-y-4">
           {data.portrait && (
             <div className="text-center">
-              <img src={data.portrait} alt={data.name} className="w-32 h-32 object-cover rounded-lg mx-auto border-2 border-gray-600" />
+              <img src={data.portrait} alt={data.name} className="w-32 h-32 object-contain rounded-lg mx-auto border-2 border-gray-600" />
             </div>
           )}
           <div className="grid grid-cols-2 gap-4">

--- a/src/components/EnemyViewModal.jsx
+++ b/src/components/EnemyViewModal.jsx
@@ -92,7 +92,7 @@ const EnemyViewModal = ({ enemy, onClose, onEdit, highlightText = (t) => t, floa
                 <img
                   src={enemy.portrait}
                   alt={enemy.name}
-                  className="w-full h-full object-cover object-center rounded-lg shadow-md border border-gray-800"
+                  className="w-full h-full object-contain object-center rounded-lg shadow-md border border-gray-800"
                   style={{ background: '#222' }}
                 />
               </div>

--- a/src/components/InitiativeTracker.jsx
+++ b/src/components/InitiativeTracker.jsx
@@ -867,7 +867,7 @@ const InitiativeTracker = ({ playerName, isMaster, enemies = [], glossary = [], 
                     <img
                       src={previewEnemy.portrait}
                       alt={previewEnemy.name}
-                      className="w-32 h-32 object-cover rounded-lg mx-auto border-2 border-gray-600"
+                      className="w-32 h-32 object-contain rounded-lg mx-auto border-2 border-gray-600"
                     />
                   </div>
                 )}

--- a/src/components/TokenSheetEditor.jsx
+++ b/src/components/TokenSheetEditor.jsx
@@ -3,6 +3,16 @@ import PropTypes from 'prop-types';
 import { createPortal } from 'react-dom';
 import Input from './Input';
 import Boton from './Boton';
+import AtributoCard from './AtributoCard';
+
+const atributos = ['destreza', 'vigor', 'intelecto', 'voluntad'];
+const atributoColor = {
+  destreza: '#34d399',
+  vigor: '#f87171',
+  intelecto: '#60a5fa',
+  voluntad: '#a78bfa',
+};
+const dadoImgUrl = (d) => `/dados/${d}.png`;
 
 const TokenSheetEditor = ({
   sheet,
@@ -35,6 +45,16 @@ const TokenSheetEditor = ({
           ...prev.stats[stat],
           [field]: parseInt(value, 10) || 0,
         },
+      },
+    }));
+  };
+
+  const updateAtributo = (attr, value) => {
+    setData((prev) => ({
+      ...prev,
+      atributos: {
+        ...prev.atributos,
+        [attr]: value,
       },
     }));
   };
@@ -166,6 +186,23 @@ const TokenSheetEditor = ({
                 className="w-full p-2 bg-gray-700 border border-gray-600 rounded-lg text-white h-16 resize-none"
                 placeholder="Descripción del personaje"
               />
+            </div>
+          )}
+          {data.atributos && (
+            <div>
+              <label className="block text-sm font-medium text-gray-300 mb-2">Atributos</label>
+              <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
+                {atributos.map((attr) => (
+                  <AtributoCard
+                    key={attr}
+                    name={attr}
+                    value={data.atributos[attr] || 'D4'}
+                    color={atributoColor[attr]}
+                    dadoImgUrl={dadoImgUrl}
+                    onChange={(v) => updateAtributo(attr, v)}
+                  />
+                ))}
+              </div>
             </div>
           )}
           {data.stats && (

--- a/src/components/TokenSheetModal.jsx
+++ b/src/components/TokenSheetModal.jsx
@@ -29,7 +29,7 @@ const TokenSheetModal = ({
           sheet.id = sheetId;
         }
       }
-      if (!sheet) sheet = { id: sheetId, name: '', stats: {} };
+      if (!sheet) sheet = { id: sheetId, name: '', stats: {}, atributos: {} };
     }
     setData(sheet);
   }, [sheetId, token, enemies]);


### PR DESCRIPTION
## Summary
- support editing attributes in token sheets
- include default `atributos` when opening a token sheet
- show images with `object-contain` to avoid cropping
- document new feature and image behavior in README

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_686c3554881883268a34bf4875c9af4f