### PR TITLE
Implement request throttling for Firebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -633,6 +633,10 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 
 - Sincronización de páginas optimizada para evitar envíos repetidos a Firestore.
 
+**Resumen de cambios v2.3.21:**
+
+- Nueva regla de "rate limiting" en `safeFirestore` para prevenir bucles de peticiones.
+
 ### 🛠️ **Características Técnicas**
 
 - **Interfaz responsive** - Optimizada para móviles y escritorio con TailwindCSS

--- a/src/App.js
+++ b/src/App.js
@@ -1,7 +1,7 @@
 // src/App.js
 import React, { useState, useEffect, useCallback, useRef } from 'react';
 import fetchSheetData from './utils/fetchSheetData';
-import { doc, getDoc, setDoc, deleteDoc, collection, getDocs } from 'firebase/firestore';
+import { doc, getDoc, setDoc, deleteDoc, collection, getDocs } from './utils/safeFirestore';
 import { db } from './firebase';
 import { BsDice6 } from 'react-icons/bs';
 import { GiFist } from 'react-icons/gi';

--- a/src/components/AssetSidebar.jsx
+++ b/src/components/AssetSidebar.jsx
@@ -14,7 +14,7 @@ import {
 import { motion, AnimatePresence } from 'framer-motion';
 import { useDrag, useDrop, useDragLayer } from 'react-dnd';
 import { getOrUploadFile } from '../utils/storage';
-import { doc, getDoc, setDoc, onSnapshot } from 'firebase/firestore';
+import { doc, getDoc, setDoc, onSnapshot } from '../utils/safeFirestore';
 import { db } from '../firebase';
 import Input from './Input';
 import { rollExpression } from '../utils/dice';

--- a/src/components/InitiativeTracker.jsx
+++ b/src/components/InitiativeTracker.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
-import { doc, onSnapshot, updateDoc, setDoc } from 'firebase/firestore';
+import { doc, onSnapshot, updateDoc, setDoc } from '../utils/safeFirestore';
 import { db } from '../firebase';
 import Boton from './Boton';
 import Input from './Input';

--- a/src/components/inventory/Inventory.jsx
+++ b/src/components/inventory/Inventory.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { useDrop } from 'react-dnd';
-import { doc, getDoc, setDoc } from 'firebase/firestore';
+import { doc, getDoc, setDoc } from '../../utils/safeFirestore';
 import { db } from '../../firebase';
 import Slot from './Slot';
 import ItemToken, { ItemTypes } from './ItemToken';

--- a/src/hooks/useGlossary.js
+++ b/src/hooks/useGlossary.js
@@ -1,5 +1,5 @@
 import { useState, useCallback, useEffect } from 'react';
-import { collection, getDocs, setDoc, deleteDoc, doc } from 'firebase/firestore';
+import { collection, getDocs, setDoc, deleteDoc, doc } from '../utils/safeFirestore';
 import { db } from '../firebase';
 
 export default function useGlossary() {

--- a/src/utils/safeFirestore.js
+++ b/src/utils/safeFirestore.js
@@ -1,0 +1,53 @@
+import {
+  doc as fbDoc,
+  getDoc as fbGetDoc,
+  setDoc as fbSetDoc,
+  deleteDoc as fbDeleteDoc,
+  collection as fbCollection,
+  getDocs as fbGetDocs,
+  onSnapshot as fbOnSnapshot,
+  updateDoc as fbUpdateDoc,
+  increment as fbIncrement,
+} from 'firebase/firestore';
+
+const lastCall = new Map();
+const LIMIT_MS = 1000;
+
+function throttle(key) {
+  const now = Date.now();
+  const prev = lastCall.get(key) || 0;
+  if (now - prev < LIMIT_MS) {
+    throw new Error('Peticiones demasiado seguidas. Intentar más tarde.');
+  }
+  lastCall.set(key, now);
+}
+
+export const doc = (...args) => fbDoc(...args);
+export const collection = (...args) => fbCollection(...args);
+export const increment = (...args) => fbIncrement(...args);
+export const onSnapshot = (...args) => fbOnSnapshot(...args);
+
+export async function getDoc(ref) {
+  throttle(`getDoc:${ref.path}`);
+  return fbGetDoc(ref);
+}
+
+export async function setDoc(ref, data, options) {
+  throttle(`setDoc:${ref.path}`);
+  return fbSetDoc(ref, data, options);
+}
+
+export async function deleteDoc(ref, options) {
+  throttle(`deleteDoc:${ref.path}`);
+  return fbDeleteDoc(ref, options);
+}
+
+export async function getDocs(q) {
+  throttle(`getDocs:${q._queryPath?.canonicalString || q.path}`);
+  return fbGetDocs(q);
+}
+
+export async function updateDoc(ref, data) {
+  throttle(`updateDoc:${ref.path}`);
+  return fbUpdateDoc(ref, data);
+}

--- a/src/utils/storage.js
+++ b/src/utils/storage.js
@@ -14,7 +14,7 @@ import {
   updateDoc,
   increment,
   deleteDoc,
-} from 'firebase/firestore';
+} from './safeFirestore';
 import { db } from '../firebase';
 
 const storage = getStorage();


### PR DESCRIPTION
## Summary
- create `safeFirestore` wrapper with simple rate limiting
- use `safeFirestore` in components and utilities
- document new rate-limiting feature in README

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_6875516f73288326b9c5e7ff73ecd068