### PR TITLE
Fix extra parenthesis in MapCanvas

### DIFF
--- a/README.md
+++ b/README.md
@@ -613,6 +613,10 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 
 - El resultado de las tiradas en el chat ahora se presenta con el mismo estilo que la calculadora de dados.
 
+**Resumen de cambios v2.3.17:**
+
+- Corrección de paréntesis duplicado en **MapCanvas** que impedía compilar la aplicación.
+
 ### 🛠️ **Características Técnicas**
 
 - **Interfaz responsive** - Optimizada para móviles y escritorio con TailwindCSS

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -1116,7 +1116,7 @@ const MapCanvas = ({
                 height={imageSize.height}
                 listening={false}
               />
-            ))}
+            )}
             {drawGrid()}
             <Group listening={false}>
               {dragShadow && (


### PR DESCRIPTION
## Summary
- fix syntax error in MapCanvas JSX
- document MapCanvas fix in README

## Testing
- `npm run lint`
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6874306fed448326a5451197eeb3cd45