### PR TITLE
Fix token layer reordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,6 +470,12 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 **Resumen de cambios v2.3.12:**
 - Los tokens cargados desde Firebase ahora incluyen un índice **z** inicial para mantener su orden.
 
+**Resumen de cambios v2.3.13:**
+- Al eliminar un token, el orden de capa se normaliza para mantener índices consecutivos.
+
+**Resumen de cambios v2.3.14:**
+- Subir o bajar capa reordena la ficha correctamente para que se muestre por encima o debajo del resto.
+
 ### 🛠️ **Características Técnicas**
 - **Interfaz responsive** - Optimizada para móviles y escritorio con TailwindCSS
 - **Persistencia en Firebase** - Almacenamiento seguro y sincronización en tiempo real

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -29,7 +29,7 @@ import TokenBars from './TokenBars';
 import LoadingSpinner from './LoadingSpinner';
 import KonvaSpinner from './KonvaSpinner';
 import Konva from 'konva';
-import { normalizeZ } from '../utils/zOrder';
+import { normalizeZ, shiftZ } from '../utils/zOrder';
 
 const hexToRgba = (hex, alpha = 1) => {
   let h = hex.replace('#', '');
@@ -741,9 +741,7 @@ const MapCanvas = ({
   };
 
   const moveTokenLayer = (id, delta) => {
-    const updated = normalizeZ(
-      tokens.map((t) => (t.id === id ? { ...t, z: (t.z ?? 0) + delta } : t))
-    );
+    const updated = shiftZ(tokens, id, delta);
     onTokensChange(updated);
   };
 
@@ -830,7 +828,7 @@ const MapCanvas = ({
         x += 1;
         break;
       case 'delete':
-        onTokensChange(tokens.filter((t) => t.id !== selectedId));
+        onTokensChange(normalizeZ(tokens.filter((t) => t.id !== selectedId)));
         setSelectedId(null);
         return;
       case 'r': {

--- a/src/utils/zOrder.js
+++ b/src/utils/zOrder.js
@@ -8,3 +8,15 @@ export function normalizeZ(tokens = []) {
     .sort((a, b) => (a.z ?? 0) - (b.z ?? 0))
     .map((t, i) => ({ ...t, z: i }));
 }
+
+export function shiftZ(tokens = [], id, delta) {
+  const ordered = normalizeZ(tokens);
+  const index = ordered.findIndex((t) => t.id === id);
+  if (index === -1) return ordered;
+  let newIndex = index + delta;
+  newIndex = Math.max(0, Math.min(ordered.length - 1, newIndex));
+  if (newIndex === index) return ordered;
+  const [token] = ordered.splice(index, 1);
+  ordered.splice(newIndex, 0, token);
+  return ordered.map((t, i) => ({ ...t, z: i }));
+}


### PR DESCRIPTION
## Summary
- add `shiftZ` helper to reliably move tokens in z-order
- update MapCanvas to use `shiftZ` for layer controls
- document improved layer behaviour in README

## Testing
- `npx react-scripts test --runTestsByPath src/App.test.js --watchAll=false --silent`

------
https://chatgpt.com/codex/tasks/task_e_6872f4bf03e48326929f6d7f28dbf588