### PR TITLE
Store sidebar chat in Firebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,6 +471,9 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 **Resumen de cambios v2.3.12:**
 - El chat de la barra lateral ahora permite enviar mensajes como "Master" y mantiene el historial.
 
+**Resumen de cambios v2.3.13:**
+- Los mensajes del chat se guardan en Firebase y solo el Máster puede eliminarlos.
+
 ### 🛠️ **Características Técnicas**
 - **Interfaz responsive** - Optimizada para móviles y escritorio con TailwindCSS
 - **Persistencia en Firebase** - Almacenamiento seguro y sincronización en tiempo real

--- a/src/App.js
+++ b/src/App.js
@@ -3163,7 +3163,7 @@ function App() {
               playerName={playerName}
             />
           </div>
-          <AssetSidebar />
+          <AssetSidebar isMaster={authenticated} playerName={playerName} />
         </div>
       </div>
     );


### PR DESCRIPTION
## Summary
- persist sidebar chat to Firestore
- allow only the Master to remove messages
- pass Master/player info into `AssetSidebar`
- document new behaviour in README

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6873bd7519148326a52b712b20623f16