### PR TITLE
Fix map tokens not loading initially

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,6 +421,9 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 **Resumen de cambios v2.2.98:**
 - Se evita sobrescribir los datos de assets al cargar la página esperando a que Firebase devuelva la información.
 
+**Resumen de cambios v2.2.99:**
+- Corrección de carga inicial del Mapa de Batalla: los tokens aparecen sin necesidad de cambiar de página.
+
 ### 🛠️ **Características Técnicas**
 - **Interfaz responsive** - Optimizada para móviles y escritorio con TailwindCSS
 - **Persistencia en Firebase** - Almacenamiento seguro y sincronización en tiempo real

--- a/src/App.js
+++ b/src/App.js
@@ -428,7 +428,7 @@ function App() {
     setGridCells(p.gridCells || 1);
     setGridOffsetX(p.gridOffsetX || 0);
     setGridOffsetY(p.gridOffsetY || 0);
-  }, [currentPage]);
+  }, [currentPage, pages]);
 
   useEffect(() => {
     setPages(ps => ps.map((pg, i) => i === currentPage ? { ...pg, tokens: canvasTokens } : pg));


### PR DESCRIPTION
## Summary
- trigger page sync effect when pages data changes
- document map token load fix in README

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68725d77c6988326a7b2c907d81616b7