### PR TITLE
Improve text editing visuals on battle map

### DIFF
--- a/README.md
+++ b/README.md
@@ -652,6 +652,11 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 
 - Los cuadros de texto creados en el mapa ahora tienen un tamaño mínimo inicial para ser visibles al colocarlos.
 
+**Resumen de cambios v2.3.24:**
+
+- Los textos creados en el mapa cuentan con un fondo semitransparente por defecto y el cuadro de edición aparece enfocado con un borde visible.
+- Al editar un texto, el área de edición muestra el mismo color y fondo del texto y se puede redimensionar manualmente.
+
 ### 🛠️ **Características Técnicas**
 
 - **Interfaz responsive** - Optimizada para móviles y escritorio con TailwindCSS

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -758,7 +758,7 @@ const MapCanvas = ({
   const [editingTextId, setEditingTextId] = useState(null);
   const [textOptions, setTextOptions] = useState({
     fill: '#ffffff',
-    bgColor: 'rgba(0,0,0,0)',
+    bgColor: 'rgba(0,0,0,0.5)',
     fontFamily: 'Arial',
     fontSize: 20,
     bold: false,
@@ -1772,7 +1772,8 @@ const MapCanvas = ({
             onChange={handleTextareaChange}
             onBlur={closeTextarea}
             placeholder="Texto"
-            className="absolute bg-transparent text-white border-none outline-none resize-none whitespace-pre"
+            autoFocus
+            className="absolute border border-gray-500 outline-none resize whitespace-pre"
             style={{
               left,
               top,
@@ -1783,6 +1784,8 @@ const MapCanvas = ({
               minWidth: '1ch',
               minHeight: t.fontSize,
               transform: `translate(-4px,-4px)`,
+              backgroundColor: t.bgColor,
+              color: t.fill,
             }}
           />
         );


### PR DESCRIPTION
## Summary
- default text box backgrounds are semi-transparent
- textarea for editing text auto-focuses and has a visible border
- edit box now uses text colors and allows resizing
- document the improvement in the changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68763c6749888326b35dfcb8138bff23