### PR TITLE
Fix token tint blur

### DIFF
--- a/README.md
+++ b/README.md
@@ -506,6 +506,10 @@ src/
 - ✅ **Listado completo de jugadores** - Ahora se muestran todos los nombres en "Controlado por" al editar un token
 - ✅ **Ajustes de token en tiempo real** - Los cambios se aplican sin cerrar la ventana de configuración
 
+### 🖌️ **Mejora de tinte de tokens (Febrero 2025) - v2.1.6**
+- ✅ **Tinte nítido** - El token usa filtro RGBA en lugar de un overlay
+- 🔧 **Cacheado con pixelRatio** - La imagen se cachea a la resolución de pantalla para no perder nitidez
+
 ## 🔄 Historial de cambios previos
 
 <details>

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -103,6 +103,27 @@ const mixColors = (baseHex, tintHex, opacity) => {
   const placeholderBase = color || 'red';
   const fillColor = tintOpacity > 0 ? mixColors(placeholderBase, tintColor, tintOpacity) : placeholderBase;
 
+  useEffect(() => {
+    const node = shapeRef.current;
+    if (!node || !img) return;
+    const { r, g, b } = hexToRgb(tintColor);
+
+    if (tintOpacity > 0) {
+      node.cache({
+        pixelRatio: window.devicePixelRatio,
+      });
+      node.filters([Konva.Filters.RGBA]);
+      node.red(r);
+      node.green(g);
+      node.blue(b);
+      node.alpha(tintOpacity);
+    } else {
+      node.filters([]);
+      node.clearCache();
+    }
+    node.getLayer()?.batchDraw();
+  }, [tintColor, tintOpacity, img]);
+
 
 
   useEffect(() => {
@@ -320,17 +341,6 @@ const mixColors = (baseHex, tintHex, opacity) => {
     strokeWidth: selected ? 3 : 0,
   };
 
-  const overlayProps = {
-    x: x + offX,
-    y: y + offY,
-    width: width * gridSize,
-    height: height * gridSize,
-    offsetX: offX,
-    offsetY: offY,
-    rotation: angle,
-    listening: false,
-    draggable: false,
-  };
 
   return (
     <Group
@@ -362,30 +372,9 @@ const mixColors = (baseHex, tintHex, opacity) => {
         )
       )}
       {img ? (
-        <>
-          <KonvaImage
-            ref={shapeRef}
-            image={img}
-            onTransform={updateHandle}
-            {...common}
-          />
-          {tintOpacity > 0 && (
-            <Rect
-              {...overlayProps}
-              fill={tintColor}
-              opacity={tintOpacity}
-              listening={false}
-              globalCompositeOperation="source-atop"
-            />
-          )}
-        </>
+        <KonvaImage ref={shapeRef} image={img} {...common} />
       ) : (
-        <Rect
-          ref={shapeRef}
-          fill={fillColor}
-          onTransform={updateHandle}
-          {...common}
-        />
+        <Rect ref={shapeRef} fill={fillColor} {...common} />
       )}
       {showName && (customName || name) && (
         <Group


### PR DESCRIPTION
## Summary
- cache token tint with window.devicePixelRatio
- clarify changelog entry

## Testing
- `CI=true npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_686e52ef793c83268c4a46e7ff754529