### PR TITLE
Add map loading spinner

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 **Resumen de cambios v2.1.11:**
 - Lista completa de jugadores en el campo **Controlado por** al editar un token.
 
+**Resumen de cambios v2.1.12:**
+- Indicador de carga en el mapa con spinner mientras se descarga la imagen.
+
 **Resumen de cambios v2.2.0:**
 - Botón **Guardar datos** para respaldar la ficha completa.
 - Botón **RESET** que restaura la ficha al último respaldo guardado.
@@ -566,6 +569,9 @@ src/
 - 🔧 **Cacheado con pixelRatio** - La imagen se cachea a la resolución de pantalla para no perder nitidez
 - 🛠️ **pixelRatio ajustado** - El zoom del mapa se tiene en cuenta para evitar desenfoque
 - 🚫 **Selección intacta** - El contorno de selección ya no se tiñe
+
+### 🌀 **Indicador de carga del mapa (Marzo 2025) - v2.1.7**
+- ✅ Spinner visible mientras se carga la imagen del mapa para evitar pantalla negra
 
 ## 🔄 Historial de cambios previos
 

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -18,6 +18,7 @@ import TokenSettings from './TokenSettings';
 import TokenSheetModal from './TokenSheetModal';
 import { nanoid } from 'nanoid';
 import TokenBars from './TokenBars';
+import LoadingSpinner from './LoadingSpinner';
 import Konva from 'konva';
 
 const hexToRgba = (hex, alpha = 1) => {
@@ -546,7 +547,8 @@ const MapCanvas = ({
   const tokenRefs = useRef({});
   const panStart = useRef({ x: 0, y: 0 });
   const panOrigin = useRef({ x: 0, y: 0 });
-  const [bg] = useImage(backgroundImage, 'anonymous');
+  const [bg, bgStatus] = useImage(backgroundImage, 'anonymous');
+  const isBgLoading = bgStatus !== 'loaded';
 
   const canSeeBars = useCallback((tk) => {
     if (!tk.barsVisibility || tk.barsVisibility === 'all') return true;
@@ -847,7 +849,10 @@ const MapCanvas = ({
   );
 
   return (
-    <div ref={containerRef} className="w-full h-full overflow-hidden">
+    <div ref={containerRef} className="w-full h-full overflow-hidden relative">
+      {isBgLoading && (
+        <LoadingSpinner overlay color="white" text="Cargando mapa..." />
+      )}
       <div ref={drop}>
         <Stage
         ref={stageRef}


### PR DESCRIPTION
## Summary
- display spinner while background image loads
- document new feature in README

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6871c021a3a08326962383645c4d04fc