### PR TITLE
Add token stat capsules

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 - **Mapa de Batalla integrado** - VTT sencillo con grid y tokens arrastrables
 - **Fichas de token personalizadas** - Cada token puede tener su propia hoja de personaje
 - **Nombre en tokens** - El nombre del personaje aparece justo debajo del token en negrita con contorno negro (text-shadow en cuatro direcciones y leve desenfoque)
+- **Mini-barras en tokens** - Cada stat importante se muestra sobre el token mediante cápsulas interactivas
 - **Mapas personalizados** - Sube una imagen como fondo en el Mapa de Batalla
 - **Grid ajustable** - Tamaño y desplazamiento de la cuadrícula configurables
 - **Mapa adaptable** - La imagen se ajusta al viewport manteniendo su proporción

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -17,6 +17,7 @@ import { AssetTypes } from './AssetSidebar';
 import TokenSettings from './TokenSettings';
 import TokenSheetModal from './TokenSheetModal';
 import { nanoid } from 'nanoid';
+import { getResourceColors } from './ResourceBar';
 
 const Token = ({
   id,
@@ -43,6 +44,7 @@ const Token = ({
   onTransformEnd,
   onRotate,
   onSettings,
+  tokenSheetId,
 }) => {
   const [img] = useImage(image);
   const shapeRef = useRef();
@@ -53,8 +55,28 @@ const Token = ({
   const textGroupRef = useRef();
   const HANDLE_OFFSET = 12;
   const [hover, setHover] = useState(false);
+  const [stats, setStats] = useState({});
 
   const SNAP = gridSize / 4;
+
+  useEffect(() => {
+    if (!tokenSheetId) return;
+    const load = () => {
+      const stored = localStorage.getItem('tokenSheets');
+      if (!stored) return;
+      const sheets = JSON.parse(stored);
+      const sheet = sheets[tokenSheetId];
+      if (sheet && sheet.stats) setStats(sheet.stats);
+    };
+    load();
+    const handler = e => {
+      if (e.detail && e.detail.id === tokenSheetId) {
+        setStats(e.detail.stats || {});
+      }
+    };
+    window.addEventListener('tokenSheetSaved', handler);
+    return () => window.removeEventListener('tokenSheetSaved', handler);
+  }, [tokenSheetId]);
 
   const updateHandle = () => {
     const node = shapeRef.current;
@@ -174,6 +196,37 @@ const Token = ({
     onRotate(id, shapeRef.current.rotation());
   };
 
+  const handleStatClick = (statKey, e) => {
+    if (!draggable) return;
+    e.cancelBubble = true;
+    setStats(prev => {
+      const current = prev[statKey] || {};
+      const max = current.total ?? current.base ?? current.actual ?? 0;
+      const delta = e.evt.shiftKey ? -1 : 1;
+      const next = {
+        ...current,
+        actual: Math.max(0, Math.min(max, (current.actual || 0) + delta)),
+      };
+      const updated = { ...prev, [statKey]: next };
+      if (tokenSheetId) {
+        const stored = localStorage.getItem('tokenSheets');
+        if (stored) {
+          const sheets = JSON.parse(stored);
+          const sheet = sheets[tokenSheetId];
+          if (sheet && sheet.stats) {
+            sheet.stats = updated;
+            sheets[tokenSheetId] = sheet;
+            localStorage.setItem('tokenSheets', JSON.stringify(sheets));
+            window.dispatchEvent(
+              new CustomEvent('tokenSheetSaved', { detail: { id: tokenSheetId, stats: updated } })
+            );
+          }
+        }
+      }
+      return updated;
+    });
+  };
+
   const offX = (width * gridSize) / 2;
   const offY = (height * gridSize) / 2;
 
@@ -246,6 +299,31 @@ const Token = ({
           />
         </Group>
       )}
+      {Object.entries(stats)
+        .filter(([, v]) => v && v.showOnToken)
+        .map(([key, v], idx) => {
+          const max = v.total ?? v.base ?? 0;
+          const current = Math.min(v.actual ?? 0, max);
+          const colors = getResourceColors({ color: v.color || '#ffffff', penalizacion: 0, actual: current, base: 0, buff: 0, max });
+          const rowWidth = max * 12 + (max - 1) * 2;
+          const yPos = -height * gridSize / 2 - (idx + 1) * (6 + 4);
+          return (
+            <Group key={key} x={x + (width * gridSize) / 2 - rowWidth / 2} y={y + yPos} listening={true}>
+              {colors.map((c, i) => (
+                <Rect
+                  key={i}
+                  x={i * (12 + 2)}
+                  width={12}
+                  height={6}
+                  fill={c}
+                  stroke="#1f2937"
+                  cornerRadius={3}
+                  onClick={(e) => handleStatClick(key, e)}
+                />
+              ))}
+            </Group>
+          );
+        })}
       {selected && (
         <>
           <Transformer
@@ -307,6 +385,7 @@ Token.propTypes = {
   onTransformEnd: PropTypes.func.isRequired,
   onRotate: PropTypes.func.isRequired,
   onSettings: PropTypes.func,
+  tokenSheetId: PropTypes.string,
 };
 
 /**
@@ -679,6 +758,7 @@ const MapCanvas = ({
                 name={token.name}
                 customName={token.customName}
                 showName={token.showName}
+                tokenSheetId={token.tokenSheetId}
                 selected={token.id === selectedId}
                 onDragEnd={handleDragEnd}
                 onDragStart={handleDragStart}

--- a/src/components/ResourceBar.jsx
+++ b/src/components/ResourceBar.jsx
@@ -1,7 +1,20 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const DEFAULT_MAX = 20;
+export const DEFAULT_MAX = 20;
+
+export function getResourceColors({ color, penalizacion = 0, actual = 0, base = 0, buff = 0, max = DEFAULT_MAX }) {
+  const baseEfectiva = Math.max(0, base - penalizacion);
+  const buffLimit = Math.min(buff, max - baseEfectiva);
+
+  return Array.from({ length: max }, (_, i) => {
+    if (i < penalizacion) return '#f87171aa';
+    if (i < penalizacion + actual) return color;
+    if (i < penalizacion + baseEfectiva) return color + '55';
+    if (i < penalizacion + baseEfectiva + buffLimit) return '#facc15';
+    return 'transparent';
+  });
+}
 
 const ResourceBar = ({
   color,
@@ -11,16 +24,7 @@ const ResourceBar = ({
   buff = 0,
   max = DEFAULT_MAX,
 }) => {
-  const baseEfectiva = Math.max(0, base - penalizacion);
-  const buffLimit = Math.min(buff, max - baseEfectiva);
-
-  const circles = Array.from({ length: max }, (_, i) => {
-    if (i < penalizacion) return '#f87171aa';
-    if (i < penalizacion + actual) return color;
-    if (i < penalizacion + baseEfectiva) return color + '55';
-    if (i < penalizacion + baseEfectiva + buffLimit) return '#facc15';
-    return 'transparent';
-  });
+  const circles = getResourceColors({ color, penalizacion, actual, base, buff, max });
 
   return (
     <div

--- a/src/components/TokenSheetEditor.jsx
+++ b/src/components/TokenSheetEditor.jsx
@@ -38,13 +38,17 @@ const TokenSheetEditor = ({
 
   const updateStat = (stat, field, value) => {
     setData(prev => {
-      const num = parseInt(value, 10) || 0;
-      const updated = {
-        ...prev.stats[stat],
-        [field]: num,
-      };
-      if (field === 'base' && updated.buff == null) {
-        updated.total = num;
+      const updated = { ...prev.stats[stat] };
+      if (field === 'showOnToken') {
+        updated.showOnToken = value;
+      } else if (field === 'color') {
+        updated.color = value;
+      } else {
+        const num = parseInt(value, 10) || 0;
+        updated[field] = num;
+        if (field === 'base' && updated.buff == null) {
+          updated.total = num;
+        }
       }
       return {
         ...prev,
@@ -237,6 +241,22 @@ const TokenSheetEditor = ({
                           min="0"
                         />
                       </div>
+                    </div>
+                    <div className="flex items-center justify-between text-xs">
+                      <label className="flex items-center gap-1">
+                        <input
+                          type="checkbox"
+                          checked={value.showOnToken ?? true}
+                          onChange={e => updateStat(stat, 'showOnToken', e.target.checked)}
+                        />
+                        Mostrar en token
+                      </label>
+                      <input
+                        type="color"
+                        value={value.color || '#ffffff'}
+                        onChange={e => updateStat(stat, 'color', e.target.value)}
+                        className="w-8 h-5 p-0 border-none bg-transparent"
+                      />
                     </div>
                   </div>
                 ))}

--- a/src/components/TokenSheetModal.jsx
+++ b/src/components/TokenSheetModal.jsx
@@ -3,6 +3,14 @@ import PropTypes from 'prop-types';
 import EnemyViewModal from './EnemyViewModal';
 import TokenSheetEditor from './TokenSheetEditor';
 
+const recursoColor = {
+  postura: '#34d399',
+  vida: '#f87171',
+  ingenio: '#60a5fa',
+  cordura: '#a78bfa',
+  armadura: '#9ca3af',
+};
+
 const TokenSheetModal = ({
   token,
   enemies = [],
@@ -39,17 +47,22 @@ const TokenSheetModal = ({
     };
     if (!sheet.stats || Object.keys(sheet.stats).length === 0) {
       sheet.stats = {
-        postura: { base: 0, actual: 0, total: 0 },
-        vida: { base: 0, actual: 0, total: 0 },
-        ingenio: { base: 0, actual: 0, total: 0 },
-        cordura: { base: 0, actual: 0, total: 0 },
-        armadura: { base: 0, actual: 0, total: 0 },
+        postura: { base: 0, actual: 0, total: 0, color: recursoColor.postura, showOnToken: true },
+        vida: { base: 0, actual: 0, total: 0, color: recursoColor.vida, showOnToken: true },
+        ingenio: { base: 0, actual: 0, total: 0, color: recursoColor.ingenio, showOnToken: true },
+        cordura: { base: 0, actual: 0, total: 0, color: recursoColor.cordura, showOnToken: true },
+        armadura: { base: 0, actual: 0, total: 0, color: recursoColor.armadura, showOnToken: true },
       };
     } else {
-      Object.keys(sheet.stats).forEach((k) => {
+      Object.keys(sheet.stats).forEach((k, index) => {
         const st = sheet.stats[k] || {};
         if (st.base === undefined) st.base = st.total ?? 0;
         if (st.total === undefined) st.total = st.base;
+        if (st.color === undefined) st.color = recursoColor[k] || '#ffffff';
+        if (st.showOnToken === undefined) {
+          st.showOnToken = index < 5 ? true : !!(st.base || st.total || st.actual || st.buff);
+        }
+        sheet.stats[k] = st;
       });
     }
     setData(sheet);
@@ -62,6 +75,7 @@ const TokenSheetModal = ({
     localStorage.setItem('tokenSheets', JSON.stringify(sheets));
     setData(updated);
     setEditing(false);
+    window.dispatchEvent(new CustomEvent('tokenSheetSaved', { detail: updated }));
   };
 
   if (!token || !data) return null;


### PR DESCRIPTION
## Summary
- expose `getResourceColors` helper
- let token sheets define `color` and `showOnToken`
- make stats editable with color and token flag
- render mini capsule rows on tokens
- document token mini-bars in README

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686cea621ee48326a33464446b9d7ac6