### PR TITLE
Fix responsive page menu button

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 
 ### 🎲 **Gestión de Personajes**
 
-> **Versión actual: 2.2.93**
+> **Versión actual: 2.2.94**
 
 **Resumen de cambios v2.1.1:**
 - Rediseño visual de la vista de enemigos como cartas tipo Magic, con layout responsive y efectos visuales exclusivos.
@@ -401,6 +401,9 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 
 **Resumen de cambios v2.2.93:**
 - Se corrige la visibilidad del botón de ajustes en el selector de páginas.
+
+**Resumen de cambios v2.2.94:**
+- Diseño responsive para el selector de páginas y su botón de ajustes.
 
 ### 🛠️ **Características Técnicas**
 - **Interfaz responsive** - Optimizada para móviles y escritorio con TailwindCSS

--- a/src/components/PageSelector.jsx
+++ b/src/components/PageSelector.jsx
@@ -40,12 +40,12 @@ const PageSelector = ({ pages, current, onSelect, onAdd, onUpdate, onDelete }) =
   };
 
   return (
-    <div className="flex items-center gap-2 mb-4 overflow-x-auto overflow-y-visible">
+    <div className="flex items-center gap-2 mb-4 overflow-x-auto overflow-y-visible py-1">
       {pages.map((p, i) => (
-        <div key={p.id} className="relative group">
+        <div key={p.id} className="relative group flex-shrink-0">
           <button
             onClick={() => onSelect(i)}
-            className={`relative w-40 h-28 rounded-lg border border-gray-600 overflow-hidden ${
+            className={`relative w-28 h-20 sm:w-36 sm:h-24 md:w-40 md:h-28 rounded-lg border border-gray-600 overflow-hidden ${
               i === current ? 'ring-2 ring-blue-400' : ''
             }`}
           >
@@ -62,7 +62,7 @@ const PageSelector = ({ pages, current, onSelect, onAdd, onUpdate, onDelete }) =
           </button>
           <button
             onClick={() => openEdit(i)}
-            className="absolute -top-2 -right-2 hidden group-hover:block p-1 bg-gray-700 rounded-full"
+            className="absolute top-1 right-1 p-1 bg-gray-700 hover:bg-gray-600 rounded-full text-white shadow focus:outline-none hidden group-hover:block"
             aria-label="Editar"
           >
             <FiMoreVertical />


### PR DESCRIPTION
## Summary
- adjust PageSelector button styles so the 3-dot menu is visible
- improve responsive sizing for page thumbnails
- document the improvement and bump patch version to 2.2.94

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6871bb13f0588326a87e1a6bcfbf4587