### PR TITLE
Add token aura option

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 
 ### 🎲 **Gestión de Personajes**
 
-> **Versión actual: 2.2.71**
+> **Versión actual: 2.2.74**
 
 **Resumen de cambios v2.1.1:**
 - Rediseño visual de la vista de enemigos como cartas tipo Magic, con layout responsive y efectos visuales exclusivos.
@@ -331,6 +331,9 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 
 **Resumen de cambios v2.2.73:**
 - Se puede elegir la visibilidad de las barras del token: para todos, solo para su controlador o nadie.
+
+**Resumen de cambios v2.2.74:**
+- Nueva opción **Aura** en Ajustes de ficha para mostrar un área alrededor del token.
 
 ### 🛠️ **Características Técnicas**
 - **Interfaz responsive** - Optimizada para móviles y escritorio con TailwindCSS

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -19,7 +19,7 @@ import TokenSheetModal from './TokenSheetModal';
 import { nanoid } from 'nanoid';
 import TokenBars from './TokenBars';
 
-const Token = forwardRef(({
+  const Token = forwardRef(({
   id,
   x,
   y,
@@ -50,6 +50,9 @@ const Token = forwardRef(({
   onSettings,
   onHoverChange,
   tokenSheetId,
+  auraRadius = 0,
+  auraShape = 'circle',
+  auraColor = '#ffff0088',
 }, ref) => {
   const [img] = useImage(image);
   const groupRef = useRef();
@@ -286,6 +289,28 @@ const Token = forwardRef(({
       onMouseLeave={() => onHoverChange?.(false)}
       onDblClick={() => onSettings?.(id)}
     >
+      {auraRadius > 0 && (
+        auraShape === 'circle' ? (
+          <Circle
+            x={x + offX}
+            y={y + offY}
+            radius={(Math.max(width, height) / 2 + auraRadius) * gridSize}
+            fill={auraColor}
+            listening={false}
+          />
+        ) : (
+          <Rect
+            x={x + offX}
+            y={y + offY}
+            width={(width + auraRadius * 2) * gridSize}
+            height={(height + auraRadius * 2) * gridSize}
+            offsetX={((width + auraRadius * 2) * gridSize) / 2}
+            offsetY={((height + auraRadius * 2) * gridSize) / 2}
+            fill={auraColor}
+            listening={false}
+          />
+        )
+      )}
       {img ? (
         <KonvaImage ref={shapeRef} image={img} onTransform={updateHandle} {...common} />
       ) : (
@@ -390,6 +415,9 @@ Token.propTypes = {
   name: PropTypes.string,
   customName: PropTypes.string,
   showName: PropTypes.bool,
+  auraRadius: PropTypes.number,
+  auraShape: PropTypes.oneOf(['circle', 'square']),
+  auraColor: PropTypes.string,
   onClick: PropTypes.func,
   onDragStart: PropTypes.func,
   onDragEnd: PropTypes.func.isRequired,
@@ -715,6 +743,9 @@ const MapCanvas = ({
           showName: false,
           controlledBy: 'master',
           barsVisibility: 'all',
+          auraRadius: 0,
+          auraShape: 'circle',
+          auraColor: '#ffff0088',
         };
         onTokensChange([...tokens, newToken]);
       },
@@ -771,6 +802,9 @@ const MapCanvas = ({
                 draggable={false}
                 listening={false}
                 opacity={0.35}
+                auraRadius={dragShadow.auraRadius}
+                auraShape={dragShadow.auraShape}
+                auraColor={dragShadow.auraColor}
               />
             )}
             {tokens.map((token) => (
@@ -798,6 +832,9 @@ const MapCanvas = ({
                 customName={token.customName}
                 showName={token.showName}
                 tokenSheetId={token.tokenSheetId}
+                auraRadius={token.auraRadius}
+                auraShape={token.auraShape}
+                auraColor={token.auraColor}
                 selected={token.id === selectedId}
                 onDragEnd={handleDragEnd}
                 onDragStart={handleDragStart}
@@ -881,6 +918,9 @@ MapCanvas.propTypes = {
       w: PropTypes.number,
       h: PropTypes.number,
       angle: PropTypes.number,
+      auraRadius: PropTypes.number,
+      auraShape: PropTypes.oneOf(['circle', 'square']),
+      auraColor: PropTypes.string,
     })
   ).isRequired,
   onTokensChange: PropTypes.func.isRequired,

--- a/src/components/TokenSettings.jsx
+++ b/src/components/TokenSettings.jsx
@@ -35,6 +35,9 @@ const TokenSettings = ({ token, enemies = [], players = [], onClose, onUpdate, o
   const [showName, setShowName] = useState(token.showName || false);
   const [controlledBy, setControlledBy] = useState(token.controlledBy || 'master');
   const [barsVisibility, setBarsVisibility] = useState(token.barsVisibility || 'all');
+  const [auraRadius, setAuraRadius] = useState(token.auraRadius || 0);
+  const [auraShape, setAuraShape] = useState(token.auraShape || 'circle');
+  const [auraColor, setAuraColor] = useState(token.auraColor || '#ffff0088');
 
   const applyChanges = () => {
     const enemy = enemies.find((e) => e.id === enemyId);
@@ -47,6 +50,9 @@ const TokenSettings = ({ token, enemies = [], players = [], onClose, onUpdate, o
       showName,
       controlledBy,
       barsVisibility,
+      auraRadius,
+      auraShape,
+      auraColor,
     });
   };
 
@@ -65,6 +71,7 @@ const TokenSettings = ({ token, enemies = [], players = [], onClose, onUpdate, o
           <button onClick={() => setTab('details')} className={`flex-1 p-2 ${tab==='details' ? 'bg-gray-800' : 'bg-gray-700'}`}>Detalles</button>
           <button onClick={() => setTab('notes')} className={`flex-1 p-2 ${tab==='notes' ? 'bg-gray-800' : 'bg-gray-700'}`}>Notas</button>
           <button onClick={() => setTab('light')} className={`flex-1 p-2 ${tab==='light' ? 'bg-gray-800' : 'bg-gray-700'}`}>Iluminación</button>
+          <button onClick={() => setTab('aura')} className={`flex-1 p-2 ${tab==='aura' ? 'bg-gray-800' : 'bg-gray-700'}`}>Aura</button>
         </div>
         <div className="p-3 space-y-3 text-sm">
           {tab === 'details' && (
@@ -113,6 +120,9 @@ const TokenSettings = ({ token, enemies = [], players = [], onClose, onUpdate, o
         showName,
         controlledBy,
         barsVisibility,
+        auraRadius,
+        auraShape,
+        auraColor,
       };
                     onUpdate(updated);
                     onOpenSheet(updated);
@@ -123,7 +133,26 @@ const TokenSettings = ({ token, enemies = [], players = [], onClose, onUpdate, o
               </div>
             </>
           )}
-          {tab !== 'details' && (
+          {tab === 'aura' && (
+            <>
+              <div>
+                <label className="block mb-1">Radio en casillas</label>
+                <Input type="number" value={auraRadius} onChange={e => setAuraRadius(parseInt(e.target.value,10) || 0)} />
+              </div>
+              <div>
+                <label className="block mb-1">Forma</label>
+                <select value={auraShape} onChange={e => setAuraShape(e.target.value)} className="w-full bg-gray-700 text-white">
+                  <option value="circle">Círculo</option>
+                  <option value="square">Cuadrado</option>
+                </select>
+              </div>
+              <div>
+                <label className="block mb-1">Color</label>
+                <input type="color" value={auraColor} onChange={e => setAuraColor(e.target.value)} className="w-full h-8 p-0 border-0" />
+              </div>
+            </>
+          )}
+          {tab !== 'details' && tab !== 'aura' && (
             <div className="text-gray-400">(Sin contenido)</div>
           )}
         </div>


### PR DESCRIPTION
## Summary
- allow configuring token aura radius, shape and color
- render aura around tokens on the map
- document new feature and bump version to 2.2.74

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686daca82c0483268a0c35e6b2fe2a63