### PR TITLE
Fix MapCanvas hooks ESLint error

### DIFF
--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -1,4 +1,12 @@
-import React, { useRef, useState, useEffect, useCallback, forwardRef, useImperativeHandle } from 'react';
+import React, {
+  useRef,
+  useState,
+  useEffect,
+  useCallback,
+  forwardRef,
+  useImperativeHandle,
+  useLayoutEffect,
+} from 'react';
 import PropTypes from 'prop-types';
 import {
   Stage,
@@ -90,7 +98,6 @@ const mixColors = (baseHex, tintHex, opacity) => {
   // Load token texture with CORS enabled so filters like tint work
   const [img, imgStatus] = useImage(image, 'anonymous');
   const isImgLoading = !!image && imgStatus === 'loading';
-  const loadFailed = !!image && imgStatus === 'failed';
   const groupRef = useRef();
   const shapeRef = useRef();
   const trRef = useRef();


### PR DESCRIPTION
## Summary
- import `useLayoutEffect`
- remove unused `loadFailed` variable

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6872e99271188326ac0f361ab6e6ae7e