### PR TITLE
Fix token tint overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,6 +357,15 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 - La imagen se clona sobre sí misma con `globalCompositeOperation: 'multiply'` para colorear sin perder nitidez.
 - Se elimina el uso del filtro `RGBA` y el cacheado de la textura.
 
+**Resumen de cambios v2.2.82:**
+- Eliminado el último `useEffect` que aplicaba el filtro RGBA en `MapCanvas.jsx`.
+- El overlay colorea el token sin desenfoque ni referencias a `tintRgb`.
+- Añadido `updateSizes` a las dependencias de su `useEffect` correspondiente.
+
+**Resumen de cambios v2.2.83:**
+- El overlay vuelve a usarse con un `Rect` en modo `source-atop` para evitar el cuadrado opaco.
+- El `useEffect` que ajusta tamaños mantiene solo `[cellSize, selected]` y se ignora la advertencia de ESLint.
+
 ### 🛠️ **Características Técnicas**
 - **Interfaz responsive** - Optimizada para móviles y escritorio con TailwindCSS
 - **Persistencia en Firebase** - Almacenamiento seguro y sincronización en tiempo real

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -104,22 +104,6 @@ const mixColors = (baseHex, tintHex, opacity) => {
   const fillColor = tintOpacity > 0 ? mixColors(placeholderBase, tintColor, tintOpacity) : placeholderBase;
 
 
-  useEffect(() => {
-    if (!shapeRef.current || !img) return;
-    const node = shapeRef.current;
-    if (tintOpacity > 0) {
-      node.cache({ pixelRatio: window.devicePixelRatio });
-      node.filters([Konva.Filters.RGBA]);
-      node.red(tintRgb.r);
-      node.green(tintRgb.g);
-      node.blue(tintRgb.b);
-      node.alpha(tintOpacity);
-    } else {
-      node.filters([]);
-      node.clearCache();
-    }
-    node.getLayer()?.batchDraw();
-  }, [tintColor, tintOpacity, img]);
 
   useEffect(() => {
     if (!tokenSheetId) return;
@@ -177,6 +161,7 @@ const mixColors = (baseHex, tintHex, opacity) => {
   useEffect(() => {
     updateSizes();
     if (selected) updateHandle();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [cellSize, selected]);
   useEffect(() => {
     if (selected && trRef.current && shapeRef.current) {
@@ -385,12 +370,12 @@ const mixColors = (baseHex, tintHex, opacity) => {
             {...common}
           />
           {tintOpacity > 0 && (
-            <KonvaImage
-              image={img}
-              opacity={tintOpacity}
-              fill={tintColor}
-              globalCompositeOperation="multiply"
+            <Rect
               {...overlayProps}
+              fill={tintColor}
+              opacity={tintOpacity}
+              listening={false}
+              globalCompositeOperation="source-atop"
             />
           )}
         </>


### PR DESCRIPTION
## Summary
- draw token tint with a mask using `source-atop`
- silence updateSizes effect warning
- document new behaviour in README

## Testing
- `npm install --silent`
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686e4be3112083268df0bbe46c68a601