### PR TITLE
Improve token bars and double-click settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 - **Nombre en tokens** - El nombre del personaje aparece justo debajo del token en negrita con contorno negro (text-shadow en cuatro direcciones y leve desenfoque)
 - **Nombre escalable** - La fuente del nombre aumenta si el token ocupa varias casillas
 - **Mini-barras en tokens** - Cada stat se muestra sobre el token mediante cápsulas interactivas y puedes elegir su posición
+- **Barras compactas** - Las barras de recursos son más pequeñas y están más cerca del token
+- **Ajustes al hacer doble clic** - Haz doble clic en un token para abrir su menú de configuración
 - **Iconos de control de tamaño fijo** - Engranaje, círculo de rotación y barras mantienen un tamaño constante al hacer zoom
 - **Mapas personalizados** - Sube una imagen como fondo en el Mapa de Batalla
 - **Grid ajustable** - Tamaño y desplazamiento de la cuadrícula configurables

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -56,9 +56,9 @@ const Token = ({
   const textGroupRef = useRef();
   const HANDLE_OFFSET = 12;
   const iconSize = cellSize * 0.15;
-  const barHeight = cellSize * 0.2;
+  const barHeight = cellSize * 0.15;
   const capsuleW = barHeight * 2;
-  const capsuleGap = cellSize * 0.05;
+  const capsuleGap = cellSize * 0.04;
   const nameFontSize = Math.max(10, cellSize * 0.12 * Math.min(Math.max(width, height), 2));
   const [hover, setHover] = useState(false);
   const [stats, setStats] = useState({});
@@ -273,7 +273,11 @@ const Token = ({
   };
 
   return (
-    <Group onMouseEnter={() => setHover(true)} onMouseLeave={() => setHover(false)}>
+    <Group
+      onMouseEnter={() => setHover(true)}
+      onMouseLeave={() => setHover(false)}
+      onDblClick={() => onSettings?.(id)}
+    >
       {img ? (
         <KonvaImage ref={shapeRef} image={img} onTransform={updateHandle} {...common} />
       ) : (
@@ -331,7 +335,7 @@ const Token = ({
           const current = Math.min(v.actual ?? 0, max);
           const colors = getResourceColors({ color: v.color || '#ffffff', penalizacion: 0, actual: current, base: 0, buff: 0, max });
           const rowWidth = max * capsuleW + (max - 1) * capsuleGap;
-          const baseOffset = cellSize * 0.2 + rowIdx * (barHeight + cellSize * 0.05);
+          const baseOffset = 4 + rowIdx * (barHeight + 2);
           const yPos = anchor === 'top'
             ? -height * gridSize / 2 - baseOffset
             : height * gridSize / 2 + baseOffset;
@@ -345,6 +349,7 @@ const Token = ({
                   height={barHeight}
                   fill={c}
                   stroke="#1f2937"
+                  strokeScaleEnabled={false}
                   cornerRadius={barHeight / 2}
                   onClick={(e) => handleStatClick(key, e)}
                 />


### PR DESCRIPTION
## Summary
- shrink token resource bars and position them closer to tokens
- preserve bar borders on large maps
- open token settings on double-click
- document new features in README

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686d5abef6808326ae640737a0ece608