### PR TITLE
Implementar nombre y stats en fichas de token

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 
 ### 🎲 **Gestión de Personajes**
 
-> **Versión actual: 2.2.55**
+> **Versión actual: 2.2.61**
 
 **Resumen de cambios v2.1.1:**
 - Rediseño visual de la vista de enemigos como cartas tipo Magic, con layout responsive y efectos visuales exclusivos.
@@ -281,6 +281,9 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 
 **Resumen de cambios v2.2.60:**
 - El nombre del token se muestra siempre justo debajo y sigue al token en todo momento, en negrita con contorno negro (text-shadow en cuatro direcciones) y leve desenfoque.
+
+**Resumen de cambios v2.2.61:**
+- Las fichas de token sin ficha de enemigo usan la imagen del token y permiten editar sus estadísticas. El nombre personalizado se muestra al ver la ficha.
 
 ### 🛠️ **Características Técnicas**
 - **Interfaz responsive** - Optimizada para móviles y escritorio con TailwindCSS

--- a/src/components/TokenSheetModal.jsx
+++ b/src/components/TokenSheetModal.jsx
@@ -31,6 +31,21 @@ const TokenSheetModal = ({
       }
       if (!sheet) sheet = { id: sheetId, name: '', stats: {}, atributos: {} };
     }
+    // Use token info if sheet lacks it
+    sheet = {
+      ...sheet,
+      name: token.customName || sheet.name || token.name || '',
+      portrait: sheet.portrait || token.url,
+    };
+    if (!sheet.stats || Object.keys(sheet.stats).length === 0) {
+      sheet.stats = {
+        postura: { actual: 0, total: 0 },
+        vida: { actual: 0, total: 0 },
+        ingenio: { actual: 0, total: 0 },
+        cordura: { actual: 0, total: 0 },
+        armadura: { actual: 0, total: 0 },
+      };
+    }
     setData(sheet);
   }, [sheetId, token, enemies]);
 


### PR DESCRIPTION
## Summary
- mostrar datos del token al abrir la ficha si no existe en localStorage
- reflejar el nombre personalizado en la ficha
- generar estadísticas por defecto y usar la imagen del token
- actualizar changelog y versión en README

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686ce19ef7088326a4d4ad85e4e52e67