### PR TITLE
Token name display below token

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 - **Modo Master y Jugador** - Controles especializados según el rol del usuario
 - **Mapa de Batalla integrado** - VTT sencillo con grid y tokens arrastrables
 - **Fichas de token personalizadas** - Cada token puede tener su propia hoja de personaje
+- **Nombre en tokens** - El nombre del personaje aparece justo debajo del token en negrita con sombra
 - **Mapas personalizados** - Sube una imagen como fondo en el Mapa de Batalla
 - **Grid ajustable** - Tamaño y desplazamiento de la cuadrícula configurables
 - **Mapa adaptable** - La imagen se ajusta al viewport manteniendo su proporción

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -198,13 +198,13 @@ const Token = ({
       ) : (
         <Rect ref={shapeRef} fill={color || 'red'} onTransform={updateHandle} {...common} />
       )}
-      {showName && (customName || name) && hover && (
+      {showName && (customName || name) && (
         <Text
           text={customName || name}
           x={(width * gridSize) / 2}
           y={height * gridSize + 4}
           offsetX={(width * gridSize) / 2}
-          fontSize={12}
+          fontSize={10}
           fontStyle="bold"
           fill="#fff"
           align="center"


### PR DESCRIPTION
## Summary
- show token name without hover
- make token name smaller
- document token name display in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686cd49e575c832699e06b0fa347d540