### PR TITLE
Implement deduped background uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,6 +395,10 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 **Resumen de cambios v2.2.91:**
 - Bucket de Firebase Storage actualizado a 'base-de-datos-noma.firebasestorage.app'.
 
+**Resumen de cambios v2.2.92:**
+- Imágenes de fondo deduplicadas usando hashes SHA-256 y referencias en Firestore.
+- Posibilidad de eliminar páginas del mapa de batalla.
+
 ### 🛠️ **Características Técnicas**
 - **Interfaz responsive** - Optimizada para móviles y escritorio con TailwindCSS
 - **Persistencia en Firebase** - Almacenamiento seguro y sincronización en tiempo real

--- a/src/components/PageSelector.jsx
+++ b/src/components/PageSelector.jsx
@@ -5,7 +5,7 @@ import Modal from './Modal';
 import Input from './Input';
 import Boton from './Boton';
 
-const PageSelector = ({ pages, current, onSelect, onAdd, onUpdate }) => {
+const PageSelector = ({ pages, current, onSelect, onAdd, onUpdate, onDelete }) => {
   const [editIndex, setEditIndex] = useState(null);
   const [pageData, setPageData] = useState({});
 
@@ -31,6 +31,11 @@ const PageSelector = ({ pages, current, onSelect, onAdd, onUpdate }) => {
       gridOffsetX: parseInt(pageData.gridOffsetX, 10) || 0,
       gridOffsetY: parseInt(pageData.gridOffsetY, 10) || 0,
     });
+    closeEdit();
+  };
+
+  const handleDelete = () => {
+    onDelete(editIndex);
     closeEdit();
   };
 
@@ -73,6 +78,7 @@ const PageSelector = ({ pages, current, onSelect, onAdd, onUpdate }) => {
         title="Editar página"
         footer={
           <>
+            <Boton color="red" onClick={handleDelete}>Eliminar</Boton>
             <Boton color="gray" onClick={closeEdit}>Cancelar</Boton>
             <Boton color="green" onClick={handleSave}>Guardar</Boton>
           </>
@@ -129,6 +135,7 @@ PageSelector.propTypes = {
   onSelect: PropTypes.func.isRequired,
   onAdd: PropTypes.func.isRequired,
   onUpdate: PropTypes.func.isRequired,
+  onDelete: PropTypes.func.isRequired,
 };
 
 export default PageSelector;

--- a/src/utils/storage.js
+++ b/src/utils/storage.js
@@ -4,8 +4,17 @@ import {
   uploadBytes,
   uploadString,
   getDownloadURL,
+  getMetadata,
+  deleteObject,
 } from 'firebase/storage';
-import { doc, getDoc, setDoc } from 'firebase/firestore';
+import {
+  doc,
+  getDoc,
+  setDoc,
+  updateDoc,
+  increment,
+  deleteDoc,
+} from 'firebase/firestore';
 import { db } from '../firebase';
 
 const storage = getStorage();
@@ -67,4 +76,71 @@ export const uploadDataUrl = async (dataUrl, path) => {
   }
   await updateUsage(size);
   return getDownloadURL(storageRef);
+};
+
+export const getFileHash = async (fileOrDataUrl) => {
+  let buffer;
+  if (typeof fileOrDataUrl === 'string') {
+    const base64 = fileOrDataUrl.split(',')[1] || '';
+    const binary = atob(base64);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) {
+      bytes[i] = binary.charCodeAt(i);
+    }
+    buffer = bytes.buffer;
+  } else {
+    buffer = await fileOrDataUrl.arrayBuffer();
+  }
+  const hashBuffer = await crypto.subtle.digest('SHA-256', buffer);
+  return Array.from(new Uint8Array(hashBuffer))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+};
+
+export const getOrUploadFile = async (file, basePath = 'Mapas') => {
+  const hash = await getFileHash(file);
+  const ext = file.name.split('.').pop().toLowerCase();
+  const path = `${basePath}/${hash}.${ext}`;
+  const storageRef = ref(storage, safePath(path));
+  let exists = true;
+  try {
+    await getMetadata(storageRef);
+  } catch {
+    exists = false;
+  }
+  if (!exists) {
+    const current = await getUsage();
+    if (current + file.size > LIMIT_BYTES) {
+      throw new Error('Límite de almacenamiento superado');
+    }
+    await uploadBytes(storageRef, file);
+    await updateUsage(file.size);
+  }
+  const url = await getDownloadURL(storageRef);
+  const refDoc = doc(db, 'fileRefs', hash);
+  await setDoc(refDoc, { url, count: increment(1) }, { merge: true });
+  return { url, hash };
+};
+
+export const releaseFile = async (hash) => {
+  const refDoc = doc(db, 'fileRefs', hash);
+  const snap = await getDoc(refDoc);
+  if (!snap.exists()) return;
+  const data = snap.data();
+  const newCount = (data.count || 1) - 1;
+  if (newCount <= 0) {
+    const encoded = data.url.split('/o/')[1].split('?')[0];
+    const path = decodeURIComponent(encoded);
+    const storageRef = ref(storage, safePath(path));
+    let size = 0;
+    try {
+      const meta = await getMetadata(storageRef);
+      size = meta.size || 0;
+    } catch {}
+    await deleteObject(storageRef);
+    await updateUsage(-size);
+    await deleteDoc(refDoc);
+  } else {
+    await updateDoc(refDoc, { count: increment(-1) });
+  }
 };


### PR DESCRIPTION
## Summary
- generate SHA-256 hashes for uploaded files and reuse existing images
- manage file reference counts in Firestore and remove unused images
- store background hash on pages and update background upload logic
- allow deleting pages via PageSelector
- document new behaviour

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6871b47c76bc8326980ecd2340b89aa5