### PR TITLE
Fix token tint blur

### DIFF
--- a/README.md
+++ b/README.md
@@ -509,6 +509,7 @@ src/
 ### 🖌️ **Mejora de tinte de tokens (Febrero 2025) - v2.1.6**
 - ✅ **Tinte nítido** - El token usa filtro RGBA en lugar de un overlay
 - 🔧 **Cacheado con pixelRatio** - La imagen se cachea a la resolución de pantalla para no perder nitidez
+- 🛠️ **pixelRatio ajustado** - El zoom del mapa se tiene en cuenta para evitar desenfoque
 
 ## 🔄 Historial de cambios previos
 

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -109,8 +109,9 @@ const mixColors = (baseHex, tintHex, opacity) => {
     const { r, g, b } = hexToRgb(tintColor);
 
     if (tintOpacity > 0) {
+      const pixelRatio = window.devicePixelRatio * groupScale;
       node.cache({
-        pixelRatio: window.devicePixelRatio,
+        pixelRatio,
       });
       node.filters([Konva.Filters.RGBA]);
       node.red(r);
@@ -122,7 +123,7 @@ const mixColors = (baseHex, tintHex, opacity) => {
       node.clearCache();
     }
     node.getLayer()?.batchDraw();
-  }, [tintColor, tintOpacity, img]);
+  }, [tintColor, tintOpacity, img, groupScale]);
 
 
 


### PR DESCRIPTION
## Summary
- scale tint cache with zoom to keep sharp image
- document blur fix in README

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686e94cb7e80832689b4ac5fd0353367