### PR TITLE
Fix repeated Firestore writes on load

### DIFF
--- a/README.md
+++ b/README.md
@@ -623,6 +623,11 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 
 - Animación al desplegar el menú de ajustes de la herramienta de dibujo.
 
+**Resumen de cambios v2.3.19:**
+
+- Se evita la ráfaga inicial de peticiones POST a Firestore al cargar la barra
+  lateral de assets.
+
 ### 🛠️ **Características Técnicas**
 
 - **Interfaz responsive** - Optimizada para móviles y escritorio con TailwindCSS

--- a/src/components/AssetSidebar.jsx
+++ b/src/components/AssetSidebar.jsx
@@ -40,6 +40,10 @@ const AssetSidebar = ({
   const [message, setMessage] = useState('');
   const [chatLoaded, setChatLoaded] = useState(false);
 
+  // Flags para evitar sobrescribir datos justo tras la carga inicial
+  const initialFolders = useRef(true);
+  const initialChat = useRef(true);
+
   // Preview element shown on hover without triggering re-renders
   const previewRef = useRef(null);
   const isDragging = useDragLayer((monitor) => monitor.isDragging());
@@ -148,12 +152,20 @@ const AssetSidebar = ({
 
   useEffect(() => {
     if (!chatLoaded) return;
+    if (initialChat.current) {
+      initialChat.current = false;
+      return;
+    }
     localStorage.setItem('sidebarChat', JSON.stringify(messages));
     setDoc(doc(db, 'assetSidebar', 'chat'), { messages }).catch(console.error);
   }, [messages, chatLoaded]);
 
   useEffect(() => {
     if (!loaded) return;
+    if (initialFolders.current) {
+      initialFolders.current = false;
+      return;
+    }
     localStorage.setItem('assetSidebar', JSON.stringify(folders));
     setDoc(doc(db, 'assetSidebar', 'state'), { folders }).catch(console.error);
   }, [folders, loaded]);


### PR DESCRIPTION
## Summary
- prevent AssetSidebar from sending writes right after initial load
- document fix in README changelog

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68746626764083268c51179a3c2558df