### PR TITLE
Add toolbar for map tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 - **Sombra de arrastre** - Mientras arrastras un token queda una copia semitransparente en su casilla original
 - **Control de capas** - Desde Ajustes puedes subir o bajar un token para colocarlo encima o debajo de otros
 - **Auras siempre debajo** - El aura de un token nunca se superpone sobre los demás, incluso al cambiar su capa
+- **Barra de herramientas vertical** - Modos de selección, dibujo, medición y texto independientes del zoom
+- **Mapa desplazado** - El mapa se ajusta para que la barra de herramientas no oculte la cabecera ni los controles
+- **Ajustes de dibujo** - Selector de color y tamaño de pincel al usar la herramienta Dibujar
 
 ### 🎲 **Gestión de Personajes**
 

--- a/src/App.js
+++ b/src/App.js
@@ -3095,7 +3095,7 @@ function App() {
   }
   if (userType === 'master' && authenticated && chosenView === 'canvas') {
     return (
-      <div className="h-screen flex flex-col bg-gray-900 text-gray-100 p-4 overflow-hidden">
+      <div className="h-screen flex flex-col bg-gray-900 text-gray-100 p-4 pl-16 overflow-hidden">
         <div className="sticky top-0 bg-gray-900 z-10 h-14 flex items-center justify-between mb-4 mr-80">
           <h1 className="text-2xl font-bold">🗺️ Mapa de Batalla</h1>
           <div className="flex flex-wrap gap-2">

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -31,6 +31,7 @@ import TokenBars from './TokenBars';
 import LoadingSpinner from './LoadingSpinner';
 import KonvaSpinner from './KonvaSpinner';
 import Konva from 'konva';
+import Toolbar from './Toolbar';
 
 const hexToRgba = (hex, alpha = 1) => {
   let h = hex.replace('#', '');
@@ -56,6 +57,12 @@ const mixColors = (baseHex, tintHex, opacity) => {
   const g = Math.round(base.g * (1 - opacity) + tint.g * opacity);
   const b = Math.round(base.b * (1 - opacity) + tint.b * opacity);
   return `rgb(${r},${g},${b})`;
+};
+
+const BRUSH_WIDTHS = {
+  small: 2,
+  medium: 4,
+  large: 6,
 };
 
 const TokenAura = ({
@@ -694,6 +701,13 @@ const MapCanvas = ({
   const [settingsTokenIds, setSettingsTokenIds] = useState([]);
   const [estadoTokenIds, setEstadoTokenIds] = useState([]);
   const [openSheetTokens, setOpenSheetTokens] = useState([]);
+  const [activeTool, setActiveTool] = useState('select');
+  const [lines, setLines] = useState([]);
+  const [currentLine, setCurrentLine] = useState(null);
+  const [measureLine, setMeasureLine] = useState(null);
+  const [texts, setTexts] = useState([]);
+  const [drawColor, setDrawColor] = useState('#ffffff');
+  const [brushSize, setBrushSize] = useState('medium');
   const tokenRefs = useRef({});
   const panStart = useRef({ x: 0, y: 0 });
   const panOrigin = useRef({ x: 0, y: 0 });
@@ -903,20 +917,56 @@ const MapCanvas = ({
     });
   };
 
-  // Iniciar paneo con el botón central del ratón
+  // Iniciar acciones según la herramienta seleccionada
   const handleMouseDown = (e) => {
-    if (e.evt.button === 1) {
+    if (activeTool === 'select' && e.evt.button === 1) {
       e.evt.preventDefault();
       setIsPanning(true);
       panStart.current = stageRef.current.getPointerPosition();
       panOrigin.current = { ...groupPos };
     }
+    if (activeTool === 'draw' && e.evt.button === 0) {
+      const pointer = stageRef.current.getPointerPosition();
+      const relX = (pointer.x - groupPos.x) / (baseScale * zoom);
+      const relY = (pointer.y - groupPos.y) / (baseScale * zoom);
+      setCurrentLine({
+        points: [relX, relY],
+        color: drawColor,
+        width: BRUSH_WIDTHS[brushSize],
+      });
+    }
+    if (activeTool === 'measure' && e.evt.button === 0) {
+      const pointer = stageRef.current.getPointerPosition();
+      const relX = (pointer.x - groupPos.x) / (baseScale * zoom);
+      const relY = (pointer.y - groupPos.y) / (baseScale * zoom);
+      setMeasureLine([relX, relY, relX, relY]);
+    }
+    if (activeTool === 'text' && e.evt.button === 0) {
+      const pointer = stageRef.current.getPointerPosition();
+      const relX = (pointer.x - groupPos.x) / (baseScale * zoom);
+      const relY = (pointer.y - groupPos.y) / (baseScale * zoom);
+      const content = prompt('Texto:', 'Nuevo texto');
+      if (content) setTexts((t) => [...t, { x: relX, y: relY, text: content }]);
+    }
   };
 
-  // Actualiza la posición del grupo durante el paneo
+  // Actualiza la acción activa según la herramienta
   const handleMouseMove = () => {
-    if (!isPanning) return;
     const pointer = stageRef.current.getPointerPosition();
+    const relX = (pointer.x - groupPos.x) / (baseScale * zoom);
+    const relY = (pointer.y - groupPos.y) / (baseScale * zoom);
+    if (currentLine) {
+      setCurrentLine((ln) => ({
+        ...ln,
+        points: [...ln.points, relX, relY],
+      }));
+      return;
+    }
+    if (measureLine) {
+      setMeasureLine(([x1, y1]) => [x1, y1, relX, relY]);
+      return;
+    }
+    if (!isPanning) return;
     setGroupPos({
       x: panOrigin.current.x + (pointer.x - panStart.current.x),
       y: panOrigin.current.y + (pointer.y - panStart.current.y),
@@ -924,6 +974,11 @@ const MapCanvas = ({
   };
 
   const stopPanning = () => {
+    if (currentLine) {
+      setLines((ls) => [...ls, currentLine]);
+      setCurrentLine(null);
+    }
+    if (measureLine) setMeasureLine(null);
     if (isPanning) setIsPanning(false);
   };
 
@@ -1170,7 +1225,43 @@ const MapCanvas = ({
                 onRotate={handleRotateChange}
                 onHoverChange={(h) => setHoveredId(h ? token.id : null)}
                 estados={token.estados || []}
+                draggable={activeTool === 'select'}
+                listening={activeTool === 'select'}
               />
+            ))}
+            {lines.map((ln, i) => (
+              <Line
+                key={`line-${i}`}
+                points={ln.points}
+                stroke={ln.color}
+                strokeWidth={ln.width}
+                lineCap="round"
+                lineJoin="round"
+              />
+            ))}
+            {currentLine && (
+              <Line
+                points={currentLine.points}
+                stroke={currentLine.color}
+                strokeWidth={currentLine.width}
+                lineCap="round"
+                lineJoin="round"
+              />
+            )}
+            {measureLine && (
+              <>
+                <Line points={measureLine} stroke="cyan" strokeWidth={2} dash={[4, 4]} />
+                <Text
+                  x={measureLine[2]}
+                  y={measureLine[3]}
+                  text={`${Math.round(Math.hypot(pxToCell(measureLine[2], gridOffsetX) - pxToCell(measureLine[0], gridOffsetX), pxToCell(measureLine[3], gridOffsetY) - pxToCell(measureLine[1], gridOffsetY)))} casillas`}
+                  fontSize={16}
+                  fill="#fff"
+                />
+              </>
+            )}
+            {texts.map((t, i) => (
+              <Text key={`text-${i}`} x={t.x} y={t.y} text={t.text} fontSize={20} fill="#fff" />
             ))}
           </Group>
         </Layer>
@@ -1182,12 +1273,20 @@ const MapCanvas = ({
               stageRef={stageRef}
               onStatClick={(key, e) => tokenRefs.current[token.id]?.handleStatClick(key, e)}
               transformKey={`${groupPos.x},${groupPos.y},${groupScale},${token.x},${token.y},${token.w},${token.h},${token.angle}`}
-              visible={hoveredId === token.id && canSeeBars(token)}
+              visible={activeTool === 'select' && hoveredId === token.id && canSeeBars(token)}
             />
           ))}
         </Layer>
         </Stage>
       </div>
+      <Toolbar
+        activeTool={activeTool}
+        onSelect={setActiveTool}
+        drawColor={drawColor}
+        onColorChange={setDrawColor}
+        brushSize={brushSize}
+        onBrushSizeChange={setBrushSize}
+      />
       {settingsTokenIds.map((id) => (
         <TokenSettings
           key={id}

--- a/src/components/Toolbar.jsx
+++ b/src/components/Toolbar.jsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { FiMousePointer, FiEdit2, FiType } from 'react-icons/fi';
+import { FaRuler } from 'react-icons/fa';
+
+const tools = [
+  { id: 'select', icon: FiMousePointer },
+  { id: 'draw', icon: FiEdit2 },
+  { id: 'measure', icon: FaRuler },
+  { id: 'text', icon: FiType },
+];
+
+const brushOptions = [
+  { id: 'small', label: 'S' },
+  { id: 'medium', label: 'M' },
+  { id: 'large', label: 'L' },
+];
+
+const Toolbar = ({
+  activeTool,
+  onSelect,
+  drawColor,
+  onColorChange,
+  brushSize,
+  onBrushSizeChange,
+}) => (
+  <div className="fixed left-0 top-0 bottom-0 w-12 bg-gray-800 z-50 flex flex-col items-center py-2 space-y-2">
+    {tools.map(({ id, icon: Icon }) => (
+      <button
+        key={id}
+        onClick={() => onSelect(id)}
+        className={`w-10 h-10 flex items-center justify-center rounded transition-colors ${
+          activeTool === id ? 'bg-gray-700' : 'bg-gray-800 hover:bg-gray-700'
+        }`}
+      >
+        <Icon />
+      </button>
+    ))}
+    {activeTool === 'draw' && (
+      <div className="absolute left-12 top-2 bg-gray-800 p-2 rounded shadow-lg space-y-2">
+        <input
+          type="color"
+          value={drawColor}
+          onChange={(e) => onColorChange(e.target.value)}
+          className="w-8 h-8 p-0 border-0"
+        />
+        <div className="flex space-x-1">
+          {brushOptions.map(({ id, label }) => (
+            <button
+              key={id}
+              onClick={() => onBrushSizeChange(id)}
+              className={`px-2 py-1 rounded text-sm ${
+                brushSize === id ? 'bg-gray-700' : 'bg-gray-600'
+              }`}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      </div>
+    )}
+  </div>
+);
+
+Toolbar.propTypes = {
+  activeTool: PropTypes.string.isRequired,
+  onSelect: PropTypes.func.isRequired,
+  drawColor: PropTypes.string,
+  onColorChange: PropTypes.func,
+  brushSize: PropTypes.string,
+  onBrushSizeChange: PropTypes.func,
+};
+
+export default Toolbar;


### PR DESCRIPTION
## Summary
- implement vertical Toolbar component
- add drawing/measure/text modes in MapCanvas
- show toolbar in map
- document new toolbar feature in README
- offset map content so toolbar doesn't cover UI
- move map a bit further right so header elements are clear
- add color picker and brush size settings for the draw tool

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68740a86662c8326ad6aec7bb672da51