### PR TITLE
Clone token sheet when duplicating tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 - **Modo Master y Jugador** - Controles especializados según el rol del usuario
 - **Mapa de Batalla integrado** - VTT sencillo con grid y tokens arrastrables
 - **Fichas de token personalizadas** - Cada token puede tener su propia hoja de personaje
+- **Copiar tokens conserva su hoja personalizada** - Al duplicar un token se clona su ficha con los mismos ajustes
 - **Nombre en tokens** - El nombre del personaje aparece justo debajo del token en negrita con contorno negro (text-shadow en cuatro direcciones y leve desenfoque)
 - **Nombre escalable** - La fuente del nombre aumenta si el token ocupa varias casillas
 - **Mini-barras en tokens** - Cada stat se muestra sobre el token mediante cápsulas interactivas y puedes elegir su posición

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -2715,13 +2715,28 @@ const MapCanvas = ({
               pasteGridPos.y + relativeY
             );
 
-            return createToken({
+            const newToken = createToken({
               ...token,
               id: Date.now() + Math.random(),
               x: finalPos.x,
               y: finalPos.y,
               layer: activeLayer
             });
+            const stored = localStorage.getItem('tokenSheets');
+            if (stored) {
+              const sheets = JSON.parse(stored);
+              const sheet = sheets[token.tokenSheetId];
+              if (sheet) {
+                const copy = JSON.parse(JSON.stringify(sheet));
+                copy.id = newToken.tokenSheetId;
+                sheets[newToken.tokenSheetId] = copy;
+                localStorage.setItem('tokenSheets', JSON.stringify(sheets));
+                window.dispatchEvent(
+                  new CustomEvent('tokenSheetSaved', { detail: copy })
+                );
+              }
+            }
+            return newToken;
           });
           handleTokensChange([...tokens, ...newTokens]);
         }
@@ -3132,6 +3147,22 @@ const MapCanvas = ({
           estados: [],
           layer: activeLayer,
         });
+        if (item.tokenSheetId) {
+          const stored = localStorage.getItem('tokenSheets');
+          if (stored) {
+            const sheets = JSON.parse(stored);
+            const sheet = sheets[item.tokenSheetId];
+            if (sheet) {
+              const copy = JSON.parse(JSON.stringify(sheet));
+              copy.id = newToken.tokenSheetId;
+              sheets[newToken.tokenSheetId] = copy;
+              localStorage.setItem('tokenSheets', JSON.stringify(sheets));
+              window.dispatchEvent(
+                new CustomEvent('tokenSheetSaved', { detail: copy })
+              );
+            }
+          }
+        }
         handleTokensChange([...tokens, newToken]);
       },
     }),

--- a/src/utils/__tests__/tokenSheetClone.test.js
+++ b/src/utils/__tests__/tokenSheetClone.test.js
@@ -1,0 +1,26 @@
+import { createToken } from '../token';
+
+describe('token sheet cloning', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  test('copy token preserves sheet data', () => {
+    const original = createToken({ id: 1 });
+    const sheet = { id: original.tokenSheetId, stats: { vida: { base: 5 } } };
+    localStorage.setItem('tokenSheets', JSON.stringify({ [sheet.id]: sheet }));
+
+    const copy = createToken({ id: 2 });
+
+    const stored = localStorage.getItem('tokenSheets');
+    const sheets = stored ? JSON.parse(stored) : {};
+    const source = sheets[original.tokenSheetId];
+    const clone = JSON.parse(JSON.stringify(source));
+    clone.id = copy.tokenSheetId;
+    sheets[copy.tokenSheetId] = clone;
+    localStorage.setItem('tokenSheets', JSON.stringify(sheets));
+
+    const result = JSON.parse(localStorage.getItem('tokenSheets'));
+    expect(result[copy.tokenSheetId]).toEqual(clone);
+  });
+});

--- a/src/utils/token.js
+++ b/src/utils/token.js
@@ -4,3 +4,4 @@ export const createToken = (data = {}) => ({
   ...data,
   tokenSheetId: nanoid(),
 });
+


### PR DESCRIPTION
## Summary
- keep token sheets when copying tokens by cloning the stored sheet
- adjust unit test for sheet cloning
- remove unused helper

## Testing
- `npm test -- --watchAll=false --runInBand` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687adc240ea88326b0a254633bae4c33