### PR TITLE
Scale token tools with grid

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 - **Fichas de token personalizadas** - Cada token puede tener su propia hoja de personaje
 - **Nombre en tokens** - El nombre del personaje aparece justo debajo del token en negrita con contorno negro (text-shadow en cuatro direcciones y leve desenfoque)
 - **Mini-barras en tokens** - Cada stat se muestra sobre el token mediante cápsulas interactivas y puedes elegir su posición
+- **Iconos de control proporcionales** - Engranaje, círculo de rotación y barras se escalan según el tamaño de la celda
 - **Mapas personalizados** - Sube una imagen como fondo en el Mapa de Batalla
 - **Grid ajustable** - Tamaño y desplazamiento de la cuadrícula configurables
 - **Mapa adaptable** - La imagen se ajusta al viewport manteniendo su proporción

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -54,6 +54,10 @@ const Token = ({
   const textRef = useRef();
   const textGroupRef = useRef();
   const HANDLE_OFFSET = 12;
+  const iconSize = gridSize * 0.15;
+  const barHeight = gridSize * 0.25;
+  const capsuleW = barHeight * 2;
+  const capsuleGap = gridSize * 0.02;
   const [hover, setHover] = useState(false);
   const [stats, setStats] = useState({});
 
@@ -102,6 +106,22 @@ const Token = ({
     }
     handle.getLayer().batchDraw();
   };
+
+  const updateSizes = () => {
+    if (rotateRef.current) {
+      rotateRef.current.radius(iconSize / 2);
+    }
+    if (gearRef.current) {
+      gearRef.current.fontSize(iconSize);
+      gearRef.current.width(iconSize);
+      gearRef.current.height(iconSize);
+    }
+  };
+
+  useEffect(() => {
+    updateSizes();
+    if (selected) updateHandle();
+  }, [gridSize, selected]);
   useEffect(() => {
     if (selected && trRef.current && shapeRef.current) {
       trRef.current.nodes([shapeRef.current]);
@@ -310,8 +330,8 @@ const Token = ({
           const max = v.total ?? v.base ?? 0;
           const current = Math.min(v.actual ?? 0, max);
           const colors = getResourceColors({ color: v.color || '#ffffff', penalizacion: 0, actual: current, base: 0, buff: 0, max });
-          const rowWidth = max * 12 + (max - 1) * 2;
-          const baseOffset = gridSize / 4 + rowIdx * (6 + 4);
+          const rowWidth = max * capsuleW + (max - 1) * capsuleGap;
+          const baseOffset = gridSize / 4 + rowIdx * (barHeight + gridSize * 0.04);
           const yPos = anchor === 'top'
             ? -height * gridSize / 2 - baseOffset
             : height * gridSize / 2 + baseOffset;
@@ -320,12 +340,12 @@ const Token = ({
               {colors.map((c, i) => (
                 <Rect
                   key={i}
-                  x={i * (12 + 2)}
-                  width={12}
-                  height={6}
+                  x={i * (capsuleW + capsuleGap)}
+                  width={capsuleW}
+                  height={barHeight}
                   fill={c}
                   stroke="#1f2937"
-                  cornerRadius={3}
+                  cornerRadius={barHeight / 2}
                   onClick={(e) => handleStatClick(key, e)}
                 />
               ))}
@@ -354,7 +374,7 @@ const Token = ({
             ref={rotateRef}
             x={width * gridSize}
             y={-12}
-            radius={6}
+            radius={iconSize / 2}
             fill="#fff"
             stroke="#000"
             strokeWidth={1}
@@ -365,7 +385,7 @@ const Token = ({
           <Text
             ref={gearRef}
             text="⚙️"
-            fontSize={24}
+            fontSize={iconSize}
             listening
             onClick={() => onSettings?.(id)}
           />


### PR DESCRIPTION
## Summary
- adjust token handle, gear and stat bar sizes based on the current grid
- keep gear icon and rotation handle proportional
- describe the new behaviour in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686d0659c75083269fdecd259a6c6210