### PR TITLE
Fix token tint overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,7 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 
 **Resumen de cambios v2.2.76:**
 - El tinte del token respeta la forma de la imagen en lugar de cubrir el rectángulo completo.
+- El tinte se aplica con el filtro RGBA y los tokens sin imagen mezclan el color base con el tinte.
 
 ### 🛠️ **Características Técnicas**
 - **Interfaz responsive** - Optimizada para móviles y escritorio con TailwindCSS

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -28,6 +28,22 @@ const hexToRgba = (hex, alpha = 1) => {
   const b = int & 255;
   return `rgba(${r},${g},${b},${alpha})`;
 };
+
+const hexToRgb = (hex) => {
+  let h = hex.replace('#', '');
+  if (h.length === 3) h = h.split('').map(ch => ch + ch).join('');
+  const int = parseInt(h, 16);
+  return { r: (int >> 16) & 255, g: (int >> 8) & 255, b: int & 255 };
+};
+
+const mixColors = (baseHex, tintHex, opacity) => {
+  const base = hexToRgb(baseHex);
+  const tint = hexToRgb(tintHex);
+  const r = Math.round(base.r * (1 - opacity) + tint.r * opacity);
+  const g = Math.round(base.g * (1 - opacity) + tint.g * opacity);
+  const b = Math.round(base.b * (1 - opacity) + tint.b * opacity);
+  return `rgb(${r},${g},${b})`;
+};
   const Token = forwardRef(({
   id,
   x,
@@ -81,6 +97,10 @@ const hexToRgba = (hex, alpha = 1) => {
   const [stats, setStats] = useState({});
 
   const SNAP = gridSize / 4;
+
+  const tintRgb = hexToRgb(tintColor);
+  const placeholderBase = color || 'red';
+  const fillColor = tintOpacity > 0 ? mixColors(placeholderBase, tintColor, tintOpacity) : placeholderBase;
 
   useEffect(() => {
     if (!tokenSheetId) return;
@@ -326,32 +346,24 @@ const hexToRgba = (hex, alpha = 1) => {
         )
       )}
       {img ? (
-        <>
-          <KonvaImage ref={shapeRef} image={img} onTransform={updateHandle} {...common} />
-          {tintOpacity > 0 && (
-            <KonvaImage
-              image={img}
-              fill={tintColor}
-              globalCompositeOperation="source-atop"
-              listening={false}
-              opacity={tintOpacity}
-              {...common}
-            />
-          )}
-        </>
+        <KonvaImage
+          ref={shapeRef}
+          image={img}
+          onTransform={updateHandle}
+          {...common}
+          filters={tintOpacity > 0 ? [Konva.Filters.RGBA] : []}
+          red={tintRgb.r}
+          green={tintRgb.g}
+          blue={tintRgb.b}
+          alpha={tintOpacity}
+        />
       ) : (
-        <>
-          <Rect ref={shapeRef} fill={color || 'red'} onTransform={updateHandle} {...common} />
-          {tintOpacity > 0 && (
-            <Rect
-              {...common}
-              fill={tintColor}
-              globalCompositeOperation="source-atop"
-              listening={false}
-              opacity={tintOpacity}
-            />
-          )}
-        </>
+        <Rect
+          ref={shapeRef}
+          fill={fillColor}
+          onTransform={updateHandle}
+          {...common}
+        />
       )}
       {showName && (customName || name) && (
         <Group


### PR DESCRIPTION
## Summary
- overlay tint using RGBA filter on image
- mix colors for placeholder tokens

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686dc3ea7c088326a753e2fa46addbc7