### PR TITLE
Add chat persistence and input in asset sidebar

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,6 +465,12 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 **Resumen de cambios v2.3.10:**
 - El nombre de los tokens se centra correctamente al cargar el mapa.
 
+**Resumen de cambios v2.3.11:**
+- La barra lateral de assets incluye botones para alternar entre gestión de carpetas y un nuevo chat (aún sin funcionalidad).
+
+**Resumen de cambios v2.3.12:**
+- El chat de la barra lateral ahora permite enviar mensajes como "Master" y mantiene el historial.
+
 ### 🛠️ **Características Técnicas**
 - **Interfaz responsive** - Optimizada para móviles y escritorio con TailwindCSS
 - **Persistencia en Firebase** - Almacenamiento seguro y sincronización en tiempo real


### PR DESCRIPTION
## Summary
- make chat tab button come first in AssetSidebar
- implement persistent chat messages with localStorage
- allow entering messages labeled "Master"
- document feature in README

## Testing
- `npm test --silent`
- `CI=true npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68739c99832c832682b96c74119771c3