### PR TITLE
Add aura visibility and token tint options

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,7 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 
 **Resumen de cambios v2.2.75:**
 - Nueva opción **Aura** con radio, forma, color y opacidad configurables.
+- Selector de visibilidad para el aura y nuevas opciones de opacidad y tinte del token.
 
 ### 🛠️ **Características Técnicas**
 - **Interfaz responsive** - Optimizada para móviles y escritorio con TailwindCSS

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -63,6 +63,9 @@ const hexToRgba = (hex, alpha = 1) => {
   auraShape = 'circle',
   auraColor = '#ffff00',
   auraOpacity = 0.25,
+  showAura = true,
+  tintColor = '#ff0000',
+  tintOpacity = 0,
 }, ref) => {
   const [img] = useImage(image);
   const groupRef = useRef();
@@ -300,7 +303,7 @@ const hexToRgba = (hex, alpha = 1) => {
       onMouseLeave={() => onHoverChange?.(false)}
       onDblClick={() => onSettings?.(id)}
     >
-      {auraRadius > 0 && (
+      {auraRadius > 0 && showAura && (
         auraShape === 'circle' ? (
           <Circle
             x={x + offX}
@@ -323,9 +326,31 @@ const hexToRgba = (hex, alpha = 1) => {
         )
       )}
       {img ? (
-        <KonvaImage ref={shapeRef} image={img} onTransform={updateHandle} {...common} />
+        <>
+          <KonvaImage ref={shapeRef} image={img} onTransform={updateHandle} {...common} />
+          {tintOpacity > 0 && (
+            <Rect
+              {...common}
+              fill={tintColor}
+              globalCompositeOperation="source-atop"
+              listening={false}
+              opacity={tintOpacity}
+            />
+          )}
+        </>
       ) : (
-        <Rect ref={shapeRef} fill={color || 'red'} onTransform={updateHandle} {...common} />
+        <>
+          <Rect ref={shapeRef} fill={color || 'red'} onTransform={updateHandle} {...common} />
+          {tintOpacity > 0 && (
+            <Rect
+              {...common}
+              fill={tintColor}
+              globalCompositeOperation="source-atop"
+              listening={false}
+              opacity={tintOpacity}
+            />
+          )}
+        </>
       )}
       {showName && (customName || name) && (
         <Group
@@ -430,6 +455,9 @@ Token.propTypes = {
   auraShape: PropTypes.oneOf(['circle', 'square']),
   auraColor: PropTypes.string,
   auraOpacity: PropTypes.number,
+  showAura: PropTypes.bool,
+  tintColor: PropTypes.string,
+  tintOpacity: PropTypes.number,
   onClick: PropTypes.func,
   onDragStart: PropTypes.func,
   onDragEnd: PropTypes.func.isRequired,
@@ -494,6 +522,19 @@ const MapCanvas = ({
     }
     return true;
   }, [playerName, userType]);
+
+  const canSeeAura = useCallback(
+    (tk) => {
+      if (!tk.auraVisibility || tk.auraVisibility === 'all') return true;
+      if (tk.auraVisibility === 'none') return false;
+      if (tk.auraVisibility === 'controlled') {
+        if (userType === 'master') return true;
+        return tk.controlledBy === playerName;
+      }
+      return true;
+    },
+    [playerName, userType]
+  );
 
   // Si se especifica el número de casillas, calculamos el tamaño de cada celda
   const effectiveGridSize = imageSize.width && gridCells ? imageSize.width / gridCells : gridSize;
@@ -759,6 +800,10 @@ const MapCanvas = ({
           auraShape: 'circle',
           auraColor: '#ffff00',
           auraOpacity: 0.25,
+          auraVisibility: 'all',
+          opacity: 1,
+          tintColor: '#ff0000',
+          tintOpacity: 0,
         };
         onTokensChange([...tokens, newToken]);
       },
@@ -815,6 +860,9 @@ const MapCanvas = ({
                 draggable={false}
                 listening={false}
                 opacity={0.35}
+                tintColor={dragShadow.tintColor}
+                tintOpacity={dragShadow.tintOpacity}
+                showAura={canSeeAura(dragShadow)}
                 auraRadius={dragShadow.auraRadius}
                 auraShape={dragShadow.auraShape}
                 auraColor={dragShadow.auraColor}
@@ -845,6 +893,10 @@ const MapCanvas = ({
                 name={token.name}
                 customName={token.customName}
                 showName={token.showName}
+                opacity={token.opacity ?? 1}
+                tintColor={token.tintColor}
+                tintOpacity={token.tintOpacity}
+                showAura={canSeeAura(token)}
                 tokenSheetId={token.tokenSheetId}
                 auraRadius={token.auraRadius}
                 auraShape={token.auraShape}
@@ -937,6 +989,10 @@ MapCanvas.propTypes = {
       auraShape: PropTypes.oneOf(['circle', 'square']),
       auraColor: PropTypes.string,
       auraOpacity: PropTypes.number,
+      auraVisibility: PropTypes.oneOf(['all', 'controlled', 'none']),
+      opacity: PropTypes.number,
+      tintColor: PropTypes.string,
+      tintOpacity: PropTypes.number,
     })
   ).isRequired,
   onTokensChange: PropTypes.func.isRequired,

--- a/src/components/TokenSettings.jsx
+++ b/src/components/TokenSettings.jsx
@@ -41,6 +41,16 @@ const TokenSettings = ({ token, enemies = [], players = [], onClose, onUpdate, o
   const [auraOpacity, setAuraOpacity] = useState(
     typeof token.auraOpacity === 'number' ? token.auraOpacity : 0.25
   );
+  const [auraVisibility, setAuraVisibility] = useState(
+    token.auraVisibility || 'all'
+  );
+  const [tokenOpacity, setTokenOpacity] = useState(
+    typeof token.opacity === 'number' ? token.opacity : 1
+  );
+  const [tintColor, setTintColor] = useState(token.tintColor || '#ff0000');
+  const [tintOpacity, setTintOpacity] = useState(
+    typeof token.tintOpacity === 'number' ? token.tintOpacity : 0
+  );
   const applyChanges = () => {
     const enemy = enemies.find((e) => e.id === enemyId);
     onUpdate({
@@ -56,12 +66,30 @@ const TokenSettings = ({ token, enemies = [], players = [], onClose, onUpdate, o
       auraShape,
       auraColor,
       auraOpacity,
+      auraVisibility,
+      opacity: tokenOpacity,
+      tintColor,
+      tintOpacity,
     });
   };
 
   useEffect(() => {
     applyChanges();
-  }, [enemyId, name, showName, controlledBy, barsVisibility, auraRadius, auraShape, auraColor, auraOpacity]);
+  }, [
+    enemyId,
+    name,
+    showName,
+    controlledBy,
+    barsVisibility,
+    auraRadius,
+    auraShape,
+    auraColor,
+    auraOpacity,
+    auraVisibility,
+    tokenOpacity,
+    tintColor,
+    tintOpacity,
+  ]);
 
   if (!token) return null;
 
@@ -114,6 +142,36 @@ const TokenSettings = ({ token, enemies = [], players = [], onClose, onUpdate, o
                   <option value="none">Nadie</option>
                 </select>
               </div>
+              <div>
+                <label className="block mb-1">Opacidad del token</label>
+                <input
+                  type="range"
+                  min="0"
+                  max="1"
+                  step="0.05"
+                  value={tokenOpacity}
+                  onChange={e => setTokenOpacity(parseFloat(e.target.value))}
+                  className="w-full"
+                />
+                <div className="text-right">{Math.round(tokenOpacity * 100)}%</div>
+              </div>
+              <div>
+                <label className="block mb-1">Color de tinte</label>
+                <input type="color" value={tintColor} onChange={e => setTintColor(e.target.value)} className="w-full h-8 p-0 border-0" />
+              </div>
+              <div>
+                <label className="block mb-1">Opacidad del tinte</label>
+                <input
+                  type="range"
+                  min="0"
+                  max="1"
+                  step="0.05"
+                  value={tintOpacity}
+                  onChange={e => setTintOpacity(parseFloat(e.target.value))}
+                  className="w-full"
+                />
+                <div className="text-right">{Math.round(tintOpacity * 100)}%</div>
+              </div>
               <div className="text-center">
                 <Boton
                   onClick={() => {
@@ -131,6 +189,10 @@ const TokenSettings = ({ token, enemies = [], players = [], onClose, onUpdate, o
                       auraShape,
                       auraColor,
                       auraOpacity,
+                      auraVisibility,
+                      opacity: tokenOpacity,
+                      tintColor,
+                      tintOpacity,
                     };
                     onOpenSheet(updated);
                   }}
@@ -169,6 +231,18 @@ const TokenSettings = ({ token, enemies = [], players = [], onClose, onUpdate, o
                   className="w-full"
                 />
                 <div className="text-right">{Math.round(auraOpacity * 100)}%</div>
+              </div>
+              <div>
+                <label className="block mb-1">Visible para</label>
+                <select
+                  value={auraVisibility}
+                  onChange={e => setAuraVisibility(e.target.value)}
+                  className="w-full bg-gray-700 text-white"
+                >
+                  <option value="all">Todos</option>
+                  <option value="controlled">Controlador</option>
+                  <option value="none">Nadie</option>
+                </select>
               </div>
             </>
           )}


### PR DESCRIPTION
## Summary
- allow selecting aura visibility
- allow token opacity and tint color from settings
- support tint overlay and aura visibility in map canvas
- document new features

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686db9dac43c832691c873c9e5b02f98