### PR TITLE
Fix token tint overlay

### DIFF
--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -329,13 +329,12 @@ const hexToRgba = (hex, alpha = 1) => {
         <>
           <KonvaImage ref={shapeRef} image={img} onTransform={updateHandle} {...common} />
           {tintOpacity > 0 && (
-            <KonvaImage
-              image={img}
+            <Rect
+              {...common}
               fill={tintColor}
               globalCompositeOperation="source-atop"
               listening={false}
               opacity={tintOpacity}
-              {...common}
             />
           )}
         </>


### PR DESCRIPTION
## Summary
- overlay tint using a `Rect` with `source-atop`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686dc3ea7c088326a753e2fa46addbc7