### PR TITLE
Fix door sync in MapCanvas

### DIFF
--- a/README.md
+++ b/README.md
@@ -834,6 +834,7 @@ src/
 - **IDs de fichas** - Cada token creado ahora recibe un `tokenSheetId` único para evitar conflictos
 - **Guardado exclusivo para el máster** - Los tokens, líneas y otros datos del mapa solo se guardan si el usuario es máster
 - **Menús de token robustos** - Se eliminan IDs obsoletos al abrir configuraciones o estados, evitando errores si la ficha fue borrada
+- **Sincronización de puertas** - Abrir o cerrar puertas se guarda correctamente al mover un token
 
 #### v2.1.1 (junio 2024)
 

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -1418,8 +1418,8 @@ const MapCanvas = ({
     });
     
     setWalls(updatedWalls);
-    onWallsChange(updatedWalls);
-  }, [walls, activeLayer, onWallsChange]);
+    handleWallsChange(updatedWalls);
+  }, [walls, activeLayer, handleWallsChange]);
 
 
   const tokenRefs = useRef({});
@@ -1739,8 +1739,8 @@ const MapCanvas = ({
       }
       return wall;
     });
-    onWallsChange(updatedWalls);
-  }, [walls, onWallsChange]);
+    handleWallsChange(updatedWalls);
+  }, [walls, handleWallsChange]);
 
   // Función para encontrar el punto de conexión más cercano
   const findNearestWallEndpoint = useCallback((x, y, threshold = 25) => {


### PR DESCRIPTION
## Summary
- ensure door toggling uses handleWallsChange
- document fix in README

## Testing
- `npm test -- -w=off`


------
https://chatgpt.com/codex/tasks/task_e_687ac947b1488326ae8d699a8ea37f26