### PR TITLE
Increase token state icon size

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 - **Corrección de miniaturas** - Vista previa sin parpadeos al pasar el ratón sobre las imágenes del sidebar
 - **Ajustes al hacer doble clic** - Haz doble clic en un token para abrir su menú de configuración
 - **Iconos de control de tamaño fijo** - Engranaje, círculo de rotación y barras mantienen un tamaño constante al hacer zoom
+- **Estados en tokens** - Nuevo botón para aplicar condiciones como Envenenado o Cansado y mostrar sus iconos, ahora aún más grandes, sobre la ficha
+- **Botones de estados y ajustes más grandes** - El engranaje y el acceso a estados son más visibles al seleccionar una ficha
 - **Mapas personalizados** - Sube una imagen como fondo en el Mapa de Batalla
 - **Grid ajustable** - Tamaño y desplazamiento de la cuadrícula configurables
 - **Mapa adaptable** - La imagen se ajusta al viewport manteniendo su proporción

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -23,7 +23,9 @@ import useImage from 'use-image';
 import { useDrop } from 'react-dnd';
 import { AssetTypes } from './AssetSidebar';
 import TokenSettings from './TokenSettings';
+import TokenEstadoMenu from './TokenEstadoMenu';
 import TokenSheetModal from './TokenSheetModal';
+import { ESTADOS } from './EstadoSelector';
 import { nanoid } from 'nanoid';
 import TokenBars from './TokenBars';
 import LoadingSpinner from './LoadingSpinner';
@@ -107,6 +109,16 @@ TokenAura.propTypes = {
   auraOpacity: PropTypes.number,
   showAura: PropTypes.bool,
 };
