### PR TITLE
Allow editing base stats in token sheets

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,9 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 **Resumen de cambios v2.2.61:**
 - Las fichas de token sin ficha de enemigo usan la imagen del token y permiten editar sus estadísticas. El nombre personalizado se muestra al ver la ficha.
 
+**Resumen de cambios v2.2.62:**
+- Al editar las estadísticas de una ficha de token se puede modificar el valor base y el actual (base a la izquierda, actual a la derecha).
+
 ### 🛠️ **Características Técnicas**
 - **Interfaz responsive** - Optimizada para móviles y escritorio con TailwindCSS
 - **Persistencia en Firebase** - Almacenamiento seguro y sincronización en tiempo real

--- a/src/components/TokenSheetEditor.jsx
+++ b/src/components/TokenSheetEditor.jsx
@@ -37,16 +37,23 @@ const TokenSheetEditor = ({
   if (!sheet || !data) return null;
 
   const updateStat = (stat, field, value) => {
-    setData(prev => ({
-      ...prev,
-      stats: {
-        ...prev.stats,
-        [stat]: {
-          ...prev.stats[stat],
-          [field]: parseInt(value, 10) || 0,
+    setData(prev => {
+      const num = parseInt(value, 10) || 0;
+      const updated = {
+        ...prev.stats[stat],
+        [field]: num,
+      };
+      if (field === 'base' && updated.buff == null) {
+        updated.total = num;
+      }
+      return {
+        ...prev,
+        stats: {
+          ...prev.stats,
+          [stat]: updated,
         },
-      },
-    }));
+      };
+    });
   };
 
   const updateAtributo = (attr, value) => {
@@ -216,16 +223,16 @@ const TokenSheetEditor = ({
                       <div className="flex items-center gap-2">
                         <Input
                           type="number"
-                          value={value.actual || 0}
-                          onChange={e => updateStat(stat, 'actual', e.target.value)}
+                          value={value.base ?? value.total ?? 0}
+                          onChange={e => updateStat(stat, 'base', e.target.value)}
                           className="w-16 h-6 text-center bg-gray-600 border-gray-500 text-white text-xs"
                           min="0"
                         />
                         <span className="text-gray-400 text-xs">/</span>
                         <Input
                           type="number"
-                          value={value.total || 0}
-                          onChange={e => updateStat(stat, 'total', e.target.value)}
+                          value={value.actual || 0}
+                          onChange={e => updateStat(stat, 'actual', e.target.value)}
                           className="w-16 h-6 text-center bg-gray-600 border-gray-500 text-white text-xs"
                           min="0"
                         />

--- a/src/components/TokenSheetModal.jsx
+++ b/src/components/TokenSheetModal.jsx
@@ -39,12 +39,18 @@ const TokenSheetModal = ({
     };
     if (!sheet.stats || Object.keys(sheet.stats).length === 0) {
       sheet.stats = {
-        postura: { actual: 0, total: 0 },
-        vida: { actual: 0, total: 0 },
-        ingenio: { actual: 0, total: 0 },
-        cordura: { actual: 0, total: 0 },
-        armadura: { actual: 0, total: 0 },
+        postura: { base: 0, actual: 0, total: 0 },
+        vida: { base: 0, actual: 0, total: 0 },
+        ingenio: { base: 0, actual: 0, total: 0 },
+        cordura: { base: 0, actual: 0, total: 0 },
+        armadura: { base: 0, actual: 0, total: 0 },
       };
+    } else {
+      Object.keys(sheet.stats).forEach((k) => {
+        const st = sheet.stats[k] || {};
+        if (st.base === undefined) st.base = st.total ?? 0;
+        if (st.total === undefined) st.total = st.base;
+      });
     }
     setData(sheet);
   }, [sheetId, token, enemies]);


### PR DESCRIPTION
## Summary
- support editing the base value for token stats
- default token sheet stats now include a base field
- document the new behaviour in the README

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686ce54af95c8326862d8215f45ac932