### PR TITLE
Restore prompt-based text editing

### DIFF
--- a/README.md
+++ b/README.md
@@ -657,6 +657,11 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 - Los textos creados en el mapa cuentan con un fondo semitransparente por defecto y el cuadro de edición aparece enfocado con un borde visible.
 - Al editar un texto, el área de edición muestra el mismo color y fondo del texto y se puede redimensionar manualmente.
 
+**Resumen de cambios v2.3.25:**
+
+- Se vuelve al sistema de edición mediante ventana emergente. Al crear un texto se solicita el contenido con `prompt` y al hacer doble clic sobre él se puede modificar.
+- Los textos siguen pudiéndose redimensionar manualmente con el transformador.
+
 ### 🛠️ **Características Técnicas**
 
 - **Interfaz responsive** - Optimizada para móviles y escritorio con TailwindCSS


### PR DESCRIPTION
## Summary
- revert inline text editor in MapCanvas
- open a prompt when creating or editing text labels
- update README with v2.3.25 notes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687643e0ffe4832680bca5cb28caf6c3