### PR TITLE
Implement asset moving between folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,6 +436,9 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 **Resumen de cambios v2.3.3:**
 - La barra lateral de assets comienza en la parte superior y ocupa toda la altura del lado derecho.
 
+**Resumen de cambios v2.3.4:**
+- Puedes mover imágenes entre carpetas arrastrándolas y soltándolas sobre la carpeta de destino.
+
 ### 🛠️ **Características Técnicas**
 - **Interfaz responsive** - Optimizada para móviles y escritorio con TailwindCSS
 - **Persistencia en Firebase** - Almacenamiento seguro y sincronización en tiempo real


### PR DESCRIPTION
## Summary
- allow dragging an asset from one folder onto another to move it
- add drop targets for folder headers and icons
- include source folder id in drag item data
- document asset moving in README

## Testing
- `npm install`
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6872ac2f9b6c8326b0679f957aabf6c1