### PR TITLE
Fix token bars border

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,13 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 - La escala del mapa se calcula correctamente cuando no hay imagen de fondo.
 - Las barras de recurso se muestran más cerca del token.
 
+**Resumen de cambios v2.2.64:**
+- Las mini-barras de los tokens vuelven a mostrar un borde oscuro para que el diseño no sea tan plano.
+- El borde se hace un poco más grueso para que sea visible con cualquier zoom.
+
+**Resumen de cambios v2.2.65:**
+- Se aumenta considerablemente el grosor del borde de las mini-barras para darles más presencia.
+
 ### 🛠️ **Características Técnicas**
 - **Interfaz responsive** - Optimizada para móviles y escritorio con TailwindCSS
 - **Persistencia en Firebase** - Almacenamiento seguro y sincronización en tiempo real

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -349,6 +349,7 @@ const Token = ({
                   height={barHeight}
                   fill={c}
                   stroke="#1f2937"
+                  strokeWidth={6}
                   strokeScaleEnabled={false}
                   cornerRadius={barHeight / 2}
                   onClick={(e) => handleStatClick(key, e)}


### PR DESCRIPTION
## Summary
- keep token bars thicker so the border is visible
- document visual update in README

## Testing
- `npm test -- -w=0`


------
https://chatgpt.com/codex/tasks/task_e_686d5d91efc083268d4a985001d0c9fd