### PR TITLE
Clone token sheet when duplicating tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 - **Modo Master y Jugador** - Controles especializados según el rol del usuario
 - **Mapa de Batalla integrado** - VTT sencillo con grid y tokens arrastrables
 - **Fichas de token personalizadas** - Cada token puede tener su propia hoja de personaje
+- **Copiar tokens conserva su hoja personalizada** - Al duplicar un token se clona su ficha con los mismos ajustes
 - **Nombre en tokens** - El nombre del personaje aparece justo debajo del token en negrita con contorno negro (text-shadow en cuatro direcciones y leve desenfoque)
 - **Nombre escalable** - La fuente del nombre aumenta si el token ocupa varias casillas
 - **Mini-barras en tokens** - Cada stat se muestra sobre el token mediante cápsulas interactivas y puedes elegir su posición

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -31,7 +31,7 @@ import TokenEstadoMenu from './TokenEstadoMenu';
 import TokenSheetModal from './TokenSheetModal';
 import { ESTADOS } from './EstadoSelector';
 import { nanoid } from 'nanoid';
-import { createToken } from '../utils/token';
+import { createToken, cloneTokenSheet } from '../utils/token';
 import TokenBars from './TokenBars';
 import LoadingSpinner from './LoadingSpinner';
 import KonvaSpinner from './KonvaSpinner';
@@ -2715,13 +2715,15 @@ const MapCanvas = ({
               pasteGridPos.y + relativeY
             );
 
-            return createToken({
+            const newToken = createToken({
               ...token,
               id: Date.now() + Math.random(),
               x: finalPos.x,
               y: finalPos.y,
               layer: activeLayer
             });
+            cloneTokenSheet(token.tokenSheetId, newToken.tokenSheetId);
+            return newToken;
           });
           handleTokensChange([...tokens, ...newTokens]);
         }
@@ -3132,6 +3134,9 @@ const MapCanvas = ({
           estados: [],
           layer: activeLayer,
         });
+        if (item.tokenSheetId) {
+          cloneTokenSheet(item.tokenSheetId, newToken.tokenSheetId);
+        }
         handleTokensChange([...tokens, newToken]);
       },
     }),

--- a/src/utils/__tests__/cloneTokenSheet.test.js
+++ b/src/utils/__tests__/cloneTokenSheet.test.js
@@ -1,0 +1,24 @@
+import { createToken, cloneTokenSheet } from '../token';
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+test('copy token clones sheet data', () => {
+  const original = createToken({ id: 1 });
+  const sheet = { id: original.tokenSheetId, stats: { vida: { base: 5 } } };
+  localStorage.setItem('tokenSheets', JSON.stringify({ [sheet.id]: sheet }));
+
+  const copy = createToken({ ...original, id: 2 });
+  let eventDetail;
+  const handler = (e) => {
+    eventDetail = e.detail;
+  };
+  window.addEventListener('tokenSheetSaved', handler);
+  cloneTokenSheet(original.tokenSheetId, copy.tokenSheetId);
+  window.removeEventListener('tokenSheetSaved', handler);
+
+  const sheets = JSON.parse(localStorage.getItem('tokenSheets'));
+  expect(sheets[copy.tokenSheetId]).toEqual({ ...sheet, id: copy.tokenSheetId });
+  expect(eventDetail.id).toBe(copy.tokenSheetId);
+});

--- a/src/utils/token.js
+++ b/src/utils/token.js
@@ -4,3 +4,17 @@ export const createToken = (data = {}) => ({
   ...data,
   tokenSheetId: nanoid(),
 });
+
+export const cloneTokenSheet = (sourceId, targetId) => {
+  if (!sourceId || !targetId) return;
+  const stored = localStorage.getItem('tokenSheets');
+  if (!stored) return;
+  const sheets = JSON.parse(stored);
+  const sheet = sheets[sourceId];
+  if (!sheet) return;
+  const copy = JSON.parse(JSON.stringify(sheet));
+  copy.id = targetId;
+  sheets[targetId] = copy;
+  localStorage.setItem('tokenSheets', JSON.stringify(sheets));
+  window.dispatchEvent(new CustomEvent('tokenSheetSaved', { detail: copy }));
+};


### PR DESCRIPTION
## Summary
- keep token sheets in sync when duplicating tokens
- export helper `cloneTokenSheet`
- copy sheets after creating tokens from clipboard or assets
- document behaviour in README
- add unit test for sheet cloning

## Testing
- `CI=true npm test -- --watchAll=false --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_687adc240ea88326b0a254633bae4c33