### PR TITLE
Improve background upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -523,6 +523,7 @@ src/
 - ✅ **Reglas de Storage añadidas** - Nuevo archivo `storage.rules` con acceso abierto para subir imágenes
 - ✅ **Despliegue actualizado** - Firebase configurado correctamente para producción
 - 🔧 **Fondos de mapa persistentes** - Las imágenes se suben automáticamente a `Mapas/` en Firebase Storage evitando guardar URLs temporales `blob:`
+- 🔧 **Guardado inmediato de mapas** - Tras la subida, la página se actualiza en Firestore con la URL definitiva
 
 ### 🗺️ **Corrección de Alineado de Tokens (Enero 2025) - v2.1.4**
 - ✅ **Snap perfecto tras drag** - Los tokens quedan totalmente centrados en la casilla al soltarlos

--- a/src/App.js
+++ b/src/App.js
@@ -393,6 +393,14 @@ function App() {
       const url = await uploadFile(file, path);
       URL.revokeObjectURL(localUrl);
       setCanvasBackground(url);
+      const pageId = pages[currentPage]?.id;
+      if (pageId) {
+        const newPage = { ...pages[currentPage], background: url };
+        await setDoc(doc(db, 'pages', pageId), newPage);
+        setPages((ps) =>
+          ps.map((p, i) => (i === currentPage ? newPage : p))
+        );
+      }
     } catch (err) {
       alert(err.message);
     }


### PR DESCRIPTION
## Summary
- upload battle map to Firebase then save updated page immediately
- document automatic page update after uploading maps

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68719618f94083268270569134c4ec2a