+
+const EstadoImg = ({ src, ...props }) => {
+  const [img] = useImage(src, 'anonymous');
+  if (!img) return null;
+  return <KonvaImage image={img} listening={false} {...props} />;
+};
+
+EstadoImg.propTypes = {
+  src: PropTypes.string.isRequired,
+};
   const Token = forwardRef(({
   id,
   x,
@@ -136,6 +148,7 @@ TokenAura.propTypes = {
   onTransformEnd,
   onRotate,
   onSettings,
+  onStates,
   onHoverChange,
   tokenSheetId,
   auraRadius = 0,
@@ -146,6 +159,7 @@ TokenAura.propTypes = {
   tintColor = '#ff0000',
   tintOpacity = 0,
   showSpinner = true,
+  estados = [],
 }, ref) => {
   // Load token texture with CORS enabled so filters like tint work
   const [img, imgStatus] = useImage(image, 'anonymous');
@@ -155,10 +169,20 @@ TokenAura.propTypes = {
   const trRef = useRef();
   const rotateRef = useRef();
   const gearRef = useRef();
+  const estadosRef = useRef();
   const textRef = useRef();
   const textGroupRef = useRef();
   const HANDLE_OFFSET = 12;
   const iconSize = cellSize * 0.15;
+  const buttonSize = cellSize * 0.22;
+  const estadoBase = cellSize * 0.3;
+  const estadosInfo = estados
+    .map((id) => ESTADOS.find((e) => e.id === id))
+    .filter(Boolean);
+  const estadoSize =
+    estadosInfo.length > 0
+      ? Math.min(estadoBase, (width * gridSize) / estadosInfo.length)
+      : estadoBase;
   const nameFontSize = Math.max(10, cellSize * 0.12 * Math.min(Math.max(width, height), 2));
   const [stats, setStats] = useState({});
 
@@ -228,6 +252,12 @@ TokenAura.propTypes = {
         y: box.y + box.height + HANDLE_OFFSET,
       });
     }
+    if (estadosRef.current) {
+      estadosRef.current.position({
+        x: box.x - HANDLE_OFFSET + buttonSize + 4,
+        y: box.y + box.height + HANDLE_OFFSET,
+      });
+    }
 if (labelGroup && label) {
   labelGroup.position({ x: box.x + box.width / 2, y: box.y + box.height + 4 });
   labelGroup.offsetX(label.width() / 2);
@@ -247,7 +277,10 @@ if (labelGroup && label) {
       rotateRef.current.radius(iconSize / 2);
     }
     if (gearRef.current) {
-      gearRef.current.fontSize(iconSize);
+      gearRef.current.fontSize(buttonSize);
+    }
+    if (estadosRef.current) {
+      estadosRef.current.fontSize(buttonSize);
     }
   };
 
@@ -474,6 +507,20 @@ if (labelGroup && label) {
         </>
       )}
       {selected && <Rect {...outline} />}
+      {estadosInfo.length > 0 && (
+        <Group listening={false}>
+          {estadosInfo.map((e, i) => (
+            <EstadoImg
+              key={e.id}
+              src={e.img}
+              x={x + width * gridSize - estadoSize * (i + 1)}
+              y={y - estadoSize - 2}
+              width={estadoSize}
+              height={estadoSize}
+            />
+          ))}
+        </Group>
+      )}
       {showName && (customName || name) && (
         <Group
           ref={textGroupRef}
@@ -540,9 +587,16 @@ if (labelGroup && label) {
           <Text
             ref={gearRef}
             text="⚙️"
-            fontSize={iconSize}
+            fontSize={buttonSize}
             listening
             onClick={() => onSettings?.(id)}
+          />
+          <Text
+            ref={estadosRef}
+            text="🩸"
+            fontSize={buttonSize}
+            listening
+            onClick={() => onStates?.(id)}
           />
         </>
       )}
@@ -586,7 +640,9 @@ Token.propTypes = {
   onTransformEnd: PropTypes.func.isRequired,
   onRotate: PropTypes.func.isRequired,
   onSettings: PropTypes.func,
+  onStates: PropTypes.func,
   onHoverChange: PropTypes.func,
+  estados: PropTypes.array,
   tokenSheetId: PropTypes.string,
 };
 
@@ -629,6 +685,7 @@ const MapCanvas = ({
   const [hoveredId, setHoveredId] = useState(null);
   const [dragShadow, setDragShadow] = useState(null);
   const [settingsTokenIds, setSettingsTokenIds] = useState([]);
+  const [estadoTokenIds, setEstadoTokenIds] = useState([]);
   const [openSheetTokens, setOpenSheetTokens] = useState([]);
   const tokenRefs = useRef({});
   const panStart = useRef({ x: 0, y: 0 });
@@ -777,6 +834,14 @@ const MapCanvas = ({
 
   const handleCloseSettings = (id) => {
     setSettingsTokenIds((prev) => prev.filter((sid) => sid !== id));
+  };
+
+  const handleOpenEstados = (id) => {
+    setEstadoTokenIds((prev) => (prev.includes(id) ? prev : [...prev, id]));
+  };
+
+  const handleCloseEstados = (id) => {
+    setEstadoTokenIds((prev) => prev.filter((sid) => sid !== id));
   };
 
   const handleOpenSheet = (token) => {
@@ -954,6 +1019,7 @@ const MapCanvas = ({
           opacity: 1,
           tintColor: '#ff0000',
           tintOpacity: 0,
+          estados: [],
         };
         onTokensChange([...tokens, newToken]);
       },
@@ -1092,9 +1158,11 @@ const MapCanvas = ({
                 onDragStart={handleDragStart}
                 onClick={setSelectedId}
                 onSettings={handleOpenSettings}
+                onStates={handleOpenEstados}
                 onTransformEnd={handleSizeChange}
                 onRotate={handleRotateChange}
                 onHoverChange={(h) => setHoveredId(h ? token.id : null)}
+                estados={token.estados || []}
               />
             ))}
           </Group>
@@ -1127,6 +1195,17 @@ const MapCanvas = ({
           onOpenSheet={handleOpenSheet}
           onMoveFront={() => moveTokenToFront(id)}
           onMoveBack={() => moveTokenToBack(id)}
+        />
+      ))}
+      {estadoTokenIds.map((id) => (
+        <TokenEstadoMenu
+          key={id}
+          token={tokens.find((t) => t.id === id)}
+          onClose={() => handleCloseEstados(id)}
+          onUpdate={(tk) => {
+            const updated = tokens.map((t) => (t.id === tk.id ? tk : t));
+            onTokensChange(updated);
+          }}
         />
       ))}
       {openSheetTokens.map((tk) => (
@@ -1180,6 +1259,7 @@ MapCanvas.propTypes = {
       opacity: PropTypes.number,
       tintColor: PropTypes.string,
       tintOpacity: PropTypes.number,
+      estados: PropTypes.array,
     })
   ).isRequired,
   onTokensChange: PropTypes.func.isRequired,

--- a/src/components/TokenEstadoMenu.jsx
+++ b/src/components/TokenEstadoMenu.jsx
@@ -1,0 +1,43 @@
+import React, { useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
+import { createPortal } from 'react-dom';
+import { FiX } from 'react-icons/fi';
+import EstadoSelector from './EstadoSelector';
+
+const TokenEstadoMenu = ({ token, onClose, onUpdate }) => {
+  const [selected, setSelected] = useState(token.estados || []);
+
+  useEffect(() => {
+    onUpdate({ ...token, estados: selected });
+  }, [selected]);
+
+  const toggle = (id) => {
+    setSelected((prev) =>
+      prev.includes(id) ? prev.filter((e) => e !== id) : [...prev, id]
+    );
+  };
+
+  const content = (
+    <div className="fixed inset-0 flex items-center justify-center z-50">
+      <div className="bg-gray-800 border border-gray-700 rounded shadow-xl p-4 max-w-md">
+        <div className="flex justify-between items-center mb-2">
+          <span className="font-bold">Estados</span>
+          <button onClick={onClose} className="text-gray-400 hover:text-red-400">
+            <FiX />
+          </button>
+        </div>
+        <EstadoSelector selected={selected} onToggle={toggle} />
+      </div>
+    </div>
+  );
+
+  return createPortal(content, document.body);
+};
+
+TokenEstadoMenu.propTypes = {
+  token: PropTypes.object.isRequired,
+  onClose: PropTypes.func.isRequired,
+  onUpdate: PropTypes.func.isRequired,
+};
+
+export default TokenEstadoMenu;


### PR DESCRIPTION
## Summary
- bump applied state icon base size in `MapCanvas`
- mention even bigger state icons in README
- add button to open token status menu
- document token state menu in README
- fix stage rendering when states are initialized
- enlarge token settings and states buttons

## Testing
- `npm install --silent`
- `npm test --silent`
- `CI=true npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_687309f0a3848326a42a636144ff8f8a