### PR TITLE
Improve token tint overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,10 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 **Resumen de cambios v2.2.78:**
 - Las texturas de los tokens se cargan con `crossOrigin: 'anonymous'` para que el tinte se aplique correctamente.
 
+**Resumen de cambios v2.2.79:**
+- El tinte del token se aplica con el filtro `Konva.Filters.RGBA` directamente sobre la imagen.
+- Se elimina el rectángulo rojo que cubría toda la celda.
+
 
 ### 🛠️ **Características Técnicas**
 - **Interfaz responsive** - Optimizada para móviles y escritorio con TailwindCSS

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -105,6 +105,21 @@ const mixColors = (baseHex, tintHex, opacity) => {
   const fillColor = tintOpacity > 0 ? mixColors(placeholderBase, tintColor, tintOpacity) : placeholderBase;
 
   useEffect(() => {
+    if (!shapeRef.current || !img) return;
+    const node = shapeRef.current;
+    if (tintOpacity > 0) {
+      node.filters([Konva.Filters.RGBA]);
+      node.red(tintRgb.r);
+      node.green(tintRgb.g);
+      node.blue(tintRgb.b);
+      node.alpha(tintOpacity);
+    } else {
+      node.filters([]);
+    }
+    node.getLayer()?.batchDraw();
+  }, [tintColor, tintOpacity, img]);
+
+  useEffect(() => {
     if (!tokenSheetId) return;
     const load = () => {
       const stored = localStorage.getItem('tokenSheets');
@@ -353,11 +368,6 @@ const mixColors = (baseHex, tintHex, opacity) => {
           image={img}
           onTransform={updateHandle}
           {...common}
-          filters={tintOpacity > 0 ? [Konva.Filters.RGBA] : []}
-          red={tintRgb.r}
-          green={tintRgb.g}
-          blue={tintRgb.b}
-          alpha={tintOpacity}
         />
       ) : (
         <Rect


### PR DESCRIPTION
## Summary
- apply tint overlay only on token texture using `Konva.Filters.RGBA`
- document the change in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686e3cf310b08326aae6635e6a401212