### PR TITLE
Improve map text editing

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 - **Ajustes de regla** - Formas (línea, cuadrado, círculo, cono, haz), opciones de cuadrícula, visibilidad para todos y menú más amplio
 - **Dibujos editables** - Selecciona con el cursor para mover, redimensionar o borrar con Delete. Cada página guarda sus propios trazos con deshacer (Ctrl+Z) y rehacer (Ctrl+Y)
 - **Cuadros de texto personalizables** - Se crean al instante con fondo opcional; muévelos, redimensiónalos y edítalos con doble clic usando diversas fuentes
+- **Edición directa de textos** - Tras crearlos o seleccionarlos puedes escribir directamente y el cuadro se adapta al contenido
 
 ### 🎲 **Gestión de Personajes**
 


### PR DESCRIPTION
## Summary
- make text background transparent by default
- allow inline editing of map text labels with textarea overlay
- auto-resize text area while typing
- document new inline text editing feature

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68762e9920e083268e04c83640b5d3dc