### PR TITLE
Fix token tint effect

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,6 +357,11 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 - La imagen se clona sobre sí misma con `globalCompositeOperation: 'multiply'` para colorear sin perder nitidez.
 - Se elimina el uso del filtro `RGBA` y el cacheado de la textura.
 
+**Resumen de cambios v2.2.82:**
+- Eliminado el último `useEffect` que aplicaba el filtro RGBA en `MapCanvas.jsx`.
+- El overlay colorea el token sin desenfoque ni referencias a `tintRgb`.
+- Añadido `updateSizes` a las dependencias de su `useEffect` correspondiente.
+
 ### 🛠️ **Características Técnicas**
 - **Interfaz responsive** - Optimizada para móviles y escritorio con TailwindCSS
 - **Persistencia en Firebase** - Almacenamiento seguro y sincronización en tiempo real

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -104,22 +104,6 @@ const mixColors = (baseHex, tintHex, opacity) => {
   const fillColor = tintOpacity > 0 ? mixColors(placeholderBase, tintColor, tintOpacity) : placeholderBase;
 
 
-  useEffect(() => {
-    if (!shapeRef.current || !img) return;
-    const node = shapeRef.current;
-    if (tintOpacity > 0) {
-      node.cache({ pixelRatio: window.devicePixelRatio });
-      node.filters([Konva.Filters.RGBA]);
-      node.red(tintRgb.r);
-      node.green(tintRgb.g);
-      node.blue(tintRgb.b);
-      node.alpha(tintOpacity);
-    } else {
-      node.filters([]);
-      node.clearCache();
-    }
-    node.getLayer()?.batchDraw();
-  }, [tintColor, tintOpacity, img]);
 
   useEffect(() => {
     if (!tokenSheetId) return;
@@ -177,7 +161,7 @@ const mixColors = (baseHex, tintHex, opacity) => {
   useEffect(() => {
     updateSizes();
     if (selected) updateHandle();
-  }, [cellSize, selected]);
+  }, [cellSize, selected, updateSizes]);
   useEffect(() => {
     if (selected && trRef.current && shapeRef.current) {
       trRef.current.nodes([shapeRef.current]);


### PR DESCRIPTION
## Summary
- remove RGBA filter effect from `MapCanvas`
- add `updateSizes` to dependencies
- document changes in README

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686e4be3112083268df0bbe46c68a601