### PR TITLE
Handle drawing deletion and persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -623,6 +623,13 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 
 - Animación al desplegar el menú de ajustes de la herramienta de dibujo.
 
+**Resumen de cambios v2.3.19:**
+
+- Los trazos del mapa se guardan en Firebase con todas sus propiedades.
+- Cambiar de página ya no muestra los trazos de la anterior.
+- Puede eliminarse un trazo seleccionado con Supr o Backspace.
+- Se limita a 100 el número de trazos para optimizar almacenamiento.
+
 ### 🛠️ **Características Técnicas**
 
 - **Interfaz responsive** - Optimizada para móviles y escritorio con TailwindCSS

--- a/src/App.js
+++ b/src/App.js
@@ -3154,6 +3154,7 @@ function App() {
         <div className="relative pt-14 flex-1 overflow-hidden">
           <div className="h-full mr-80">
             <MapCanvas
+              key={currentPage}
               backgroundImage={canvasBackground || 'https://via.placeholder.com/800x600'}
               gridSize={gridSize}
               gridCells={gridCells}

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -65,6 +65,8 @@ const BRUSH_WIDTHS = {
   large: 6,
 };
 
+const MAX_LINES = 100;
+
 const TokenAura = ({
   x,
   y,
@@ -842,10 +844,11 @@ const MapCanvas = ({
   const saveLines = (updater) => {
     setLines((prev) => {
       const next = typeof updater === 'function' ? updater(prev) : updater;
+      const limited = next.slice(-MAX_LINES);
       undoStack.current.push(prev);
       redoStack.current = [];
-      onLinesChange(next);
-      return next;
+      onLinesChange(limited);
+      return limited;
     });
   };
 
@@ -1208,7 +1211,10 @@ const MapCanvas = ({
       return;
     }
 
-    if (selectedLineId != null && e.key.toLowerCase() === 'delete') {
+    if (
+      selectedLineId != null &&
+      ['delete', 'backspace'].includes(e.key.toLowerCase())
+    ) {
       saveLines(lines.filter((ln) => ln.id !== selectedLineId));
       setSelectedLineId(null);
       return;
@@ -1232,6 +1238,7 @@ const MapCanvas = ({
         x += 1;
         break;
       case 'delete':
+      case 'backspace':
         onTokensChange(tokens.filter((t) => t.id !== selectedId));
         setSelectedId(null);
         return;


### PR DESCRIPTION
## Summary
- limit stored lines to avoid Firebase bloat
- allow deleting lines with Delete or Backspace
- remount MapCanvas when switching pages so drawings don't flicker
- document drawing persistence improvements

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68745874df2483268882d3f24dbf388f