### PR TITLE
Fix sidebar flicker on token drag

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 - **Nombre escalable** - La fuente del nombre aumenta si el token ocupa varias casillas
 - **Mini-barras en tokens** - Cada stat se muestra sobre el token mediante cápsulas interactivas y puedes elegir su posición
 - **Barras compactas** - Las barras de recursos son más pequeñas y están más cerca del token
+- **Corrección de miniaturas** - Vista previa sin parpadeos al pasar el ratón sobre las imágenes del sidebar
 - **Ajustes al hacer doble clic** - Haz doble clic en un token para abrir su menú de configuración
 - **Iconos de control de tamaño fijo** - Engranaje, círculo de rotación y barras mantienen un tamaño constante al hacer zoom
 - **Mapas personalizados** - Sube una imagen como fondo en el Mapa de Batalla
@@ -446,7 +447,10 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 - Vista previa del token al arrastrar y movimiento más fluido entre carpetas.
 
 **Resumen de cambios v2.3.7:**
-- Corrección del parpadeo al arrastrar tokens y vista previa estable bajo el cursor.
+- Corrección del parpadeo al coger tokens y al pasar el cursor sobre las miniaturas.
+
+**Resumen de cambios v2.3.8:**
+- Actualización del arrastre para React DnD v14+ evitando la advertencia `spec.begin`.
 
 ### 🛠️ **Características Técnicas**
 - **Interfaz responsive** - Optimizada para móviles y escritorio con TailwindCSS


### PR DESCRIPTION
## Summary
- hide hover preview immediately on mousedown
- trigger drag callbacks directly from useDrag events
- document smoother token pickup in README
- fix deprecated useDrag `begin` callback

## Testing
- `CI=true npm test --silent -- -u`

------
https://chatgpt.com/codex/tasks/task_e_6872be91d3008326a2a311483a9e2891