### PR TITLE
Fix extra parenthesis in MapCanvas

### DIFF
--- a/README.md
+++ b/README.md
@@ -613,6 +613,14 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 
 - El resultado de las tiradas en el chat ahora se presenta con el mismo estilo que la calculadora de dados.
 
+**Resumen de cambios v2.3.17:**
+
+- Corrección de paréntesis duplicado en **MapCanvas** que impedía compilar la aplicación.
+
+**Resumen de cambios v2.3.18:**
+
+- Animación al desplegar el menú de ajustes de la herramienta de dibujo.
+
 ### 🛠️ **Características Técnicas**
 
 - **Interfaz responsive** - Optimizada para móviles y escritorio con TailwindCSS

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -1116,7 +1116,7 @@ const MapCanvas = ({
                 height={imageSize.height}
                 listening={false}
               />
-            ))}
+            )}
             {drawGrid()}
             <Group listening={false}>
               {dragShadow && (

--- a/src/components/Toolbar.jsx
+++ b/src/components/Toolbar.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { FiMousePointer, FiEdit2, FiType } from 'react-icons/fi';
 import { FaRuler } from 'react-icons/fa';
+import { motion, AnimatePresence } from 'framer-motion';
 
 const tools = [
   { id: 'select', icon: FiMousePointer },
@@ -36,29 +37,38 @@ const Toolbar = ({
         <Icon />
       </button>
     ))}
-    {activeTool === 'draw' && (
-      <div className="absolute left-12 top-2 bg-gray-800 p-2 rounded shadow-lg space-y-2">
-        <input
-          type="color"
-          value={drawColor}
-          onChange={(e) => onColorChange(e.target.value)}
-          className="w-8 h-8 p-0 border-0"
-        />
-        <div className="flex space-x-1">
-          {brushOptions.map(({ id, label }) => (
-            <button
-              key={id}
-              onClick={() => onBrushSizeChange(id)}
-              className={`px-2 py-1 rounded text-sm ${
-                brushSize === id ? 'bg-gray-700' : 'bg-gray-600'
-              }`}
-            >
-              {label}
-            </button>
-          ))}
-        </div>
-      </div>
-    )}
+    <AnimatePresence>
+      {activeTool === 'draw' && (
+        <motion.div
+          key="draw-menu"
+          initial={{ opacity: 0, x: -10 }}
+          animate={{ opacity: 1, x: 0 }}
+          exit={{ opacity: 0, x: -10 }}
+          transition={{ type: 'spring', stiffness: 300, damping: 30 }}
+          className="absolute left-12 top-2 bg-gray-800 p-2 rounded shadow-lg space-y-2"
+        >
+          <input
+            type="color"
+            value={drawColor}
+            onChange={(e) => onColorChange(e.target.value)}
+            className="w-8 h-8 p-0 border-0"
+          />
+          <div className="flex space-x-1">
+            {brushOptions.map(({ id, label }) => (
+              <button
+                key={id}
+                onClick={() => onBrushSizeChange(id)}
+                className={`px-2 py-1 rounded text-sm ${
+                  brushSize === id ? 'bg-gray-700' : 'bg-gray-600'
+                }`}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+        </motion.div>
+      )}
+    </AnimatePresence>
   </div>
 );
 


### PR DESCRIPTION
## Summary
- fix syntax error in MapCanvas JSX
- document MapCanvas fix in README
- animate drawing tool settings menu

## Testing
- `npm run lint`
- `CI=true npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6874306fed448326a5451197eeb3cd45