### PR TITLE
Update player page darkness sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -987,6 +987,10 @@ src/
 
 - 📝 Se elimina la indicación redundante de espera dejando solo el mensaje principal
 
+### 🌑 **Sincronización de oscuridad con jugadores (Julio 2026) - v2.4.19**
+
+- ✅ Los valores `enableDarkness` y `darknessOpacity` de la página visible se actualizan al instante para los jugadores
+
 ## 🔄 Historial de cambios previos
 
 <details>

--- a/src/App.js
+++ b/src/App.js
@@ -567,6 +567,11 @@ function App() {
       (docSnap) => {
         if (docSnap.exists()) {
           const pageData = docSnap.data();
+          setEnableDarkness(
+            pageData.enableDarkness !== undefined ? pageData.enableDarkness : true
+          );
+          const opacity =
+            pageData.darknessOpacity !== undefined ? pageData.darknessOpacity : 0.7;
           // Actualizar la página en el array de páginas con los datos completos
           setPages((prevPages) => {
             const pageIndex = prevPages.findIndex(
@@ -582,6 +587,11 @@ function App() {
                 texts: pageData.texts || [],
                 background: pageData.background,
                 backgroundHash: pageData.backgroundHash,
+                enableDarkness:
+                  pageData.enableDarkness !== undefined
+                    ? pageData.enableDarkness
+                    : updatedPages[pageIndex].enableDarkness,
+                darknessOpacity: opacity,
               };
               return updatedPages;
             }


### PR DESCRIPTION
## Summary
- sync darkness settings for players when visible page changes
- document darkness sync feature

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687abbf85edc83269c10d68840fb3535