### PR TITLE
Add token bar visibility options

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,9 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 **Resumen de cambios v2.2.72:**
 - Las mini-barras de los tokens se muestran solo al pasar el cursor sobre el token.
 
+**Resumen de cambios v2.2.73:**
+- Se puede elegir la visibilidad de las barras del token: para todos, solo para su controlador o nadie.
+
 ### 🛠️ **Características Técnicas**
 - **Interfaz responsive** - Optimizada para móviles y escritorio con TailwindCSS
 - **Persistencia en Firebase** - Almacenamiento seguro y sincronización en tiempo real

--- a/src/App.js
+++ b/src/App.js
@@ -3016,6 +3016,8 @@ function App() {
               armaduras={armaduras}
               habilidades={habilidades}
               highlightText={highlightText}
+              userType={userType}
+              playerName={playerName}
             />
           </div>
           <AssetSidebar className="top-14" />

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -424,6 +424,8 @@ const MapCanvas = ({
   armaduras = [],
   habilidades = [],
   highlightText,
+  userType = 'master',
+  playerName = '',
 }) => {
   const containerRef = useRef(null);
   const stageRef = useRef(null);
@@ -442,6 +444,16 @@ const MapCanvas = ({
   const panStart = useRef({ x: 0, y: 0 });
   const panOrigin = useRef({ x: 0, y: 0 });
   const [bg] = useImage(backgroundImage, 'anonymous');
+
+  const canSeeBars = useCallback((tk) => {
+    if (!tk.barsVisibility || tk.barsVisibility === 'all') return true;
+    if (tk.barsVisibility === 'none') return false;
+    if (tk.barsVisibility === 'controlled') {
+      if (userType === 'master') return true;
+      return tk.controlledBy === playerName;
+    }
+    return true;
+  }, [playerName, userType]);
 
   // Si se especifica el número de casillas, calculamos el tamaño de cada celda
   const effectiveGridSize = imageSize.width && gridCells ? imageSize.width / gridCells : gridSize;
@@ -702,6 +714,7 @@ const MapCanvas = ({
           customName: '',
           showName: false,
           controlledBy: 'master',
+          barsVisibility: 'all',
         };
         onTokensChange([...tokens, newToken]);
       },
@@ -805,7 +818,7 @@ const MapCanvas = ({
               stageRef={stageRef}
               onStatClick={(key, e) => tokenRefs.current[token.id]?.handleStatClick(key, e)}
               transformKey={`${groupPos.x},${groupPos.y},${groupScale},${token.x},${token.y},${token.w},${token.h},${token.angle}`}
-              visible={hoveredId === token.id}
+              visible={hoveredId === token.id && canSeeBars(token)}
             />
           ))}
         </Layer>
@@ -864,6 +877,7 @@ MapCanvas.propTypes = {
       customName: PropTypes.string,
       showName: PropTypes.bool,
       controlledBy: PropTypes.string,
+      barsVisibility: PropTypes.oneOf(['all', 'controlled', 'none']),
       w: PropTypes.number,
       h: PropTypes.number,
       angle: PropTypes.number,
@@ -877,6 +891,8 @@ MapCanvas.propTypes = {
   armaduras: PropTypes.array,
   habilidades: PropTypes.array,
   highlightText: PropTypes.func,
+  userType: PropTypes.oneOf(['master', 'player']),
+  playerName: PropTypes.string,
 };
 
 export default MapCanvas;

--- a/src/components/TokenSettings.jsx
+++ b/src/components/TokenSettings.jsx
@@ -34,6 +34,7 @@ const TokenSettings = ({ token, enemies = [], players = [], onClose, onUpdate, o
   const [name, setName] = useState(token.customName || '');
   const [showName, setShowName] = useState(token.showName || false);
   const [controlledBy, setControlledBy] = useState(token.controlledBy || 'master');
+  const [barsVisibility, setBarsVisibility] = useState(token.barsVisibility || 'all');
 
   const applyChanges = () => {
     const enemy = enemies.find((e) => e.id === enemyId);
@@ -45,6 +46,7 @@ const TokenSettings = ({ token, enemies = [], players = [], onClose, onUpdate, o
       customName: showName ? name : '',
       showName,
       controlledBy,
+      barsVisibility,
     });
   };
 
@@ -90,19 +92,28 @@ const TokenSettings = ({ token, enemies = [], players = [], onClose, onUpdate, o
                   ))}
                 </select>
               </div>
+              <div>
+                <label className="block mb-1">Barras visibles para</label>
+                <select value={barsVisibility} onChange={e => setBarsVisibility(e.target.value)} className="w-full bg-gray-700 text-white">
+                  <option value="all">Todos</option>
+                  <option value="controlled">Controlador</option>
+                  <option value="none">Nadie</option>
+                </select>
+              </div>
               <div className="text-center">
                 <Boton
                   onClick={() => {
                     const enemy = enemies.find((e) => e.id === enemyId);
-                    const updated = {
-                      ...token,
-                      enemyId: enemyId || null,
-                      url: enemyId ? enemy?.portrait || token.url : token.url,
-                      name: enemyId ? enemy?.name : token.name,
-                      customName: showName ? name : '',
-                      showName,
-                      controlledBy,
-                    };
+      const updated = {
+        ...token,
+        enemyId: enemyId || null,
+        url: enemyId ? enemy?.portrait || token.url : token.url,
+        name: enemyId ? enemy?.name : token.name,
+        customName: showName ? name : '',
+        showName,
+        controlledBy,
+        barsVisibility,
+      };
                     onUpdate(updated);
                     onOpenSheet(updated);
                   }}


### PR DESCRIPTION
## Summary
- add token bar visibility dropdown in token settings
- store chosen visibility in token data
- show token bars based on visibility rules
- document feature in README

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_686da2f0c79083269b9ae3922ca1ce9f