### PR TITLE
Improve token tint overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,10 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 **Resumen de cambios v2.2.78:**
 - Las texturas de los tokens se cargan con `crossOrigin: 'anonymous'` para que el tinte se aplique correctamente.
 
+**Resumen de cambios v2.2.79:**
+- El tinte se superpone únicamente sobre la textura del token usando `source-atop`.
+- Se elimina el rectángulo rojo que cubría toda la celda.
+
 
 ### 🛠️ **Características Técnicas**
 - **Interfaz responsive** - Optimizada para móviles y escritorio con TailwindCSS

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -348,17 +348,23 @@ const mixColors = (baseHex, tintHex, opacity) => {
         )
       )}
       {img ? (
-        <KonvaImage
-          ref={shapeRef}
-          image={img}
-          onTransform={updateHandle}
-          {...common}
-          filters={tintOpacity > 0 ? [Konva.Filters.RGBA] : []}
-          red={tintRgb.r}
-          green={tintRgb.g}
-          blue={tintRgb.b}
-          alpha={tintOpacity}
-        />
+        <>
+          <KonvaImage
+            ref={shapeRef}
+            image={img}
+            onTransform={updateHandle}
+            {...common}
+          />
+          {tintOpacity > 0 && (
+            <Rect
+              {...common}
+              fill={tintColor}
+              opacity={tintOpacity}
+              listening={false}
+              globalCompositeOperation="source-atop"
+            />
+          )}
+        </>
       ) : (
         <Rect
           ref={shapeRef}


### PR DESCRIPTION
## Summary
- apply tint overlay only on token texture using `source-atop`
- document the change in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686e3cf310b08326aae6635e6a401212