### PR TITLE
Add spinner animation for tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,6 +424,9 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 **Resumen de cambios v2.2.99:**
 - Corrección de carga inicial del Mapa de Batalla: los tokens aparecen sin necesidad de cambiar de página.
 
+**Resumen de cambios v2.3.0:**
+- Los tokens muestran únicamente un spinner mientras se carga su imagen, sin el rectángulo rojo temporal.
+
 ### 🛠️ **Características Técnicas**
 - **Interfaz responsive** - Optimizada para móviles y escritorio con TailwindCSS
 - **Persistencia en Firebase** - Almacenamiento seguro y sincronización en tiempo real

--- a/src/components/KonvaSpinner.jsx
+++ b/src/components/KonvaSpinner.jsx
@@ -1,0 +1,34 @@
+import React, { useRef, useEffect } from 'react';
+import { Group, Arc } from 'react-konva';
+import Konva from 'konva';
+
+const KonvaSpinner = ({ x = 0, y = 0, radius = 10, color = 'white' }) => {
+  const groupRef = useRef(null);
+
+  useEffect(() => {
+    const layer = groupRef.current?.getLayer();
+    if (!layer) return;
+    const anim = new Konva.Animation((frame) => {
+      if (groupRef.current && frame) {
+        const angle = (frame.time / 1000) * 360;
+        groupRef.current.rotation(angle % 360);
+      }
+    }, layer);
+    anim.start();
+    return () => anim.stop();
+  }, []);
+
+  return (
+    <Group ref={groupRef} x={x} y={y} listening={false}>
+      <Arc
+        innerRadius={radius - 3}
+        outerRadius={radius}
+        angle={270}
+        fill={color}
+        opacity={0.8}
+      />
+    </Group>
+  );
+};
+
+export default KonvaSpinner;

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -19,6 +19,7 @@ import TokenSheetModal from './TokenSheetModal';
 import { nanoid } from 'nanoid';
 import TokenBars from './TokenBars';
 import LoadingSpinner from './LoadingSpinner';
+import KonvaSpinner from './KonvaSpinner';
 import Konva from 'konva';
 
 const hexToRgba = (hex, alpha = 1) => {
@@ -84,9 +85,12 @@ const mixColors = (baseHex, tintHex, opacity) => {
   showAura = true,
   tintColor = '#ff0000',
   tintOpacity = 0,
+  showSpinner = true,
 }, ref) => {
   // Load token texture with CORS enabled so filters like tint work
-  const [img] = useImage(image, 'anonymous');
+  const [img, imgStatus] = useImage(image, 'anonymous');
+  const isImgLoading = !!image && imgStatus === 'loading';
+  const loadFailed = !!image && imgStatus === 'failed';
   const groupRef = useRef();
   const shapeRef = useRef();
   const trRef = useRef();
@@ -385,7 +389,23 @@ const mixColors = (baseHex, tintHex, opacity) => {
       {img ? (
         <KonvaImage ref={shapeRef} image={img} {...common} />
       ) : (
-        <Rect ref={shapeRef} fill={fillColor} {...common} />
+        <>
+          <Rect
+            ref={shapeRef}
+            {...common}
+            fill={isImgLoading ? undefined : fillColor}
+            fillEnabled={!isImgLoading}
+            strokeEnabled={false}
+          />
+          {isImgLoading && showSpinner && (
+            <KonvaSpinner
+              x={x + offX}
+              y={y + offY}
+              radius={Math.min(width, height) * gridSize * 0.3}
+              color="white"
+            />
+          )}
+        </>
       )}
       {selected && <Rect {...outline} />}
       {showName && (customName || name) && (
@@ -902,6 +922,7 @@ const MapCanvas = ({
                 opacity={0.35}
                 tintColor={dragShadow.tintColor}
                 tintOpacity={dragShadow.tintOpacity}
+                showSpinner={false}
                 showAura={canSeeAura(dragShadow)}
                 auraRadius={dragShadow.auraRadius}
                 auraShape={dragShadow.auraShape}


### PR DESCRIPTION
## Summary
- show loader while token textures load
- add `KonvaSpinner` component to animate a small spinner inside the canvas
- remove red placeholder while loading token images
- disable spinner for drag shadows
- document new behaviour in README

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6872617a6b788326b634c761dba5124e