### PR TITLE
Fix stale page load overwrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -974,6 +974,10 @@ src/
 
 - ✅ Listener `onSnapshot` mantiene tokens, líneas y demás elementos actualizados al instante para el máster
 
+### 🔄 **Protección contra cargas desfasadas (Abril 2026) - v2.4.17**
+
+- ✅ Se evita que una carga previa de página sobrescriba el estado actual comprobando la versión del efecto
+
 ## 🔄 Historial de cambios previos
 
 <details>

--- a/src/App.js
+++ b/src/App.js
@@ -471,6 +471,7 @@ function App() {
     background: 0,
     grid: 0,
   });
+  const loadVersionRef = useRef(0);
   // Tokens para el Mapa de Batalla
   const [canvasTokens, setCanvasTokens] = useState([]);
   const [canvasLines, setCanvasLines] = useState([]);
@@ -700,6 +701,9 @@ function App() {
     const page = pages[currentPage];
     if (!page) return undefined;
 
+    loadVersionRef.current++;
+    const version = loadVersionRef.current;
+
     console.log(
       'Cargando datos de página:',
       page.id,
@@ -715,6 +719,7 @@ function App() {
 
         const data = snap.data();
         console.log('Datos cargados para página:', page.id);
+        if (version !== loadVersionRef.current) return;
 
         // Actualizar estados del canvas con los datos de esta página específica
         setCanvasTokens(data.tokens || []);


### PR DESCRIPTION
## Summary
- prevent stale page loads from overwriting current state by tracking load version
- document the new protection against outdated loads in README

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687a93d561d48326a170def38dfa20e6