### PR TITLE
Add dice rolling to chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -477,6 +477,9 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 **Resumen de cambios v2.3.14:**
 - El botón para eliminar mensajes se mantiene visible incluso con textos largos.
 
+**Resumen de cambios v2.3.15:**
+- El chat reconoce tiradas como `2d6+1` o cálculos matemáticos y muestra el resultado.
+
 ### 🛠️ **Características Técnicas**
 - **Interfaz responsive** - Optimizada para móviles y escritorio con TailwindCSS
 - **Persistencia en Firebase** - Almacenamiento seguro y sincronización en tiempo real

--- a/src/utils/dice.js
+++ b/src/utils/dice.js
@@ -1,0 +1,51 @@
+export const parseAndRollFormula = (formula) => {
+  const cleanFormula = formula.replace(/\s/g, '').toLowerCase();
+  const diceRegex = /(\d*)d(\d+)/g;
+  const modifierRegex = /[+-]\d+/g;
+
+  let total = 0;
+  let details = [];
+
+  let match;
+  while ((match = diceRegex.exec(cleanFormula)) !== null) {
+    const count = parseInt(match[1]) || 1;
+    const sides = parseInt(match[2]);
+    const rolls = [];
+    for (let i = 0; i < count; i++) {
+      const roll = Math.floor(Math.random() * sides) + 1;
+      rolls.push(roll);
+      total += roll;
+    }
+    details.push({
+      type: 'dice',
+      formula: `${count}d${sides}`,
+      rolls,
+      subtotal: rolls.reduce((sum, r) => sum + r, 0),
+    });
+  }
+
+  const modifiers = cleanFormula.match(modifierRegex) || [];
+  modifiers.forEach((mod) => {
+    const value = parseInt(mod);
+    total += value;
+    details.push({ type: 'modifier', value, formula: mod });
+  });
+
+  return { total, details };
+};
+
+export const rollExpression = (expr) => {
+  const formula = expr.trim();
+  if (!formula) throw new Error('Empty expression');
+
+  if (!/\d+d\d+/i.test(formula)) {
+    const safe = formula.replace(/[^0-9+\-*/().,% ]/g, '');
+    const safeEval = safe.replace(/(\d+(?:\.\d+)?)%/g, '($1/100)');
+    // eslint-disable-next-line no-eval
+    const total = eval(safeEval);
+    if (typeof total !== 'number' || isNaN(total)) throw new Error('Invalid');
+    return { formula: expr, total, details: [{ type: 'calc', formula: safe, value: total }] };
+  }
+  const parsed = parseAndRollFormula(formula);
+  return { formula: expr, total: parsed.total, details: parsed.details };
+};


### PR DESCRIPTION
## Summary
- expose dice parsing utilities
- reuse dice utils inside dice calculator component
- enable dice and math rolls in chat messages
- document chat dice rolling feature

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687401859e28832688fcaedb8b1472c8