### PR TITLE
Increase token bar offset

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 
 ### 🎲 **Gestión de Personajes**
 
-> **Versión actual: 2.2.61**
+> **Versión actual: 2.2.71**
 
 **Resumen de cambios v2.1.1:**
 - Rediseño visual de la vista de enemigos como cartas tipo Magic, con layout responsive y efectos visuales exclusivos.
@@ -316,6 +316,12 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 
 **Resumen de cambios v2.2.69:**
 - Las mini-barras se dibujan en una capa fija y conservan su tamaño en píxeles aunque hagas zoom.
+
+**Resumen de cambios v2.2.70:**
+- Las barras de recurso se separan un poco del token.
+
+**Resumen de cambios v2.2.71:**
+- Se incrementa la distancia de las barras a 20 píxeles.
 
 ### 🛠️ **Características Técnicas**
 - **Interfaz responsive** - Optimizada para móviles y escritorio con TailwindCSS

--- a/src/components/TokenBars.jsx
+++ b/src/components/TokenBars.jsx
@@ -25,7 +25,7 @@ const TokenBars = ({ tokenRef, stageRef, onStatClick, transformKey }) => {
     const current = Math.min(v.actual ?? 0, max);
     const colors = getResourceColors({ color: v.color || '#ffffff', penalizacion: 0, actual: current, base: 0, buff: 0, max });
     const rowWidth = max * CAPSULE_W + (max - 1) * GAP;
-    const baseOffset = 4 + rowIdx * (BAR_HEIGHT + 2);
+    const baseOffset = 20 + rowIdx * (BAR_HEIGHT + 2);
     const yPos = anchor === 'top' ? layout.top - baseOffset : layout.bottom + baseOffset;
     return (
       <Group key={key} x={layout.x - rowWidth / 2} y={yPos} listening>


### PR DESCRIPTION
## Summary
- bump token bar separation to 20 pixels
- document version 2.2.71 and change

## Testing
- `npm install`
- `CI=true npm test -- -u`


------
https://chatgpt.com/codex/tasks/task_e_686d7926b2808326ad20d1c633c6795f