### PR TITLE
Fix token ID generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -825,6 +825,7 @@ src/
 - **Interfaz más intuitiva** - Píldoras organizadas por color (azul para armas, morado para poderes) sin subtítulos
 - **Corrección de desincronización** - Las páginas ya no se actualizan antes de
   cargarse por completo
+- **IDs de fichas** - Cada token creado ahora recibe un `tokenSheetId` único para evitar conflictos
 
 #### v2.1.1 (junio 2024)
 

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -31,6 +31,7 @@ import TokenEstadoMenu from './TokenEstadoMenu';
 import TokenSheetModal from './TokenSheetModal';
 import { ESTADOS } from './EstadoSelector';
 import { nanoid } from 'nanoid';
+import { createToken } from '../utils/token';
 import TokenBars from './TokenBars';
 import LoadingSpinner from './LoadingSpinner';
 import KonvaSpinner from './KonvaSpinner';
@@ -2693,14 +2694,13 @@ const MapCanvas = ({
               pasteGridPos.y + relativeY
             );
 
-            return {
+            return createToken({
               ...token,
               id: Date.now() + Math.random(),
-              tokenSheetId: nanoid(),
               x: finalPos.x,
               y: finalPos.y,
               layer: activeLayer
-            };
+            });
           });
           handleTokensChange([...tokens, ...newTokens]);
         }
@@ -3086,7 +3086,7 @@ const MapCanvas = ({
           return;
         }
         
-        const newToken = {
+        const newToken = createToken({
           id: Date.now(),
           x,
           y,
@@ -3096,7 +3096,6 @@ const MapCanvas = ({
           url: item.url,
           name: item.name || '',
           enemyId: item.enemyId || null,
-          tokenSheetId: nanoid(),
           customName: '',
           showName: false,
           controlledBy: 'master',
@@ -3111,7 +3110,7 @@ const MapCanvas = ({
           tintOpacity: 0,
           estados: [],
           layer: activeLayer,
-        };
+        });
         handleTokensChange([...tokens, newToken]);
       },
     }),

--- a/src/utils/__tests__/token.test.js
+++ b/src/utils/__tests__/token.test.js
@@ -1,0 +1,9 @@
+import { createToken } from '../token';
+
+test('generated tokens across pages have unique tokenSheetId', () => {
+  const page1 = [createToken({ id: 1 }), createToken({ id: 2 })];
+  const page2 = [createToken({ id: 3 }), createToken({ id: 4 })];
+  const ids = [...page1, ...page2].map(t => t.tokenSheetId);
+  const unique = new Set(ids);
+  expect(unique.size).toBe(ids.length);
+});

--- a/src/utils/token.js
+++ b/src/utils/token.js
@@ -1,0 +1,6 @@
+import { nanoid } from 'nanoid';
+
+export const createToken = (data = {}) => ({
+  ...data,
+  tokenSheetId: nanoid(),
+});


### PR DESCRIPTION
## Summary
- create helper for generating tokens with unique `tokenSheetId`
- use the helper when dropping or pasting tokens
- document new behaviour in README
- add unit test for unique `tokenSheetId`

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687a3be9ebc48326bd631ce86fd995dc