### PR TITLE
Fix Firestore limit by using Firebase Storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 
 ### 🎲 **Gestión de Personajes**
 
-> **Versión actual: 2.2.86**
+> **Versión actual: 2.2.87**
 
 **Resumen de cambios v2.1.1:**
 - Rediseño visual de la vista de enemigos como cartas tipo Magic, con layout responsive y efectos visuales exclusivos.
@@ -377,6 +377,10 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 **Resumen de cambios v2.2.86:**
 - El botón "Examinar" para subir el fondo se muestra ahora encima de las miniaturas.
 - Las miniaturas del selector de páginas se han ampliado para mayor visibilidad.
+
+**Resumen de cambios v2.2.87:**
+- Las imágenes del Mapa de Batalla ahora se almacenan en Firebase Storage.
+- Se limita el almacenamiento total a 1GB para prevenir errores de tamaño.
 
 ### 🛠️ **Características Técnicas**
 - **Interfaz responsive** - Optimizada para móviles y escritorio con TailwindCSS

--- a/src/components/AssetSidebar.jsx
+++ b/src/components/AssetSidebar.jsx
@@ -12,6 +12,7 @@ import {
 } from 'react-icons/fi';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useDrag } from 'react-dnd';
+import { uploadFile } from '../utils/storage';
 
 export const AssetTypes = { IMAGE: 'asset-image' };
 
@@ -67,26 +68,25 @@ const AssetSidebar = ({ onAssetSelect, onDragStart, className = '' }) => {
     });
   };
 
-  const fileToDataURL = (file) =>
-    new Promise((resolve) => {
-      const reader = new FileReader();
-      reader.onload = () => resolve(reader.result);
-      reader.readAsDataURL(file);
-    });
-
   const handleFilesUpload = async (folderId, files) => {
     if (!files) return;
     const uploads = await Promise.all(
       Array.from(files).map(async (file) => {
-        const url = await fileToDataURL(file);
         const name = file.name.replace(/\.[^/.]+$/, '');
-        return { id: nanoid(), name, url };
+        const path = `canvas-assets/${nanoid()}-${file.name}`;
+        try {
+          const url = await uploadFile(file, path);
+          return { id: nanoid(), name, url };
+        } catch (e) {
+          alert(e.message);
+          return null;
+        }
       })
     );
     setFolders((fs) =>
       updateFolders(fs, folderId, (f) => ({
         ...f,
-        assets: [...f.assets, ...uploads],
+        assets: [...f.assets, ...uploads.filter(Boolean)],
       }))
     );
   };

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -1,5 +1,6 @@
 import { initializeApp } from "firebase/app";
 import { getFirestore } from "firebase/firestore";
+import { getStorage } from "firebase/storage";
 
 // Permite usar variables de entorno para ocultar las claves. Si no se
 // proporcionan (por ejemplo en entornos de pruebas o desarrollo rápido),
@@ -21,3 +22,4 @@ const firebaseConfig = {
 
 const app = initializeApp(firebaseConfig);
 export const db = getFirestore(app);
+export const storage = getStorage(app);

--- a/src/utils/storage.js
+++ b/src/utils/storage.js
@@ -1,0 +1,40 @@
+import { ref, uploadBytes, getDownloadURL } from 'firebase/storage';
+import { doc, getDoc, setDoc } from 'firebase/firestore';
+import { storage, db } from '../firebase';
+
+const LIMIT_BYTES = 1024 * 1024 * 1024; // 1 GB
+const USAGE_DOC = doc(db, 'storageUsage', 'usage');
+
+export const getUsage = async () => {
+  const snap = await getDoc(USAGE_DOC);
+  return snap.exists() ? snap.data().bytesUsed || 0 : 0;
+};
+
+const updateUsage = async (delta) => {
+  const current = await getUsage();
+  await setDoc(USAGE_DOC, { bytesUsed: current + delta });
+};
+
+export const uploadFile = async (file, path) => {
+  const current = await getUsage();
+  if (current + file.size > LIMIT_BYTES) {
+    throw new Error('Límite de almacenamiento superado');
+  }
+  const storageRef = ref(storage, path);
+  await uploadBytes(storageRef, file);
+  await updateUsage(file.size);
+  return getDownloadURL(storageRef);
+};
+
+export const uploadDataUrl = async (dataUrl, path) => {
+  const res = await fetch(dataUrl);
+  const blob = await res.blob();
+  const current = await getUsage();
+  if (current + blob.size > LIMIT_BYTES) {
+    throw new Error('Límite de almacenamiento superado');
+  }
+  const storageRef = ref(storage, path);
+  await uploadBytes(storageRef, blob);
+  await updateUsage(blob.size);
+  return getDownloadURL(storageRef);
+};


### PR DESCRIPTION
## Summary
- add Firebase storage to the app
- upload asset images to Firebase Storage
- store battle map background in Storage
- persist pages by uploading data URLs to Storage
- track Storage usage with 1GB limit
- document feature in README

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686eea5dd2808326a5dc5b5c9adb7e44