### PR TITLE
Fix map backgrounds persisting

### DIFF
--- a/README.md
+++ b/README.md
@@ -521,6 +521,7 @@ src/
 - ✅ **Configuración de seguridad** - Añadidas reglas permisivas para acceso completo a datos
 - ✅ **Archivos de configuración** - Creados `firestore.rules` y `firestore.indexes.json`
 - ✅ **Despliegue actualizado** - Firebase configurado correctamente para producción
+- 🔧 **Fondos de mapa persistentes** - Las imágenes se suben automáticamente a `Mapas/` en Firebase Storage evitando guardar URLs temporales `blob:`
 
 ### 🗺️ **Corrección de Alineado de Tokens (Enero 2025) - v2.1.4**
 - ✅ **Snap perfecto tras drag** - Los tokens quedan totalmente centrados en la casilla al soltarlos

--- a/src/App.js
+++ b/src/App.js
@@ -389,7 +389,7 @@ function App() {
     const localUrl = URL.createObjectURL(file);
     setCanvasBackground(localUrl);
     try {
-      const path = `canvas-backgrounds/${nanoid()}-${file.name}`;
+      const path = `Mapas/${nanoid()}-${file.name}`;
       const url = await uploadFile(file, path);
       URL.revokeObjectURL(localUrl);
       setCanvasBackground(url);
@@ -442,8 +442,11 @@ function App() {
           );
           let bg = p.background;
           if (bg && bg.startsWith('data:')) {
-            bg = await uploadDataUrl(bg, `canvas-backgrounds/${p.id}`);
+            bg = await uploadDataUrl(bg, `Mapas/${p.id}`);
             changed = true;
+          }
+          if (bg && bg.startsWith('blob:')) {
+            return p; // no guardar hasta que termine la subida
           }
           const newPage = changed ? { ...p, tokens, background: bg } : p;
           await setDoc(doc(db, 'pages', newPage.id), newPage);

--- a/src/components/__tests__/Confirm.test.js
+++ b/src/components/__tests__/Confirm.test.js
@@ -1,5 +1,4 @@
-import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { ConfirmProvider, useConfirm } from '../Confirm';
 import React from 'react';
 
@@ -25,10 +24,10 @@ test('shows confirmation modal and resolves', async () => {
     </ConfirmProvider>
   );
 
-  await userEvent.click(screen.getByText('delete'));
+  fireEvent.click(screen.getByText('delete'));
   expect(screen.getByText('¿Seguro?')).toBeInTheDocument();
 
-  await userEvent.click(screen.getByRole('button', { name: /aceptar/i }));
+  fireEvent.click(screen.getByRole('button', { name: /aceptar/i }));
   expect(screen.queryByText('¿Seguro?')).not.toBeInTheDocument();
   const result = await screen.findByTestId('result');
   expect(result).toHaveTextContent('yes');


### PR DESCRIPTION
## Summary
- upload battle map backgrounds to the `Mapas/` folder in Firebase Storage
- update the changelog about automatic background upload
- fix tests by avoiding unsupported userEvent setup

## Testing
- `npm install`
- `CI=true npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_686f0386d1b083269e3896ab67156933