### PR TITLE
Fix map upload with Firebase Storage SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 
 ### 🎲 **Gestión de Personajes**
 
-> **Versión actual: 2.2.89**
+> **Versión actual: 2.2.90**
 
 **Resumen de cambios v2.1.1:**
 - Rediseño visual de la vista de enemigos como cartas tipo Magic, con layout responsive y efectos visuales exclusivos.
@@ -388,6 +388,9 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 
 **Resumen de cambios v2.2.89:**
 - Las carpetas y miniaturas del panel de assets se guardan ahora en Firebase.
+
+**Resumen de cambios v2.2.90:**
+- Subida de mapas corregida usando el SDK de Firebase Storage.
 
 ### 🛠️ **Características Técnicas**
 - **Interfaz responsive** - Optimizada para móviles y escritorio con TailwindCSS

--- a/src/App.js
+++ b/src/App.js
@@ -389,7 +389,8 @@ function App() {
     const localUrl = URL.createObjectURL(file);
     setCanvasBackground(localUrl);
     try {
-      const path = `Mapas/${nanoid()}-${file.name}`;
+      const safeName = encodeURIComponent(file.name);
+      const path = `Mapas/${nanoid()}-${safeName}`;
       const url = await uploadFile(file, path);
       URL.revokeObjectURL(localUrl);
       setCanvasBackground(url);

--- a/src/components/AssetSidebar.jsx
+++ b/src/components/AssetSidebar.jsx
@@ -96,7 +96,8 @@ const AssetSidebar = ({ onAssetSelect, onDragStart, className = '' }) => {
     const uploads = await Promise.all(
       Array.from(files).map(async (file) => {
         const name = file.name.replace(/\.[^/.]+$/, '');
-        const path = `canvas-assets/${nanoid()}-${file.name}`;
+        const safeName = encodeURIComponent(file.name);
+        const path = `canvas-assets/${nanoid()}-${safeName}`;
         try {
           const url = await uploadFile(file, path);
           return { id: nanoid(), name, url };

--- a/src/utils/storage.js
+++ b/src/utils/storage.js
@@ -1,4 +1,4 @@
-import { ref, uploadBytes, getDownloadURL } from 'firebase/storage';
+import { ref, uploadBytes, uploadString, getDownloadURL } from 'firebase/storage';
 import { doc, getDoc, setDoc } from 'firebase/firestore';
 import { storage, db } from '../firebase';
 
@@ -27,14 +27,14 @@ export const uploadFile = async (file, path) => {
 };
 
 export const uploadDataUrl = async (dataUrl, path) => {
-  const res = await fetch(dataUrl);
-  const blob = await res.blob();
+  const base64 = dataUrl.split(',')[1] || '';
+  const size = Buffer.from(base64, 'base64').length;
   const current = await getUsage();
-  if (current + blob.size > LIMIT_BYTES) {
+  if (current + size > LIMIT_BYTES) {
     throw new Error('Límite de almacenamiento superado');
   }
   const storageRef = ref(storage, path);
-  await uploadBytes(storageRef, blob);
-  await updateUsage(blob.size);
+  await uploadString(storageRef, dataUrl, 'data_url');
+  await updateUsage(size);
   return getDownloadURL(storageRef);
 };


### PR DESCRIPTION
## Summary
- upload backgrounds and assets with encoded filenames
- store map images via `uploadString` for data URLs
- document new behaviour

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68719c4a885c8326bc8e9c8406453644