### PR TITLE
Fix token name centering

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,6 +459,9 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 **Resumen de cambios v2.3.9:**
 - Se evita el parpadeo en **AssetSidebar** al mover fichas o abrir sus ajustes.
 
+**Resumen de cambios v2.3.10:**
+- Corrección de alineado: el nombre del token aparece centrado al cargar el stage.
+
 
 ### 🛠️ **Características Técnicas**
 - **Interfaz responsive** - Optimizada para móviles y escritorio con TailwindCSS

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -176,6 +176,11 @@ const mixColors = (baseHex, tintHex, opacity) => {
     handle.getLayer().batchDraw();
   };
 
+  // Ensure controls and name label are correctly positioned on mount
+  useEffect(() => {
+    updateHandle();
+  }, []);
+
   const updateSizes = () => {
     if (rotateRef.current) {
       rotateRef.current.radius(iconSize / 2);


### PR DESCRIPTION
## Summary
- ensure token names are centered when the stage loads
- document the fix in the README

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6872e0ce0a7c8326b4d99457c9a28792