### PR TITLE
Persist assets sidebar in realtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,6 +408,9 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 **Resumen de cambios v2.2.94:**
 - Diseño responsive para el selector de páginas y su botón de ajustes.
 
+**Resumen de cambios v2.2.95:**
+- Sincronización en tiempo real del panel de assets usando Firebase.
+
 ### 🛠️ **Características Técnicas**
 - **Interfaz responsive** - Optimizada para móviles y escritorio con TailwindCSS
 - **Persistencia en Firebase** - Almacenamiento seguro y sincronización en tiempo real


### PR DESCRIPTION
## Summary
- save asset sidebar changes in real time using `onSnapshot`
- document the new behavior in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68724cbaee988326a09cdb39e3d16609