### PR TITLE
Fix page settings menu visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 
 ### 🎲 **Gestión de Personajes**
 
-> **Versión actual: 2.2.91**
+> **Versión actual: 2.2.93**
 
 **Resumen de cambios v2.1.1:**
 - Rediseño visual de la vista de enemigos como cartas tipo Magic, con layout responsive y efectos visuales exclusivos.
@@ -398,6 +398,9 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 **Resumen de cambios v2.2.92:**
 - Imágenes de fondo deduplicadas usando hashes SHA-256 y referencias en Firestore.
 - Posibilidad de eliminar páginas del mapa de batalla.
+
+**Resumen de cambios v2.2.93:**
+- Se corrige la visibilidad del botón de ajustes en el selector de páginas.
 
 ### 🛠️ **Características Técnicas**
 - **Interfaz responsive** - Optimizada para móviles y escritorio con TailwindCSS

--- a/src/components/PageSelector.jsx
+++ b/src/components/PageSelector.jsx
@@ -40,7 +40,7 @@ const PageSelector = ({ pages, current, onSelect, onAdd, onUpdate, onDelete }) =
   };
 
   return (
-    <div className="flex items-center gap-2 mb-4 overflow-x-auto">
+    <div className="flex items-center gap-2 mb-4 overflow-x-auto overflow-y-visible">
       {pages.map((p, i) => (
         <div key={p.id} className="relative group">
           <button


### PR DESCRIPTION
## Summary
- ensure vertical overflow visible in `PageSelector` so the options button isn't clipped
- document change in README and bump version

## Testing
- `npm install --silent`
- `npm test --silent -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_6871b86e4afc8326b58ec50bd5399531