### PR TITLE
Refactor token tinting

### DIFF
--- a/README.md
+++ b/README.md
@@ -506,6 +506,9 @@ src/
 - ✅ **Listado completo de jugadores** - Ahora se muestran todos los nombres en "Controlado por" al editar un token
 - ✅ **Ajustes de token en tiempo real** - Los cambios se aplican sin cerrar la ventana de configuración
 
+### 🖌️ **Mejora de tinte de tokens (Febrero 2025) - v2.1.6**
+- ✅ **Tinte nítido** - El token usa filtro RGBA en lugar de un overlay
+
 ## 🔄 Historial de cambios previos
 
 <details>

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -103,6 +103,24 @@ const mixColors = (baseHex, tintHex, opacity) => {
   const placeholderBase = color || 'red';
   const fillColor = tintOpacity > 0 ? mixColors(placeholderBase, tintColor, tintOpacity) : placeholderBase;
 
+  useEffect(() => {
+    const node = shapeRef.current;
+    if (!node || !img) return;
+    const tintRgb = hexToRgb(tintColor);
+    if (tintOpacity > 0) {
+      node.cache();
+      node.filters([Konva.Filters.RGBA]);
+      node.red(tintRgb.r);
+      node.green(tintRgb.g);
+      node.blue(tintRgb.b);
+      node.alpha(tintOpacity);
+    } else {
+      node.clearCache();
+      node.filters([]);
+    }
+    node.getLayer()?.batchDraw();
+  }, [tintColor, tintOpacity, img]);
+
 
 
   useEffect(() => {
@@ -320,17 +338,6 @@ const mixColors = (baseHex, tintHex, opacity) => {
     strokeWidth: selected ? 3 : 0,
   };
 
-  const overlayProps = {
-    x: x + offX,
-    y: y + offY,
-    width: width * gridSize,
-    height: height * gridSize,
-    offsetX: offX,
-    offsetY: offY,
-    rotation: angle,
-    listening: false,
-    draggable: false,
-  };
 
   return (
     <Group
@@ -362,30 +369,9 @@ const mixColors = (baseHex, tintHex, opacity) => {
         )
       )}
       {img ? (
-        <>
-          <KonvaImage
-            ref={shapeRef}
-            image={img}
-            onTransform={updateHandle}
-            {...common}
-          />
-          {tintOpacity > 0 && (
-            <Rect
-              {...overlayProps}
-              fill={tintColor}
-              opacity={tintOpacity}
-              listening={false}
-              globalCompositeOperation="source-atop"
-            />
-          )}
-        </>
+        <KonvaImage ref={shapeRef} image={img} {...common} />
       ) : (
-        <Rect
-          ref={shapeRef}
-          fill={fillColor}
-          onTransform={updateHandle}
-          {...common}
-        />
+        <Rect ref={shapeRef} fill={fillColor} {...common} />
       )}
       {showName && (customName || name) && (
         <Group


### PR DESCRIPTION
## Summary
- apply RGBA filter to KonvaImage for token tint
- remove overlay rectangle
- document new feature in README

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686e52ef793c83268c4a46e7ff754529