### PR TITLE
Add tests for rapid page switching and token sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -757,6 +757,10 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 - **Pruebas automáticas** - Suite de pruebas con React Testing Library
 - *Nuevo:* pruebas que simulan el cambio entre páginas y verifican que los tokens
   se mantienen independientes para jugadores y máster (`PageSwitchTokens.test.js`).
+- *Nuevo:* prueba rápida de cambio de página para asegurar que no se mezclan los tokens
+  al navegar velozmente (`QuickPageSwitch.test.js`).
+- *Nuevo:* prueba de sincronización de movimiento de tokens entre jugador y máster
+  usando un listener activo (`TokenListenerSync.test.js`).
 
 ## 🚀 Instalación y uso
 

--- a/src/components/__tests__/QuickPageSwitch.test.js
+++ b/src/components/__tests__/QuickPageSwitch.test.js
@@ -1,0 +1,69 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import PageSelector from '../PageSelector';
+
+function TestApp() {
+  const [pages, setPages] = React.useState([
+    { id: 'p1', name: 'Page 1', tokens: ['A'] },
+    { id: 'p2', name: 'Page 2', tokens: ['B'] }
+  ]);
+  const [current, setCurrent] = React.useState(0);
+  const [playerVisible, setPlayerVisible] = React.useState('p1');
+
+  const addToken = () => {
+    setPages(ps =>
+      ps.map((p, i) =>
+        i === current ? { ...p, tokens: [...p.tokens, 'new'] } : p
+      )
+    );
+  };
+
+  const playerPage = pages.find(p => p.id === playerVisible);
+  const currentPage = pages[current];
+
+  return (
+    <div>
+      <PageSelector
+        pages={pages}
+        current={current}
+        onSelect={setCurrent}
+        onAdd={() => {}}
+        onUpdate={() => {}}
+        onDelete={() => {}}
+        playerVisiblePageId={playerVisible}
+        onPlayerVisiblePageChange={setPlayerVisible}
+      />
+      <div>
+        <h2>Master</h2>
+        <span data-testid="masterTokens">{currentPage.tokens.join(',')}</span>
+        <button onClick={addToken}>Add Token</button>
+      </div>
+      <div>
+        <h2>Player</h2>
+        <span data-testid="playerTokens">{playerPage.tokens.join(',')}</span>
+      </div>
+    </div>
+  );
+}
+
+// Rapid switch back and forth should not mix tokens
+test('rapid page switch keeps tokens separated', async () => {
+  render(<TestApp />);
+  const addBtn = screen.getByRole('button', { name: /add token/i });
+  const page1Btn = screen.getByRole('button', { name: /page 1/i });
+  const page2Btn = screen.getByRole('button', { name: /page 2/i });
+
+  // add a token to page 1
+  await userEvent.click(addBtn);
+  expect(screen.getByTestId('masterTokens')).toHaveTextContent('A,new');
+
+  // rapidly switch to page 2 and back to page 1
+  await userEvent.click(page2Btn);
+  await userEvent.click(page1Btn);
+
+  // tokens should remain unchanged for both pages
+  expect(screen.getByTestId('masterTokens')).toHaveTextContent('A,new');
+  await userEvent.click(page2Btn);
+  expect(screen.getByTestId('masterTokens')).toHaveTextContent('B');
+});

--- a/src/components/__tests__/TokenListenerSync.test.js
+++ b/src/components/__tests__/TokenListenerSync.test.js
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+
+function TokenSyncApp() {
+  const [tokens, setTokens] = React.useState([{ id: 't1', x: 0 }]);
+  const [masterTokens, setMasterTokens] = React.useState(tokens);
+
+  // listener effect as master
+  React.useEffect(() => {
+    setMasterTokens(tokens);
+  }, [tokens]);
+
+  const moveToken = () => {
+    setTokens(ts => ts.map(t => (t.id === 't1' ? { ...t, x: t.x + 10 } : t)));
+  };
+
+  return (
+    <div>
+      <button onClick={moveToken}>Move Token</button>
+      <span data-testid="masterPos">{masterTokens[0].x}</span>
+    </div>
+  );
+}
+
+test('master receives token movement without reload', async () => {
+  render(<TokenSyncApp />);
+  const moveBtn = screen.getByRole('button', { name: /move token/i });
+  const pos = screen.getByTestId('masterPos');
+
+  expect(pos).toHaveTextContent('0');
+  await userEvent.click(moveBtn);
+  expect(pos).toHaveTextContent('10');
+  await userEvent.click(moveBtn);
+  expect(pos).toHaveTextContent('20');
+});


### PR DESCRIPTION
## Summary
- add QuickPageSwitch.test to ensure tokens remain isolated when switching quickly
- add TokenListenerSync.test to verify master listener receives token movement
- document new tests in README

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687a959bbb2483269f8a493097324468