### PR TITLE
Fix drawing lines flicker

### DIFF
--- a/README.md
+++ b/README.md
@@ -696,6 +696,7 @@ src/
 - **Mejoras en Sistema de Velocidad** - Los jugadores ahora pueden eliminar sus propios participantes, no solo el master
 - **Botón de papelera mejorado** - Color rojo consistente con el sistema de velocidad en inventario y línea de sucesos
 - **Corrección de error en MapCanvas** - Paréntesis faltante causaba fallo de compilación
+- **Corrección de trazos al dibujar** - Las líneas ya no parpadean ni desaparecen al moverlas
 - **Consumo de velocidad inteligente** - Las píldoras muestran el consumo real basado en emojis 🟡 del equipamiento
 - **Interfaz más intuitiva** - Píldoras organizadas por color (azul para armas, morado para poderes) sin subtítulos
 

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -1495,23 +1495,6 @@ const MapCanvas = ({
                 lineJoin="round"
               />
             )}
-            {measureElement}
-            {texts.map((t, i) => (
-              <Text key={`text-${i}`} x={t.x} y={t.y} text={t.text} fontSize={20} fill="#fff" />
-            ))}
-            {currentLine && (
-              <Line
-                points={currentLine.points}
-                stroke={currentLine.color}
-                strokeWidth={currentLine.width}
-                lineCap="round"
-                lineJoin="round"
-              />
-            )}
-            {measureElement}
-            {texts.map((t, i) => (
-              <Text key={`text-${i}`} x={t.x} y={t.y} text={t.text} fontSize={20} fill="#fff" />
-            ))}
           </Group>
         </Layer>
         <Layer listening>


### PR DESCRIPTION
## Summary
- remove duplicate drawing overlays from `MapCanvas`
- document drawing fix in README

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6874552bfff48326b042e4f448fd8984