### PR TITLE
Add toolbar for map tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 - **Sombra de arrastre** - Mientras arrastras un token queda una copia semitransparente en su casilla original
 - **Control de capas** - Desde Ajustes puedes subir o bajar un token para colocarlo encima o debajo de otros
 - **Auras siempre debajo** - El aura de un token nunca se superpone sobre los demás, incluso al cambiar su capa
+- **Barra de herramientas vertical** - Modos de selección, dibujo, medición y texto independientes del zoom
 
 ### 🎲 **Gestión de Personajes**
 

--- a/src/components/Toolbar.jsx
+++ b/src/components/Toolbar.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { FiMousePointer, FiEdit2, FiRuler, FiType } from 'react-icons/fi';
+
+const tools = [
+  { id: 'select', icon: FiMousePointer },
+  { id: 'draw', icon: FiEdit2 },
+  { id: 'measure', icon: FiRuler },
+  { id: 'text', icon: FiType },
+];
+
+const Toolbar = ({ activeTool, onSelect }) => (
+  <div className="fixed left-0 top-0 bottom-0 w-12 bg-gray-800 z-50 flex flex-col items-center py-2 space-y-2">
+    {tools.map(({ id, icon: Icon }) => (
+      <button
+        key={id}
+        onClick={() => onSelect(id)}
+        className={`w-10 h-10 flex items-center justify-center rounded transition-colors ${
+          activeTool === id ? 'bg-gray-700' : 'bg-gray-800 hover:bg-gray-700'
+        }`}
+      >
+        <Icon />
+      </button>
+    ))}
+  </div>
+);
+
+Toolbar.propTypes = {
+  activeTool: PropTypes.string.isRequired,
+  onSelect: PropTypes.func.isRequired,
+};
+
+export default Toolbar;


### PR DESCRIPTION
## Summary
- implement vertical Toolbar component
- add drawing/measure/text modes in MapCanvas
- show toolbar in map
- document new toolbar feature in README

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68740a86662c8326ad6aec7bb672da51