### PR TITLE
Fix token name centering

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,6 +459,9 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 **Resumen de cambios v2.3.9:**
 - Se evita el parpadeo en **AssetSidebar** al mover fichas o abrir sus ajustes.
 
+**Resumen de cambios v2.3.10:**
+- El nombre de los tokens se centra correctamente al cargar el mapa.
+
 
 ### 🛠️ **Características Técnicas**
 - **Interfaz responsive** - Optimizada para móviles y escritorio con TailwindCSS

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -169,12 +169,21 @@ const mixColors = (baseHex, tintHex, opacity) => {
         y: box.y + box.height + HANDLE_OFFSET,
       });
     }
-    if (labelGroup && label) {
-      labelGroup.position({ x: box.x + box.width / 2, y: box.y + box.height + 4 });
-      labelGroup.offsetX(label.width() / 2);
-    }
+if (labelGroup && label) {
+  labelGroup.position({ x: box.x + box.width / 2, y: box.y + box.height + 4 });
+  labelGroup.offsetX(label.width() / 2);
+}
     handle.getLayer().batchDraw();
   };
+
+  useLayoutEffect(() => {
+    const label = textRef.current;
+    const group = textGroupRef.current;
+    if (label && group) {
+      group.offsetX(label.width() / 2);
+      group.getLayer()?.batchDraw();
+    }
+  }, [customName, name, cellSize]);
 
   const updateSizes = () => {
     if (rotateRef.current) {


### PR DESCRIPTION
## Summary
- ensure token name group always recenters using `useLayoutEffect`
- document new behaviour in README

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872e25a0d6483269faa343eaf5c9ed2