### PR TITLE
Fix JSX syntax error in MapCanvas

### DIFF
--- a/README.md
+++ b/README.md
@@ -685,6 +685,7 @@ src/
 - **Sistema de Píldoras de Equipamiento** - Nuevas píldoras interactivas en el Sistema de Velocidad que permiten usar armas y poderes equipados directamente
 - **Mejoras en Sistema de Velocidad** - Los jugadores ahora pueden eliminar sus propios participantes, no solo el master
 - **Botón de papelera mejorado** - Color rojo consistente con el sistema de velocidad en inventario y línea de sucesos
+- **Corrección de error en MapCanvas** - Paréntesis faltante causaba fallo de compilación
 - **Consumo de velocidad inteligente** - Las píldoras muestran el consumo real basado en emojis 🟡 del equipamiento
 - **Interfaz más intuitiva** - Píldoras organizadas por color (azul para armas, morado para poderes) sin subtítulos
 

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -1116,7 +1116,7 @@ const MapCanvas = ({
                 height={imageSize.height}
                 listening={false}
               />
-            )}
+            ))}
             {drawGrid()}
             <Group listening={false}>
               {dragShadow && (
@@ -1238,7 +1238,7 @@ const MapCanvas = ({
                 lineCap="round"
                 lineJoin="round"
               />
-            )}
+            ))}
             {measureLine && (
               <>
                 <Line points={measureLine} stroke="cyan" strokeWidth={2} dash={[4, 4]} />


### PR DESCRIPTION
## Summary
- fix missing closing parenthesis in MapCanvas line rendering
- document MapCanvas fix in README

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68742e02cfb883269d67f039390d94fa