### PR TITLE
Fix page subscription

### DIFF
--- a/README.md
+++ b/README.md
@@ -637,6 +637,10 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 
 - Cada página se guarda como documento individual y solo se sincroniza la que está abierta.
 
+**Resumen de cambios v2.3.22:**
+
+- La suscripción a la página actual depende solo de la página abierta y solo actualiza los metadatos cuando cambian, evitando resuscripciones infinitas.
+
 ### 🛠️ **Características Técnicas**
 
 - **Interfaz responsive** - Optimizada para móviles y escritorio con TailwindCSS

--- a/src/App.js
+++ b/src/App.js
@@ -562,25 +562,25 @@ function App() {
         gridOffsetX: data.gridOffsetX || 0,
         gridOffsetY: data.gridOffsetY || 0,
       };
-      setPages((ps) =>
-        ps.map((p, i) =>
-          i === currentPage
-            ? {
-                ...p,
-                name: data.name || p.name,
-                background: data.background || null,
-                backgroundHash: data.backgroundHash || null,
-                gridSize: data.gridSize || 1,
-                gridCells: data.gridCells || 1,
-                gridOffsetX: data.gridOffsetX || 0,
-                gridOffsetY: data.gridOffsetY || 0,
-              }
-            : p
-        )
-      );
+      setPages((ps) => {
+        const existing = ps[currentPage];
+        const meta = {
+          ...existing,
+          id: page.id,
+          name: data.name || existing?.name,
+          background: data.background || null,
+          backgroundHash: data.backgroundHash || null,
+          gridSize: data.gridSize || 1,
+          gridCells: data.gridCells || 1,
+          gridOffsetX: data.gridOffsetX || 0,
+          gridOffsetY: data.gridOffsetY || 0,
+        };
+        if (pageDataEqual(existing, meta)) return ps;
+        return ps.map((p, i) => (i === currentPage ? meta : p));
+      });
     });
     return unsub;
-  }, [currentPage, pages]);
+  }, [currentPage, pages[currentPage]?.id]);
 
   useEffect(() => {
     if (!pagesLoadedRef.current) return;


### PR DESCRIPTION
## Summary
- only track current page ID when subscribing to a page
- avoid updating pages state if metadata hasn't changed
- document new optimization in README

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68759ea76ffc8326846daab3d7d54529