### PR TITLE
Fix token tint application

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,9 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 **Resumen de cambios v2.2.77:**
 - Corrección de error "Konva is not defined" al aplicar el filtro de tinte.
 
+**Resumen de cambios v2.2.78:**
+- Las texturas de los tokens se cargan con `crossOrigin: 'anonymous'` para que el tinte se aplique correctamente.
+
 
 ### 🛠️ **Características Técnicas**
 - **Interfaz responsive** - Optimizada para móviles y escritorio con TailwindCSS

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -84,7 +84,8 @@ const mixColors = (baseHex, tintHex, opacity) => {
   tintColor = '#ff0000',
   tintOpacity = 0,
 }, ref) => {
-  const [img] = useImage(image);
+  // Load token texture with CORS enabled so filters like tint work
+  const [img] = useImage(image, 'anonymous');
   const groupRef = useRef();
   const shapeRef = useRef();
   const trRef = useRef();


### PR DESCRIPTION
## Summary
- ensure token textures are loaded with CORS enabled so tint works
- document v2.2.78 update in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686e3ab16c30832685210069e46d6170