### PR TITLE
Implement persistent token name rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 - **Modo Master y Jugador** - Controles especializados según el rol del usuario
 - **Mapa de Batalla integrado** - VTT sencillo con grid y tokens arrastrables
 - **Fichas de token personalizadas** - Cada token puede tener su propia hoja de personaje
-- **Nombre en tokens** - El nombre del personaje aparece justo debajo del token en negrita con sombra
+- **Nombre en tokens** - El nombre del personaje aparece justo debajo del token en negrita con contorno negro (text-shadow en cuatro direcciones y leve desenfoque)
 - **Mapas personalizados** - Sube una imagen como fondo en el Mapa de Batalla
 - **Grid ajustable** - Tamaño y desplazamiento de la cuadrícula configurables
 - **Mapa adaptable** - La imagen se ajusta al viewport manteniendo su proporción
@@ -280,7 +280,7 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 - El nombre configurado en Ajustes de ficha se muestra al pasar el cursor sobre el token.
 
 **Resumen de cambios v2.2.60:**
-- El nombre del token aparece debajo de la ficha al pasar el ratón, en negrita y con sombra.
+- El nombre del token se muestra siempre justo debajo y sigue al token en todo momento, en negrita con contorno negro (text-shadow en cuatro direcciones) y leve desenfoque.
 
 ### 🛠️ **Características Técnicas**
 - **Interfaz responsive** - Optimizada para móviles y escritorio con TailwindCSS

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -49,6 +49,8 @@ const Token = ({
   const trRef = useRef();
   const rotateRef = useRef();
   const gearRef = useRef();
+  const textRef = useRef();
+  const textGroupRef = useRef();
   const HANDLE_OFFSET = 12;
   const [hover, setHover] = useState(false);
 
@@ -58,6 +60,8 @@ const Token = ({
     const node = shapeRef.current;
     const handle = rotateRef.current;
     const gear = gearRef.current;
+    const label = textRef.current;
+    const labelGroup = textGroupRef.current;
     if (!node || !handle) return;
     const box = node.getClientRect({ relativeTo: node.getParent() });
     handle.position({
@@ -69,6 +73,10 @@ const Token = ({
         x: box.x - HANDLE_OFFSET,
         y: box.y + box.height + HANDLE_OFFSET,
       });
+    }
+    if (labelGroup && label) {
+      labelGroup.position({ x: box.x + box.width / 2, y: box.y + box.height + 4 });
+      labelGroup.offsetX(label.width() / 2);
     }
     handle.getLayer().batchDraw();
   };
@@ -199,21 +207,44 @@ const Token = ({
         <Rect ref={shapeRef} fill={color || 'red'} onTransform={updateHandle} {...common} />
       )}
       {showName && (customName || name) && (
-        <Text
-          text={customName || name}
-          x={(width * gridSize) / 2}
-          y={height * gridSize + 4}
+        <Group
+          ref={textGroupRef}
+          x={x + (width * gridSize) / 2}
+          y={y + height * gridSize + 4}
           offsetX={(width * gridSize) / 2}
-          fontSize={10}
-          fontStyle="bold"
-          fill="#fff"
-          align="center"
-          shadowColor="#000"
-          shadowBlur={2}
-          shadowOffset={{ x: 1, y: 1 }}
-          shadowOpacity={0.6}
           listening={false}
-        />
+        >
+          {[{ x: 1, y: 1 }, { x: -1, y: 1 }, { x: -1, y: -1 }, { x: 1, y: -1 }].map(
+            (o, i) => (
+              <Text
+                key={i}
+                text={customName || name}
+                x={o.x}
+                y={o.y}
+                fontSize={10}
+                fontStyle="bold"
+                fontFamily="sans-serif"
+                fill="#000"
+                align="center"
+                shadowColor="#000"
+                shadowBlur={1}
+                shadowOpacity={0.9}
+              />
+            )
+          )}
+          <Text
+            ref={textRef}
+            text={customName || name}
+            fontSize={10}
+            fontStyle="bold"
+            fontFamily="sans-serif"
+            fill="#fff"
+            align="center"
+            shadowColor="#000"
+            shadowBlur={1}
+            shadowOpacity={0.8}
+          />
+        </Group>
       )}
       {selected && (
         <>


### PR DESCRIPTION
## Summary
- ensure token name text follows token movement
- update README with new token name behavior
- refine token label style with bold sans-serif font and black text-shadow

## Testing
- `CI=true npm test -- -u`


------
https://chatgpt.com/codex/tasks/task_e_686cd67e8b808326b6a034f4d64e3e1b