### PR TITLE
Show token bars on hover

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,9 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 **Resumen de cambios v2.2.71:**
 - Se incrementa la distancia de las barras a 20 píxeles.
 
+**Resumen de cambios v2.2.72:**
+- Las mini-barras de los tokens se muestran solo al pasar el cursor sobre el token.
+
 ### 🛠️ **Características Técnicas**
 - **Interfaz responsive** - Optimizada para móviles y escritorio con TailwindCSS
 - **Persistencia en Firebase** - Almacenamiento seguro y sincronización en tiempo real

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -48,6 +48,7 @@ const Token = forwardRef(({
   onTransformEnd,
   onRotate,
   onSettings,
+  onHoverChange,
   tokenSheetId,
 }, ref) => {
   const [img] = useImage(image);
@@ -61,7 +62,6 @@ const Token = forwardRef(({
   const HANDLE_OFFSET = 12;
   const iconSize = cellSize * 0.15;
   const nameFontSize = Math.max(10, cellSize * 0.12 * Math.min(Math.max(width, height), 2));
-  const [hover, setHover] = useState(false);
   const [stats, setStats] = useState({});
 
   const SNAP = gridSize / 4;
@@ -282,8 +282,8 @@ const Token = forwardRef(({
   return (
     <Group
       ref={groupRef}
-      onMouseEnter={() => setHover(true)}
-      onMouseLeave={() => setHover(false)}
+      onMouseEnter={() => onHoverChange?.(true)}
+      onMouseLeave={() => onHoverChange?.(false)}
       onDblClick={() => onSettings?.(id)}
     >
       {img ? (
@@ -396,6 +396,7 @@ Token.propTypes = {
   onTransformEnd: PropTypes.func.isRequired,
   onRotate: PropTypes.func.isRequired,
   onSettings: PropTypes.func,
+  onHoverChange: PropTypes.func,
   tokenSheetId: PropTypes.string,
 };
 
@@ -433,6 +434,7 @@ const MapCanvas = ({
   const [groupPos, setGroupPos] = useState({ x: 0, y: 0 });
   const [isPanning, setIsPanning] = useState(false);
   const [selectedId, setSelectedId] = useState(null);
+  const [hoveredId, setHoveredId] = useState(null);
   const [dragShadow, setDragShadow] = useState(null);
   const [settingsTokenIds, setSettingsTokenIds] = useState([]);
   const [openSheetTokens, setOpenSheetTokens] = useState([]);
@@ -790,6 +792,7 @@ const MapCanvas = ({
                 onSettings={handleOpenSettings}
                 onTransformEnd={handleSizeChange}
                 onRotate={handleRotateChange}
+                onHoverChange={(h) => setHoveredId(h ? token.id : null)}
               />
             ))}
           </Group>
@@ -802,6 +805,7 @@ const MapCanvas = ({
               stageRef={stageRef}
               onStatClick={(key, e) => tokenRefs.current[token.id]?.handleStatClick(key, e)}
               transformKey={`${groupPos.x},${groupPos.y},${groupScale},${token.x},${token.y},${token.w},${token.h},${token.angle}`}
+              visible={hoveredId === token.id}
             />
           ))}
         </Layer>

--- a/src/components/TokenBars.jsx
+++ b/src/components/TokenBars.jsx
@@ -7,7 +7,13 @@ const CAPSULE_W = 18;
 const BAR_HEIGHT = 8;
 const GAP = 2;
 
-const TokenBars = ({ tokenRef, stageRef, onStatClick, transformKey }) => {
+const TokenBars = ({
+  tokenRef,
+  stageRef,
+  onStatClick,
+  transformKey,
+  visible = true,
+}) => {
   const [layout, setLayout] = useState({ x: 0, top: 0, bottom: 0 });
   const [stats, setStats] = useState({});
 
@@ -54,6 +60,8 @@ const TokenBars = ({ tokenRef, stageRef, onStatClick, transformKey }) => {
     .filter(([, v]) => v && v.showOnToken && (v.tokenAnchor ?? 'top') === 'bottom')
     .sort((a, b) => (a[1].tokenRow ?? 0) - (b[1].tokenRow ?? 0));
 
+  if (!visible) return null;
+
   return (
     <>
       {topStats.map((entry, i) => renderRow(entry, i, 'top'))}
@@ -67,6 +75,7 @@ TokenBars.propTypes = {
   stageRef: PropTypes.shape({ current: PropTypes.any }).isRequired,
   onStatClick: PropTypes.func.isRequired,
   transformKey: PropTypes.string,
+  visible: PropTypes.bool,
 };
 
 export default TokenBars;


### PR DESCRIPTION
## Summary
- hide TokenBars unless their token is hovered
- track hovered token in MapCanvas and control TokenBars visibility
- document hover bars behaviour in README

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686da11ceab88326870b9d5842b59d00