### PR TITLE
Add ruler menu improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,9 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 - **Auras siempre debajo** - El aura de un token nunca se superpone sobre los demás, incluso al cambiar su capa
 - **Barra de herramientas vertical** - Modos de selección, dibujo, medición y texto independientes del zoom
 - **Mapa desplazado** - El mapa se ajusta para que la barra de herramientas no oculte la cabecera ni los controles
-- **Ajustes de dibujo** - Selector de color y tamaño de pincel al usar la herramienta Dibujar
+- **Ajustes de dibujo** - Selector de color y tamaño de pincel con menú ajustado al contenido
+- **Ajustes de regla** - Formas (línea, cuadrado, círculo, cono, haz), opciones de cuadrícula, visibilidad para todos y menú más amplio
+- **Dibujos editables** - Los trazos se pueden mover, redimensionar y eliminar. Incluye deshacer (Ctrl+Z) y rehacer (Ctrl+Y)
 
 ### 🎲 **Gestión de Personajes**
 

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -704,11 +704,19 @@ const MapCanvas = ({
   const [activeTool, setActiveTool] = useState('select');
   const [lines, setLines] = useState([]);
   const [currentLine, setCurrentLine] = useState(null);
+  const [selectedLineId, setSelectedLineId] = useState(null);
   const [measureLine, setMeasureLine] = useState(null);
+  const [measureShape, setMeasureShape] = useState('line');
+  const [measureSnap, setMeasureSnap] = useState('center');
+  const [measureVisible, setMeasureVisible] = useState(true);
   const [texts, setTexts] = useState([]);
   const [drawColor, setDrawColor] = useState('#ffffff');
   const [brushSize, setBrushSize] = useState('medium');
   const tokenRefs = useRef({});
+  const lineRefs = useRef({});
+  const lineTrRef = useRef();
+  const undoStack = useRef([]);
+  const redoStack = useRef([]);
   const panStart = useRef({ x: 0, y: 0 });
   const panOrigin = useRef({ x: 0, y: 0 });
   const [bg, bgStatus] = useImage(backgroundImage, 'anonymous');
@@ -742,6 +750,21 @@ const MapCanvas = ({
 
   const pxToCell = (px, offset) => Math.round((px - offset) / effectiveGridSize);
   const cellToPx = (cell, offset) => cell * effectiveGridSize + offset;
+  const snapPoint = useCallback(
+    (x, y) => {
+      if (measureSnap === 'free') return [x, y];
+      const cellX = pxToCell(x, gridOffsetX);
+      const cellY = pxToCell(y, gridOffsetY);
+      if (measureSnap === 'center') {
+        return [
+          cellToPx(cellX + 0.5, gridOffsetX),
+          cellToPx(cellY + 0.5, gridOffsetY),
+        ];
+      }
+      return [cellToPx(cellX, gridOffsetX), cellToPx(cellY, gridOffsetY)];
+    },
+    [measureSnap, gridOffsetX, gridOffsetY, effectiveGridSize]
+  );
 
   // Tamaño del contenedor para ajustar el stage al redimensionar la ventana
   useEffect(() => {
@@ -806,6 +829,55 @@ const MapCanvas = ({
       );
     }
     return lines;
+  };
+
+  const saveLines = (updater) => {
+    setLines((prev) => {
+      const next = typeof updater === 'function' ? updater(prev) : updater;
+      undoStack.current.push(prev);
+      redoStack.current = [];
+      return next;
+    });
+  };
+
+  const undoLines = () => {
+    setLines((prev) => {
+      if (undoStack.current.length === 0) return prev;
+      redoStack.current.push(prev);
+      return undoStack.current.pop();
+    });
+  };
+
+  const redoLines = () => {
+    setLines((prev) => {
+      if (redoStack.current.length === 0) return prev;
+      undoStack.current.push(prev);
+      return redoStack.current.pop();
+    });
+  };
+
+  const handleLineDragEnd = (id, e) => {
+    const node = e.target;
+    const x = node.x();
+    const y = node.y();
+    saveLines((ls) => ls.map((ln) => (ln.id === id ? { ...ln, x, y } : ln)));
+  };
+
+  const handleLineTransformEnd = (id, e) => {
+    const node = e.target;
+    const scaleX = node.scaleX();
+    const scaleY = node.scaleY();
+    node.scaleX(1);
+    node.scaleY(1);
+    const newPoints = node
+      .points()
+      .map((p, i) => (i % 2 === 0 ? p * scaleX : p * scaleY));
+    node.points(newPoints);
+    const x = node.x();
+    const y = node.y();
+    saveLines((ls) =>
+      ls.map((ln) => (ln.id === id ? { ...ln, x, y, points: newPoints } : ln))
+    );
   };
 
   const handleDragEnd = (id, evt) => {
@@ -929,6 +1001,7 @@ const MapCanvas = ({
       const pointer = stageRef.current.getPointerPosition();
       const relX = (pointer.x - groupPos.x) / (baseScale * zoom);
       const relY = (pointer.y - groupPos.y) / (baseScale * zoom);
+      setSelectedLineId(null);
       setCurrentLine({
         points: [relX, relY],
         color: drawColor,
@@ -937,8 +1010,9 @@ const MapCanvas = ({
     }
     if (activeTool === 'measure' && e.evt.button === 0) {
       const pointer = stageRef.current.getPointerPosition();
-      const relX = (pointer.x - groupPos.x) / (baseScale * zoom);
-      const relY = (pointer.y - groupPos.y) / (baseScale * zoom);
+      let relX = (pointer.x - groupPos.x) / (baseScale * zoom);
+      let relY = (pointer.y - groupPos.y) / (baseScale * zoom);
+      [relX, relY] = snapPoint(relX, relY);
       setMeasureLine([relX, relY, relX, relY]);
     }
     if (activeTool === 'text' && e.evt.button === 0) {
@@ -953,8 +1027,8 @@ const MapCanvas = ({
   // Actualiza la acción activa según la herramienta
   const handleMouseMove = () => {
     const pointer = stageRef.current.getPointerPosition();
-    const relX = (pointer.x - groupPos.x) / (baseScale * zoom);
-    const relY = (pointer.y - groupPos.y) / (baseScale * zoom);
+    let relX = (pointer.x - groupPos.x) / (baseScale * zoom);
+    let relY = (pointer.y - groupPos.y) / (baseScale * zoom);
     if (currentLine) {
       setCurrentLine((ln) => ({
         ...ln,
@@ -963,6 +1037,7 @@ const MapCanvas = ({
       return;
     }
     if (measureLine) {
+      [relX, relY] = snapPoint(relX, relY);
       setMeasureLine(([x1, y1]) => [x1, y1, relX, relY]);
       return;
     }
@@ -975,8 +1050,23 @@ const MapCanvas = ({
 
   const stopPanning = () => {
     if (currentLine) {
-      setLines((ls) => [...ls, currentLine]);
+      const xs = currentLine.points.filter((_, i) => i % 2 === 0);
+      const ys = currentLine.points.filter((_, i) => i % 2 === 1);
+      const minX = Math.min(...xs);
+      const minY = Math.min(...ys);
+      const rel = currentLine.points.map((p, i) =>
+        i % 2 === 0 ? p - minX : p - minY
+      );
+      const finished = {
+        ...currentLine,
+        id: Date.now(),
+        x: minX,
+        y: minY,
+        points: rel,
+      };
+      saveLines((ls) => [...ls, finished]);
       setCurrentLine(null);
+      setSelectedLineId(finished.id);
     }
     if (measureLine) setMeasureLine(null);
     if (isPanning) setIsPanning(false);
@@ -985,11 +1075,104 @@ const MapCanvas = ({
   const handleStageClick = (e) => {
     if (e.target === stageRef.current) {
       setSelectedId(null);
+      setSelectedLineId(null);
     }
   };
 
   const mapWidth = gridCells || Math.round(imageSize.width / effectiveGridSize);
   const mapHeight = gridCells || Math.round(imageSize.height / effectiveGridSize);
+
+  const measureElement =
+    measureLine && measureVisible && (() => {
+      const [x1, y1, x2, y2] = measureLine;
+      const cellDx = Math.abs(pxToCell(x2, gridOffsetX) - pxToCell(x1, gridOffsetX));
+      const cellDy = Math.abs(pxToCell(y2, gridOffsetY) - pxToCell(y1, gridOffsetY));
+      let distance = Math.hypot(cellDx, cellDy);
+      const dx = x2 - x1;
+      const dy = y2 - y1;
+      const len = Math.hypot(dx, dy);
+      const angle = Math.atan2(dy, dx);
+      let shape;
+      if (measureShape === 'square') {
+        distance = Math.max(cellDx, cellDy);
+        shape = (
+          <Rect
+            x={Math.min(x1, x2)}
+            y={Math.min(y1, y2)}
+            width={Math.abs(dx)}
+            height={Math.abs(dy)}
+            stroke="cyan"
+            strokeWidth={2}
+            dash={[4, 4]}
+          />
+        );
+      } else if (measureShape === 'circle') {
+        distance = Math.max(cellDx, cellDy);
+        shape = (
+          <Circle
+            x={x1}
+            y={y1}
+            radius={len}
+            stroke="cyan"
+            strokeWidth={2}
+            dash={[4, 4]}
+          />
+        );
+      } else if (measureShape === 'cone') {
+        const half = Math.PI / 6;
+        const p2x = x1 + len * Math.cos(angle + half);
+        const p2y = y1 + len * Math.sin(angle + half);
+        const p3x = x1 + len * Math.cos(angle - half);
+        const p3y = y1 + len * Math.sin(angle - half);
+        shape = (
+          <Line
+            points={[x1, y1, p2x, p2y, p3x, p3y]}
+            closed
+            stroke="cyan"
+            strokeWidth={2}
+            dash={[4, 4]}
+          />
+        );
+      } else if (measureShape === 'beam') {
+        const w = effectiveGridSize;
+        const dxp = (w / 2) * Math.cos(angle + Math.PI / 2);
+        const dyp = (w / 2) * Math.sin(angle + Math.PI / 2);
+        shape = (
+          <Line
+            points={[
+              x1 + dxp,
+              y1 + dyp,
+              x2 + dxp,
+              y2 + dyp,
+              x2 - dxp,
+              y2 - dyp,
+              x1 - dxp,
+              y1 - dyp,
+            ]}
+            closed
+            stroke="cyan"
+            strokeWidth={2}
+            dash={[4, 4]}
+          />
+        );
+      } else {
+        shape = (
+          <Line points={measureLine} stroke="cyan" strokeWidth={2} dash={[4, 4]} />
+        );
+      }
+      return (
+        <>
+          {shape}
+          <Text
+            x={x2}
+            y={y2}
+            text={`${Math.round(distance)} casillas`}
+            fontSize={16}
+            fill="#fff"
+          />
+        </>
+      );
+    })();
 
   const handleKeyDown = useCallback((e) => {
     // Avoid moving the token when typing inside inputs or editable fields
@@ -998,6 +1181,23 @@ const MapCanvas = ({
       target.isContentEditable ||
       ['INPUT', 'TEXTAREA', 'SELECT'].includes(target.tagName)
     ) {
+      return;
+    }
+
+    if (e.ctrlKey && e.key.toLowerCase() === 'z') {
+      e.preventDefault();
+      undoLines();
+      return;
+    }
+    if (e.ctrlKey && e.key.toLowerCase() === 'y') {
+      e.preventDefault();
+      redoLines();
+      return;
+    }
+
+    if (selectedLineId != null && e.key.toLowerCase() === 'delete') {
+      saveLines(lines.filter((ln) => ln.id !== selectedLineId));
+      setSelectedLineId(null);
       return;
     }
 
@@ -1038,12 +1238,32 @@ const MapCanvas = ({
     y = Math.max(0, Math.min(mapHeight - 1, y));
     const updated = tokens.map((t) => (t.id === selectedId ? { ...t, x, y } : t));
     onTokensChange(updated);
-  }, [selectedId, tokens, onTokensChange, mapWidth, mapHeight]);
+  }, [
+    selectedId,
+    tokens,
+    onTokensChange,
+    mapWidth,
+    mapHeight,
+    selectedLineId,
+    lines,
+  ]);
 
   useEffect(() => {
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, [handleKeyDown]);
+
+  useEffect(() => {
+    const tr = lineTrRef.current;
+    const node = selectedLineId ? lineRefs.current[selectedLineId] : null;
+    if (tr && node && activeTool === 'draw') {
+      tr.nodes([node]);
+      tr.getLayer()?.batchDraw();
+    } else if (tr) {
+      tr.nodes([]);
+      tr.getLayer()?.batchDraw();
+    }
+  }, [selectedLineId, activeTool]);
   const groupScale = baseScale * zoom;
 
   const [, drop] = useDrop(
@@ -1229,28 +1449,27 @@ const MapCanvas = ({
                 listening={activeTool === 'select'}
               />
             ))}
-            {lines.map((ln, i) => (
+            {lines.map((ln) => (
               <Line
-                key={`line-${i}`}
+                ref={(el) => {
+                  if (el) lineRefs.current[ln.id] = el;
+                }}
+                key={ln.id}
+                x={ln.x}
+                y={ln.y}
                 points={ln.points}
                 stroke={ln.color}
                 strokeWidth={ln.width}
                 lineCap="round"
                 lineJoin="round"
+                draggable={activeTool === 'draw'}
+                onClick={() => setSelectedLineId(ln.id)}
+                onDragEnd={(e) => handleLineDragEnd(ln.id, e)}
+                onTransformEnd={(e) => handleLineTransformEnd(ln.id, e)}
               />
             ))}
-            {measureLine && (
-              <>
-                <Line points={measureLine} stroke="cyan" strokeWidth={2} dash={[4, 4]} />
-                <Text
-                  x={measureLine[2]}
-                  y={measureLine[3]}
-                  text={`${Math.round(Math.hypot(pxToCell(measureLine[2], gridOffsetX) - pxToCell(measureLine[0], gridOffsetX), pxToCell(measureLine[3], gridOffsetY) - pxToCell(measureLine[1], gridOffsetY)))} casillas`}
-                  fontSize={16}
-                  fill="#fff"
-                />
-              </>
-            )}
+            {activeTool === 'draw' && <Transformer ref={lineTrRef} rotateEnabled={false} />}
+            {measureElement}
             {texts.map((t, i) => (
               <Text key={`text-${i}`} x={t.x} y={t.y} text={t.text} fontSize={20} fill="#fff" />
             ))}
@@ -1263,18 +1482,7 @@ const MapCanvas = ({
                 lineJoin="round"
               />
             )}
-            {measureLine && (
-              <>
-                <Line points={measureLine} stroke="cyan" strokeWidth={2} dash={[4, 4]} />
-                <Text
-                  x={measureLine[2]}
-                  y={measureLine[3]}
-                  text={`${Math.round(Math.hypot(pxToCell(measureLine[2], gridOffsetX) - pxToCell(measureLine[0], gridOffsetX), pxToCell(measureLine[3], gridOffsetY) - pxToCell(measureLine[1], gridOffsetY)))} casillas`}
-                  fontSize={16}
-                  fill="#fff"
-                />
-              </>
-            )}
+            {measureElement}
             {texts.map((t, i) => (
               <Text key={`text-${i}`} x={t.x} y={t.y} text={t.text} fontSize={20} fill="#fff" />
             ))}
@@ -1287,25 +1495,7 @@ const MapCanvas = ({
                 lineJoin="round"
               />
             )}
-            {measureLine && (
-              <>
-                <Line points={measureLine} stroke="cyan" strokeWidth={2} dash={[4, 4]} />
-                <Text
-                  x={measureLine[2]}
-                  y={measureLine[3]}
-                  text={`${Math.round(
-                    Math.hypot(
-                      pxToCell(measureLine[2], gridOffsetX) -
-                        pxToCell(measureLine[0], gridOffsetX),
-                      pxToCell(measureLine[3], gridOffsetY) -
-                        pxToCell(measureLine[1], gridOffsetY)
-                    )
-                  )} casillas`}
-                  fontSize={16}
-                  fill="#fff"
-                />
-              </>
-            )}
+            {measureElement}
             {texts.map((t, i) => (
               <Text key={`text-${i}`} x={t.x} y={t.y} text={t.text} fontSize={20} fill="#fff" />
             ))}
@@ -1332,6 +1522,12 @@ const MapCanvas = ({
         onColorChange={setDrawColor}
         brushSize={brushSize}
         onBrushSizeChange={setBrushSize}
+        measureShape={measureShape}
+        onMeasureShapeChange={setMeasureShape}
+        measureSnap={measureSnap}
+        onMeasureSnapChange={setMeasureSnap}
+        measureVisible={measureVisible}
+        onMeasureVisibleChange={setMeasureVisible}
       />
       {settingsTokenIds.map((id) => (
         <TokenSettings

--- a/src/components/Toolbar.jsx
+++ b/src/components/Toolbar.jsx
@@ -17,6 +17,20 @@ const brushOptions = [
   { id: 'large', label: 'L' },
 ];
 
+const shapeOptions = [
+  { id: 'line', label: 'Línea' },
+  { id: 'square', label: 'Cuadrado' },
+  { id: 'circle', label: 'Círculo' },
+  { id: 'cone', label: 'Cono' },
+  { id: 'beam', label: 'Haz' },
+];
+
+const snapOptions = [
+  { id: 'center', label: 'Ajustar al centro' },
+  { id: 'corner', label: 'Ajustar a la esquina' },
+  { id: 'free', label: 'Sin ajuste' },
+];
+
 const Toolbar = ({
   activeTool,
   onSelect,
@@ -24,6 +38,12 @@ const Toolbar = ({
   onColorChange,
   brushSize,
   onBrushSizeChange,
+  measureShape,
+  onMeasureShapeChange,
+  measureSnap,
+  onMeasureSnapChange,
+  measureVisible,
+  onMeasureVisibleChange,
 }) => (
   <div className="fixed left-0 top-0 bottom-0 w-12 bg-gray-800 z-50 flex flex-col items-center py-2 space-y-2">
     {tools.map(({ id, icon: Icon }) => (
@@ -45,7 +65,7 @@ const Toolbar = ({
           animate={{ opacity: 1, x: 0 }}
           exit={{ opacity: 0, x: -10 }}
           transition={{ type: 'spring', stiffness: 300, damping: 30 }}
-          className="absolute left-12 top-2 bg-gray-800 p-2 rounded shadow-lg space-y-2"
+          className="absolute left-12 top-2 bg-gray-800 p-2 rounded shadow-lg space-y-2 w-fit"
         >
           <input
             type="color"
@@ -68,6 +88,56 @@ const Toolbar = ({
           </div>
         </motion.div>
       )}
+      {activeTool === 'measure' && (
+        <motion.div
+          key="measure-menu"
+          initial={{ opacity: 0, x: -10 }}
+          animate={{ opacity: 1, x: 0 }}
+          exit={{ opacity: 0, x: -10 }}
+          transition={{ type: 'spring', stiffness: 300, damping: 30 }}
+          className="absolute left-12 top-2 bg-gray-800 p-2 rounded shadow-lg space-y-2 text-white w-52"
+        >
+          <div>
+            <label className="block mb-1 text-xs">Forma</label>
+            <select
+              value={measureShape}
+              onChange={(e) => onMeasureShapeChange(e.target.value)}
+              className="bg-gray-700 w-full"
+            >
+              {shapeOptions.map(({ id, label }) => (
+                <option key={id} value={id}>
+                  {label}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label className="block mb-1 text-xs">Cuadrícula</label>
+            <select
+              value={measureSnap}
+              onChange={(e) => onMeasureSnapChange(e.target.value)}
+              className="bg-gray-700 w-full"
+            >
+              {snapOptions.map(({ id, label }) => (
+                <option key={id} value={id}>
+                  {label}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="flex items-center space-x-2">
+            <input
+              id="measure-visible"
+              type="checkbox"
+              checked={measureVisible}
+              onChange={(e) => onMeasureVisibleChange(e.target.checked)}
+            />
+            <label htmlFor="measure-visible" className="text-xs select-none">
+              Visible para todos
+            </label>
+          </div>
+        </motion.div>
+      )}
     </AnimatePresence>
   </div>
 );
@@ -79,6 +149,12 @@ Toolbar.propTypes = {
   onColorChange: PropTypes.func,
   brushSize: PropTypes.string,
   onBrushSizeChange: PropTypes.func,
+  measureShape: PropTypes.string,
+  onMeasureShapeChange: PropTypes.func,
+  measureSnap: PropTypes.string,
+  onMeasureSnapChange: PropTypes.func,
+  measureVisible: PropTypes.bool,
+  onMeasureVisibleChange: PropTypes.func,
 };
 
 export default Toolbar;


### PR DESCRIPTION
## Summary
- adjust draw tool menu to fit contents
- enlarge ruler settings menu width
- fix ruler distance calculation for square and circle modes
- document the UI tweaks in the feature list
- make drawings editable with drag, resize, undo/redo and delete

## Testing
- `npm install --silent`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_687436336f7c83269789545d439b570d