### PR TITLE
Fix map background not persisting

### DIFF
--- a/README.md
+++ b/README.md
@@ -521,6 +521,7 @@ src/
 - ✅ **Configuración de seguridad** - Añadidas reglas permisivas para acceso completo a datos
 - ✅ **Archivos de configuración** - Creados `firestore.rules` y `firestore.indexes.json`
 - ✅ **Despliegue actualizado** - Firebase configurado correctamente para producción
+- 🔧 **Fondos de mapa persistentes** - Se evita guardar URLs temporales de tipo `blob:`
 
 ### 🗺️ **Corrección de Alineado de Tokens (Enero 2025) - v2.1.4**
 - ✅ **Snap perfecto tras drag** - Los tokens quedan totalmente centrados en la casilla al soltarlos

--- a/src/App.js
+++ b/src/App.js
@@ -445,6 +445,9 @@ function App() {
             bg = await uploadDataUrl(bg, `canvas-backgrounds/${p.id}`);
             changed = true;
           }
+          if (bg && bg.startsWith('blob:')) {
+            return p; // no guardar hasta que termine la subida
+          }
           const newPage = changed ? { ...p, tokens, background: bg } : p;
           await setDoc(doc(db, 'pages', newPage.id), newPage);
           return newPage;


### PR DESCRIPTION
## Summary
- avoid saving temporary blob URLs when syncing pages
- document persistent map background fix

## Testing
- `npm install`
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686f0386d1b083269e3896ab67156933