### PR TITLE
Increase token state icon size

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 - **Corrección de miniaturas** - Vista previa sin parpadeos al pasar el ratón sobre las imágenes del sidebar
 - **Ajustes al hacer doble clic** - Haz doble clic en un token para abrir su menú de configuración
 - **Iconos de control de tamaño fijo** - Engranaje, círculo de rotación y barras mantienen un tamaño constante al hacer zoom
+- **Estados en tokens** - Nuevo botón para aplicar condiciones como Envenenado o Cansado y mostrar sus iconos, ahora aún más grandes, sobre la ficha
+- **Botones de estados y ajustes ajustados** - El engranaje y el acceso a estados mantienen un tamaño equilibrado
 - **Mapas personalizados** - Sube una imagen como fondo en el Mapa de Batalla
 - **Grid ajustable** - Tamaño y desplazamiento de la cuadrícula configurables
 - **Mapa adaptable** - La imagen se ajusta al viewport manteniendo su proporción

--- a/src/components/TokenEstadoMenu.jsx
+++ b/src/components/TokenEstadoMenu.jsx
@@ -1,0 +1,43 @@
+import React, { useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
+import { createPortal } from 'react-dom';
+import { FiX } from 'react-icons/fi';
+import EstadoSelector from './EstadoSelector';
+
+const TokenEstadoMenu = ({ token, onClose, onUpdate }) => {
+  const [selected, setSelected] = useState(token.estados || []);
+
+  useEffect(() => {
+    onUpdate({ ...token, estados: selected });
+  }, [selected]);
+
+  const toggle = (id) => {
+    setSelected((prev) =>
+      prev.includes(id) ? prev.filter((e) => e !== id) : [...prev, id]
+    );
+  };
+
+  const content = (
+    <div className="fixed inset-0 flex items-center justify-center z-50">
+      <div className="bg-gray-800 border border-gray-700 rounded shadow-xl p-4 max-w-md">
+        <div className="flex justify-between items-center mb-2">
+          <span className="font-bold">Estados</span>
+          <button onClick={onClose} className="text-gray-400 hover:text-red-400">
+            <FiX />
+          </button>
+        </div>
+        <EstadoSelector selected={selected} onToggle={toggle} />
+      </div>
+    </div>
+  );
+
+  return createPortal(content, document.body);
+};
+
+TokenEstadoMenu.propTypes = {
+  token: PropTypes.object.isRequired,
+  onClose: PropTypes.func.isRequired,
+  onUpdate: PropTypes.func.isRequired,
+};
+
+export default TokenEstadoMenu;


### PR DESCRIPTION
## Summary
- bump applied state icon base size in `MapCanvas`
- mention even bigger state icons in README
- add button to open token status menu
- document token state menu in README
- fix stage rendering when states are initialized
- enlarge token settings and states buttons
- shrink settings button to size 0.4 and match states button

## Testing
- `npm install --silent`
- `npm test --silent`
- `CI=true npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_687309f0a3848326a42a636144ff8f8a