### PR TITLE
Fix sidebar flicker on asset hover

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 - **Nombre escalable** - La fuente del nombre aumenta si el token ocupa varias casillas
 - **Mini-barras en tokens** - Cada stat se muestra sobre el token mediante cápsulas interactivas y puedes elegir su posición
 - **Barras compactas** - Las barras de recursos son más pequeñas y están más cerca del token
+- **Corrección de miniaturas** - Eliminado el parpadeo al pasar el ratón por las imágenes del sidebar
 - **Ajustes al hacer doble clic** - Haz doble clic en un token para abrir su menú de configuración
 - **Iconos de control de tamaño fijo** - Engranaje, círculo de rotación y barras mantienen un tamaño constante al hacer zoom
 - **Mapas personalizados** - Sube una imagen como fondo en el Mapa de Batalla

--- a/src/components/AssetSidebar.jsx
+++ b/src/components/AssetSidebar.jsx
@@ -26,7 +26,8 @@ const AssetSidebar = ({ onAssetSelect, onDragStart, onDragEnd, className = '' })
   const [loaded, setLoaded] = useState(false);
   
   // Image preview data {url, x, y} shown on hover
-  const [preview, setPreview] = useState(null);
+  const [previewUrl, setPreviewUrl] = useState(null);
+  const previewRef = useRef(null);
   const isDragging = useDragLayer((monitor) => monitor.isDragging());
 
   useEffect(() => {
@@ -178,18 +179,27 @@ const AssetSidebar = ({ onAssetSelect, onDragStart, onDragEnd, className = '' })
   // Show preview of asset under the pointer
   const showPreview = (asset, e) => {
     if (isDragging) return;
-    setPreview({ url: asset.url, x: e.clientX, y: e.clientY });
+    setPreviewUrl(asset.url);
+    const el = previewRef.current;
+    if (el) {
+      el.style.top = `${e.clientY + 10}px`;
+      el.style.left = `${e.clientX + 10}px`;
+    }
   };
   const movePreview = (e) => {
     if (isDragging) return;
-    setPreview((p) => (p ? { ...p, x: e.clientX, y: e.clientY } : null));
+    const el = previewRef.current;
+    if (el) {
+      el.style.top = `${e.clientY + 10}px`;
+      el.style.left = `${e.clientX + 10}px`;
+    }
   };
   const hidePreview = () => {
-    if (!isDragging) setPreview(null);
+    if (!isDragging) setPreviewUrl(null);
   };
 
   const handleDragStart = () => {
-    setPreview(null);
+    setPreviewUrl(null);
   };
 
   const handleDragEnd = () => {
@@ -375,13 +385,14 @@ const AssetSidebar = ({ onAssetSelect, onDragStart, onDragEnd, className = '' })
           ))}
         </AnimatePresence>
       </div>
-      {preview && (
+      {previewUrl && (
         <div
+          ref={previewRef}
           className="pointer-events-none fixed z-50"
-          style={{ top: preview.y + 10, left: preview.x + 10 }}
+          style={{ top: 0, left: 0 }}
         >
           <img
-            src={preview.url}
+            src={previewUrl}
             alt="preview"
             className="max-w-[256px] max-h-[256px]"
           />


### PR DESCRIPTION
## Summary
- prevent sidebar re-renders when moving the image preview
- document the fix in the feature list

## Testing
- `CI=true npm test -- -u`

------
https://chatgpt.com/codex/tasks/task_e_6872be91d3008326a2a311483a9e2891