### PR TITLE
Persist map pages in Firebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 
 ### 🎲 **Gestión de Personajes**
 
-> **Versión actual: 2.2.75**
+> **Versión actual: 2.2.85**
 
 **Resumen de cambios v2.1.1:**
 - Rediseño visual de la vista de enemigos como cartas tipo Magic, con layout responsive y efectos visuales exclusivos.
@@ -368,6 +368,11 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 
 **Resumen de cambios v2.2.84:**
 - Nuevo selector de páginas en el Mapa de Batalla con configuración de grid independiente por página.
+
+**Resumen de cambios v2.2.85:**
+- Las páginas del mapa se guardan en Firebase con su fondo y tokens.
+- Se elimina la barra de ajustes de grid en el canvas.
+- Cada página muestra una miniatura de su fondo en el selector.
 
 ### 🛠️ **Características Técnicas**
 - **Interfaz responsive** - Optimizada para móviles y escritorio con TailwindCSS

--- a/src/components/PageSelector.jsx
+++ b/src/components/PageSelector.jsx
@@ -40,11 +40,20 @@ const PageSelector = ({ pages, current, onSelect, onAdd, onUpdate }) => {
         <div key={p.id} className="relative group">
           <button
             onClick={() => onSelect(i)}
-            className={`px-3 py-1 rounded-lg border border-gray-600 whitespace-nowrap ${
-              i === current ? 'bg-gray-700' : 'bg-gray-800'
+            className={`relative w-24 h-16 rounded-lg border border-gray-600 overflow-hidden ${
+              i === current ? 'ring-2 ring-blue-400' : ''
             }`}
           >
-            {p.name}
+            {p.background && (
+              <img
+                src={p.background}
+                alt="miniatura"
+                className="absolute inset-0 object-cover w-full h-full"
+              />
+            )}
+            <span className="absolute bottom-0 left-0 right-0 bg-gray-800/60 text-xs text-center">
+              {p.name}
+            </span>
           </button>
           <button
             onClick={() => openEdit(i)}


### PR DESCRIPTION
## Summary
- persist map pages in Firestore
- remove local grid controls from canvas
- show page background thumbnails in selector
- document changes and bump version to 2.2.85

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686ee15327a4832697697cfafa0f4068