### PR TITLE
Add token layer controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 - **Zoom interactivo** - Acerca y aleja el mapa con la rueda del ratón
 - **Paneo con botón central** - Desplaza el mapa arrastrando con la rueda
 - **Sombra de arrastre** - Mientras arrastras un token queda una copia semitransparente en su casilla original
+- **Control de capas** - Desde Ajustes puedes subir o bajar un token para colocarlo encima o debajo de otros
 
 ### 🎲 **Gestión de Personajes**
 

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -739,6 +739,24 @@ const MapCanvas = ({
     setOpenSheetTokens((prev) => prev.filter((t) => t.tokenSheetId !== sheetId));
   };
 
+  const moveTokenToFront = (id) => {
+    const index = tokens.findIndex((t) => t.id === id);
+    if (index === -1) return;
+    const reordered = [...tokens];
+    const [token] = reordered.splice(index, 1);
+    reordered.push(token);
+    onTokensChange(reordered);
+  };
+
+  const moveTokenToBack = (id) => {
+    const index = tokens.findIndex((t) => t.id === id);
+    if (index === -1) return;
+    const reordered = [...tokens];
+    const [token] = reordered.splice(index, 1);
+    reordered.unshift(token);
+    onTokensChange(reordered);
+  };
+
   // Zoom interactivo con la rueda del ratón
   const handleWheel = (e) => {
     e.evt.preventDefault();
@@ -1024,6 +1042,8 @@ const MapCanvas = ({
             onTokensChange(updated);
           }}
           onOpenSheet={handleOpenSheet}
+          onMoveFront={() => moveTokenToFront(id)}
+          onMoveBack={() => moveTokenToBack(id)}
         />
       ))}
       {openSheetTokens.map((tk) => (

--- a/src/components/TokenSettings.jsx
+++ b/src/components/TokenSettings.jsx
@@ -5,7 +5,16 @@ import { FiX } from 'react-icons/fi';
 import Boton from './Boton';
 import Input from './Input';
 
-const TokenSettings = ({ token, enemies = [], players = [], onClose, onUpdate, onOpenSheet }) => {
+const TokenSettings = ({
+  token,
+  enemies = [],
+  players = [],
+  onClose,
+  onUpdate,
+  onOpenSheet,
+  onMoveFront,
+  onMoveBack,
+}) => {
   const [tab, setTab] = useState('details');
   const [pos, setPos] = useState({ x: window.innerWidth / 2 - 160, y: window.innerHeight / 2 - 140 });
   const [dragging, setDragging] = useState(false);
@@ -192,13 +201,17 @@ const TokenSettings = ({ token, enemies = [], players = [], onClose, onUpdate, o
                       auraVisibility,
                       opacity: tokenOpacity,
                       tintColor,
-                      tintOpacity,
-                    };
-                    onOpenSheet(updated);
-                  }}
-                >
-                  Abrir ficha de personaje
-                </Boton>
+                    tintOpacity,
+                  };
+                  onOpenSheet(updated);
+                }}
+              >
+                Abrir ficha de personaje
+              </Boton>
+              <div className="flex justify-center gap-2 mt-2">
+                <Boton size="sm" onClick={() => onMoveBack?.()}>Bajar capa</Boton>
+                <Boton size="sm" onClick={() => onMoveFront?.()}>Subir capa</Boton>
+              </div>
               </div>
             </>
           )}
@@ -264,6 +277,8 @@ TokenSettings.propTypes = {
   onClose: PropTypes.func.isRequired,
   onUpdate: PropTypes.func.isRequired,
   onOpenSheet: PropTypes.func.isRequired,
+  onMoveFront: PropTypes.func,
+  onMoveBack: PropTypes.func,
 };
 
 export default TokenSettings;


### PR DESCRIPTION
## Summary
- enable reordering tokens on canvas
- expose layer controls in token settings
- document layer controls in README

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6872fe989e888326baca9b9cc1205529