### PR TITLE
Fix token name display

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,9 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 - Ahora las fichas de token permiten editar sus atributos básicos.
 - Las imágenes dentro de las fichas se muestran completas con `object-contain`.
 
+**Resumen de cambios v2.2.59:**
+- El nombre configurado en Ajustes de ficha se muestra al pasar el cursor sobre el token.
+
 ### 🛠️ **Características Técnicas**
 - **Interfaz responsive** - Optimizada para móviles y escritorio con TailwindCSS
 - **Persistencia en Firebase** - Almacenamiento seguro y sincronización en tiempo real

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -27,6 +27,7 @@ const Token = ({
   angle,
   color,
   image,
+  name,
   customName,
   showName,
   gridSize,
@@ -197,9 +198,9 @@ const Token = ({
       ) : (
         <Rect ref={shapeRef} fill={color || 'red'} onTransform={updateHandle} {...common} />
       )}
-      {showName && customName && hover && (
+      {showName && (customName || name) && hover && (
         <Text
-          text={customName}
+          text={customName || name}
           x={(width * gridSize) / 2}
           y={-20}
           offsetX={(width * gridSize) / 2}
@@ -261,6 +262,7 @@ Token.propTypes = {
   draggable: PropTypes.bool,
   listening: PropTypes.bool,
   opacity: PropTypes.number,
+  name: PropTypes.string,
   customName: PropTypes.string,
   showName: PropTypes.bool,
   onClick: PropTypes.func,
@@ -617,6 +619,7 @@ const MapCanvas = ({
                 gridOffsetY={gridOffsetY}
                 image={dragShadow.url}
                 color={dragShadow.color}
+                name={dragShadow.name}
                 selected={false}
                 draggable={false}
                 listening={false}
@@ -637,6 +640,9 @@ const MapCanvas = ({
                 gridOffsetY={gridOffsetY}
                 image={token.url}
                 color={token.color}
+                name={token.name}
+                customName={token.customName}
+                showName={token.showName}
                 selected={token.id === selectedId}
                 onDragEnd={handleDragEnd}
                 onDragStart={handleDragStart}


### PR DESCRIPTION
## Summary
- show token name overlay when hovering if `Nombre` is checked
- document new behaviour in the changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686ccf66a7c08326ae6a02f5f5508a43