### PR TITLE
Add master canvas realtime sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -970,6 +970,10 @@ src/
 
 - ✅ Guardados pendientes de tokens, líneas, muros, textos y fondo se cancelan al cambiar de página
 
+### ♻️ **Sincronización en tiempo real para el máster (Abril 2026) - v2.4.16**
+
+- ✅ Listener `onSnapshot` mantiene tokens, líneas y demás elementos actualizados al instante para el máster
+
 ## 🔄 Historial de cambios previos
 
 <details>

--- a/src/App.js
+++ b/src/App.js
@@ -602,6 +602,39 @@ function App() {
     return () => unsubscribe();
   }, [playerVisiblePageId, userType]);
 
+  // Listener en tiempo real para la página actual en modo máster
+  useEffect(() => {
+    if (userType !== 'master') return;
+    const pageId = pages[currentPage]?.id;
+    if (!pageId) return;
+
+    const unsubscribe = onSnapshot(
+      doc(db, 'pages', pageId),
+      (docSnap) => {
+        if (docSnap.exists()) {
+          const pageData = docSnap.data();
+          setCanvasTokens(pageData.tokens || []);
+          setCanvasLines(pageData.lines || []);
+          setCanvasWalls(pageData.walls || []);
+          setCanvasTexts(pageData.texts || []);
+          setCanvasBackground(pageData.background || null);
+          setGridSize(pageData.gridSize || 1);
+          setGridCells(pageData.gridCells || 1);
+          setGridOffsetX(pageData.gridOffsetX || 0);
+          setGridOffsetY(pageData.gridOffsetY || 0);
+          setEnableDarkness(
+            pageData.enableDarkness !== undefined ? pageData.enableDarkness : true
+          );
+        }
+      },
+      (error) => {
+        console.error('Error en listener de página para máster:', error);
+      }
+    );
+
+    return () => unsubscribe();
+  }, [userType, currentPage, pages[currentPage]?.id]);
+
   // Función para actualizar la página visible para jugadores
   const updatePlayerVisiblePage = async (pageId) => {
     try {


### PR DESCRIPTION
## Summary
- sync battle map changes for master with onSnapshot
- document new real-time sync for master in README

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_687a59624c8c8326b1735bef796d5608