### PR TITLE
Evita sincronización redundante de páginas

### DIFF
--- a/README.md
+++ b/README.md
@@ -628,6 +628,10 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 - Se evita la ráfaga inicial de peticiones POST a Firestore al cargar la barra
   lateral de assets.
 
+**Resumen de cambios v2.3.20:**
+
+- Sincronización de páginas optimizada para evitar envíos repetidos a Firestore.
+
 ### 🛠️ **Características Técnicas**
 
 - **Interfaz responsive** - Optimizada para móviles y escritorio con TailwindCSS


### PR DESCRIPTION
## Resumen
- guarda el estado previo de `pages` con `useRef`
- compara tokens, fondo y cuadrícula usando `deepEqual`
- actualiza Firestore solo si la página cambió
- documenta la mejora en el README

## Testing
- `npm install`
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_6874702e74448326b6e425f2700dff7d