### PR TITLE
Add shape and visibility options to ruler

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 - **Barra de herramientas vertical** - Modos de selección, dibujo, medición y texto independientes del zoom
 - **Mapa desplazado** - El mapa se ajusta para que la barra de herramientas no oculte la cabecera ni los controles
 - **Ajustes de dibujo** - Selector de color y tamaño de pincel al usar la herramienta Dibujar
+- **Ajustes de regla** - Formas (l\u00ednea, cuadrado, c\u00edrculo, cono, haz), opciones de cuadr\u00edcula y visibilidad para todos
 
 ### 🎲 **Gestión de Personajes**
 

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -705,6 +705,9 @@ const MapCanvas = ({
   const [lines, setLines] = useState([]);
   const [currentLine, setCurrentLine] = useState(null);
   const [measureLine, setMeasureLine] = useState(null);
+  const [measureShape, setMeasureShape] = useState('line');
+  const [measureSnap, setMeasureSnap] = useState('center');
+  const [measureVisible, setMeasureVisible] = useState(true);
   const [texts, setTexts] = useState([]);
   const [drawColor, setDrawColor] = useState('#ffffff');
   const [brushSize, setBrushSize] = useState('medium');
@@ -742,6 +745,21 @@ const MapCanvas = ({
 
   const pxToCell = (px, offset) => Math.round((px - offset) / effectiveGridSize);
   const cellToPx = (cell, offset) => cell * effectiveGridSize + offset;
+  const snapPoint = useCallback(
+    (x, y) => {
+      if (measureSnap === 'free') return [x, y];
+      const cellX = pxToCell(x, gridOffsetX);
+      const cellY = pxToCell(y, gridOffsetY);
+      if (measureSnap === 'center') {
+        return [
+          cellToPx(cellX + 0.5, gridOffsetX),
+          cellToPx(cellY + 0.5, gridOffsetY),
+        ];
+      }
+      return [cellToPx(cellX, gridOffsetX), cellToPx(cellY, gridOffsetY)];
+    },
+    [measureSnap, gridOffsetX, gridOffsetY, effectiveGridSize]
+  );
 
   // Tamaño del contenedor para ajustar el stage al redimensionar la ventana
   useEffect(() => {
@@ -937,8 +955,9 @@ const MapCanvas = ({
     }
     if (activeTool === 'measure' && e.evt.button === 0) {
       const pointer = stageRef.current.getPointerPosition();
-      const relX = (pointer.x - groupPos.x) / (baseScale * zoom);
-      const relY = (pointer.y - groupPos.y) / (baseScale * zoom);
+      let relX = (pointer.x - groupPos.x) / (baseScale * zoom);
+      let relY = (pointer.y - groupPos.y) / (baseScale * zoom);
+      [relX, relY] = snapPoint(relX, relY);
       setMeasureLine([relX, relY, relX, relY]);
     }
     if (activeTool === 'text' && e.evt.button === 0) {
@@ -953,8 +972,8 @@ const MapCanvas = ({
   // Actualiza la acción activa según la herramienta
   const handleMouseMove = () => {
     const pointer = stageRef.current.getPointerPosition();
-    const relX = (pointer.x - groupPos.x) / (baseScale * zoom);
-    const relY = (pointer.y - groupPos.y) / (baseScale * zoom);
+    let relX = (pointer.x - groupPos.x) / (baseScale * zoom);
+    let relY = (pointer.y - groupPos.y) / (baseScale * zoom);
     if (currentLine) {
       setCurrentLine((ln) => ({
         ...ln,
@@ -963,6 +982,7 @@ const MapCanvas = ({
       return;
     }
     if (measureLine) {
+      [relX, relY] = snapPoint(relX, relY);
       setMeasureLine(([x1, y1]) => [x1, y1, relX, relY]);
       return;
     }
@@ -990,6 +1010,97 @@ const MapCanvas = ({
 
   const mapWidth = gridCells || Math.round(imageSize.width / effectiveGridSize);
   const mapHeight = gridCells || Math.round(imageSize.height / effectiveGridSize);
+
+  const measureElement =
+    measureLine && measureVisible && (() => {
+      const [x1, y1, x2, y2] = measureLine;
+      const distance = Math.hypot(
+        pxToCell(x2, gridOffsetX) - pxToCell(x1, gridOffsetX),
+        pxToCell(y2, gridOffsetY) - pxToCell(y1, gridOffsetY)
+      );
+      const dx = x2 - x1;
+      const dy = y2 - y1;
+      const len = Math.hypot(dx, dy);
+      const angle = Math.atan2(dy, dx);
+      let shape;
+      if (measureShape === 'square') {
+        shape = (
+          <Rect
+            x={Math.min(x1, x2)}
+            y={Math.min(y1, y2)}
+            width={Math.abs(dx)}
+            height={Math.abs(dy)}
+            stroke="cyan"
+            strokeWidth={2}
+            dash={[4, 4]}
+          />
+        );
+      } else if (measureShape === 'circle') {
+        shape = (
+          <Circle
+            x={x1}
+            y={y1}
+            radius={len}
+            stroke="cyan"
+            strokeWidth={2}
+            dash={[4, 4]}
+          />
+        );
+      } else if (measureShape === 'cone') {
+        const half = Math.PI / 6;
+        const p2x = x1 + len * Math.cos(angle + half);
+        const p2y = y1 + len * Math.sin(angle + half);
+        const p3x = x1 + len * Math.cos(angle - half);
+        const p3y = y1 + len * Math.sin(angle - half);
+        shape = (
+          <Line
+            points={[x1, y1, p2x, p2y, p3x, p3y]}
+            closed
+            stroke="cyan"
+            strokeWidth={2}
+            dash={[4, 4]}
+          />
+        );
+      } else if (measureShape === 'beam') {
+        const w = effectiveGridSize;
+        const dxp = (w / 2) * Math.cos(angle + Math.PI / 2);
+        const dyp = (w / 2) * Math.sin(angle + Math.PI / 2);
+        shape = (
+          <Line
+            points={[
+              x1 + dxp,
+              y1 + dyp,
+              x2 + dxp,
+              y2 + dyp,
+              x2 - dxp,
+              y2 - dyp,
+              x1 - dxp,
+              y1 - dyp,
+            ]}
+            closed
+            stroke="cyan"
+            strokeWidth={2}
+            dash={[4, 4]}
+          />
+        );
+      } else {
+        shape = (
+          <Line points={measureLine} stroke="cyan" strokeWidth={2} dash={[4, 4]} />
+        );
+      }
+      return (
+        <>
+          {shape}
+          <Text
+            x={x2}
+            y={y2}
+            text={`${Math.round(distance)} casillas`}
+            fontSize={16}
+            fill="#fff"
+          />
+        </>
+      );
+    })();
 
   const handleKeyDown = useCallback((e) => {
     // Avoid moving the token when typing inside inputs or editable fields
@@ -1239,18 +1350,7 @@ const MapCanvas = ({
                 lineJoin="round"
               />
             ))}
-            {measureLine && (
-              <>
-                <Line points={measureLine} stroke="cyan" strokeWidth={2} dash={[4, 4]} />
-                <Text
-                  x={measureLine[2]}
-                  y={measureLine[3]}
-                  text={`${Math.round(Math.hypot(pxToCell(measureLine[2], gridOffsetX) - pxToCell(measureLine[0], gridOffsetX), pxToCell(measureLine[3], gridOffsetY) - pxToCell(measureLine[1], gridOffsetY)))} casillas`}
-                  fontSize={16}
-                  fill="#fff"
-                />
-              </>
-            )}
+            {measureElement}
             {texts.map((t, i) => (
               <Text key={`text-${i}`} x={t.x} y={t.y} text={t.text} fontSize={20} fill="#fff" />
             ))}
@@ -1263,18 +1363,7 @@ const MapCanvas = ({
                 lineJoin="round"
               />
             )}
-            {measureLine && (
-              <>
-                <Line points={measureLine} stroke="cyan" strokeWidth={2} dash={[4, 4]} />
-                <Text
-                  x={measureLine[2]}
-                  y={measureLine[3]}
-                  text={`${Math.round(Math.hypot(pxToCell(measureLine[2], gridOffsetX) - pxToCell(measureLine[0], gridOffsetX), pxToCell(measureLine[3], gridOffsetY) - pxToCell(measureLine[1], gridOffsetY)))} casillas`}
-                  fontSize={16}
-                  fill="#fff"
-                />
-              </>
-            )}
+            {measureElement}
             {texts.map((t, i) => (
               <Text key={`text-${i}`} x={t.x} y={t.y} text={t.text} fontSize={20} fill="#fff" />
             ))}
@@ -1287,25 +1376,7 @@ const MapCanvas = ({
                 lineJoin="round"
               />
             )}
-            {measureLine && (
-              <>
-                <Line points={measureLine} stroke="cyan" strokeWidth={2} dash={[4, 4]} />
-                <Text
-                  x={measureLine[2]}
-                  y={measureLine[3]}
-                  text={`${Math.round(
-                    Math.hypot(
-                      pxToCell(measureLine[2], gridOffsetX) -
-                        pxToCell(measureLine[0], gridOffsetX),
-                      pxToCell(measureLine[3], gridOffsetY) -
-                        pxToCell(measureLine[1], gridOffsetY)
-                    )
-                  )} casillas`}
-                  fontSize={16}
-                  fill="#fff"
-                />
-              </>
-            )}
+            {measureElement}
             {texts.map((t, i) => (
               <Text key={`text-${i}`} x={t.x} y={t.y} text={t.text} fontSize={20} fill="#fff" />
             ))}
@@ -1332,6 +1403,12 @@ const MapCanvas = ({
         onColorChange={setDrawColor}
         brushSize={brushSize}
         onBrushSizeChange={setBrushSize}
+        measureShape={measureShape}
+        onMeasureShapeChange={setMeasureShape}
+        measureSnap={measureSnap}
+        onMeasureSnapChange={setMeasureSnap}
+        measureVisible={measureVisible}
+        onMeasureVisibleChange={setMeasureVisible}
       />
       {settingsTokenIds.map((id) => (
         <TokenSettings

--- a/src/components/Toolbar.jsx
+++ b/src/components/Toolbar.jsx
@@ -17,6 +17,20 @@ const brushOptions = [
   { id: 'large', label: 'L' },
 ];
 
+const shapeOptions = [
+  { id: 'line', label: 'L\u00ednea' },
+  { id: 'square', label: 'Cuadrado' },
+  { id: 'circle', label: 'C\u00edrculo' },
+  { id: 'cone', label: 'Cono' },
+  { id: 'beam', label: 'Haz' },
+];
+
+const snapOptions = [
+  { id: 'center', label: 'Ajustar al centro' },
+  { id: 'corner', label: 'Ajustar a la esquina' },
+  { id: 'free', label: 'Sin ajuste' },
+];
+
 const Toolbar = ({
   activeTool,
   onSelect,
@@ -24,6 +38,12 @@ const Toolbar = ({
   onColorChange,
   brushSize,
   onBrushSizeChange,
+  measureShape,
+  onMeasureShapeChange,
+  measureSnap,
+  onMeasureSnapChange,
+  measureVisible,
+  onMeasureVisibleChange,
 }) => (
   <div className="fixed left-0 top-0 bottom-0 w-12 bg-gray-800 z-50 flex flex-col items-center py-2 space-y-2">
     {tools.map(({ id, icon: Icon }) => (
@@ -68,6 +88,56 @@ const Toolbar = ({
           </div>
         </motion.div>
       )}
+      {activeTool === 'measure' && (
+        <motion.div
+          key="measure-menu"
+          initial={{ opacity: 0, x: -10 }}
+          animate={{ opacity: 1, x: 0 }}
+          exit={{ opacity: 0, x: -10 }}
+          transition={{ type: 'spring', stiffness: 300, damping: 30 }}
+          className="absolute left-12 top-2 bg-gray-800 p-2 rounded shadow-lg space-y-2 text-white"
+        >
+          <div>
+            <label className="block mb-1 text-xs">Forma</label>
+            <select
+              value={measureShape}
+              onChange={(e) => onMeasureShapeChange(e.target.value)}
+              className="bg-gray-700 w-full"
+            >
+              {shapeOptions.map(({ id, label }) => (
+                <option key={id} value={id}>
+                  {label}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label className="block mb-1 text-xs">Cuadr\u00edcula</label>
+            <select
+              value={measureSnap}
+              onChange={(e) => onMeasureSnapChange(e.target.value)}
+              className="bg-gray-700 w-full"
+            >
+              {snapOptions.map(({ id, label }) => (
+                <option key={id} value={id}>
+                  {label}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="flex items-center space-x-2">
+            <input
+              id="measure-visible"
+              type="checkbox"
+              checked={measureVisible}
+              onChange={(e) => onMeasureVisibleChange(e.target.checked)}
+            />
+            <label htmlFor="measure-visible" className="text-xs select-none">
+              Visible para todos
+            </label>
+          </div>
+        </motion.div>
+      )}
     </AnimatePresence>
   </div>
 );
@@ -79,6 +149,12 @@ Toolbar.propTypes = {
   onColorChange: PropTypes.func,
   brushSize: PropTypes.string,
   onBrushSizeChange: PropTypes.func,
+  measureShape: PropTypes.string,
+  onMeasureShapeChange: PropTypes.func,
+  measureSnap: PropTypes.string,
+  onMeasureSnapChange: PropTypes.func,
+  measureVisible: PropTypes.bool,
+  onMeasureVisibleChange: PropTypes.func,
 };
 
 export default Toolbar;


### PR DESCRIPTION
## Summary
- allow ruler to snap to grid center, corners or free
- new ruler shapes: line, square, circle, cone and beam
- visibility toggle so everyone can see ruler lines
- document new ruler options

## Testing
- `npm run format`
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687436336f7c83269789545d439b570d