### PR TITLE
Remove redundant map waiting message

### DIFF
--- a/README.md
+++ b/README.md
@@ -983,6 +983,10 @@ src/
 
 - ✅ Se evita que una carga previa de página sobrescriba el estado actual comprobando la versión del efecto
 
+### 🗺️ **Mensaje simplificado en mapa no disponible (Julio 2026) - v2.4.18**
+
+- 📝 Se elimina la indicación redundante de espera dejando solo el mensaje principal
+
 ## 🔄 Historial de cambios previos
 
 <details>

--- a/src/App.js
+++ b/src/App.js
@@ -2704,9 +2704,6 @@ function App() {
                 El Master aún no ha configurado ningún mapa como visible para
                 jugadores.
               </p>
-              <p className="text-yellow-400 text-sm">
-                Espera a que el Master seleccione un mapa para mostrar.
-              </p>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- remove "Espera a que el Master..." message from battle map placeholder
- document simplified placeholder message in README

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_687aa8dcb56083268afd311135aa83af