### PR TITLE
Add wall drawing tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 - **Ajustes de dibujo** - Selector de color y tamaño de pincel con menú ajustado al contenido
 - **Ajustes de regla** - Formas (línea, cuadrado, círculo, cono, haz), opciones de cuadrícula, visibilidad para todos y menú más amplio
 - **Dibujos editables** - Selecciona con el cursor para mover, redimensionar o borrar con Delete. Cada página guarda sus propios trazos con deshacer (Ctrl+Z) y rehacer (Ctrl+Y)
+- **Muros dibujables** - Nueva herramienta para trazar paredes que se guardan por página y se pueden mover en modo selección
 - **Cuadros de texto personalizables** - Se crean al instante con fondo opcional; muévelos, redimensiónalos y edítalos con doble clic usando diversas fuentes
 - **Edición directa de textos** - Tras crearlos o seleccionarlos puedes escribir directamente y el cuadro se adapta al contenido
 

--- a/src/components/Toolbar.jsx
+++ b/src/components/Toolbar.jsx
@@ -2,11 +2,13 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { FiMousePointer, FiEdit2, FiType } from 'react-icons/fi';
 import { FaRuler } from 'react-icons/fa';
+import { GiBrickWall } from 'react-icons/gi';
 import { motion, AnimatePresence } from 'framer-motion';
 
 const tools = [
   { id: 'select', icon: FiMousePointer },
   { id: 'draw', icon: FiEdit2 },
+  { id: 'wall', icon: GiBrickWall },
   { id: 'measure', icon: FaRuler },
   { id: 'text', icon: FiType },
 ];


### PR DESCRIPTION
## Summary
- extend page data with `walls` field
- sync wall segments in Firebase
- add wall drawing tool to MapCanvas and Toolbar
- store walls per page and allow selection & movement
- document new feature in README

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6876d103dfb48326afff876c11804103