### PR TITLE
Add shared ChatPanel and integrate in player map

### DIFF
--- a/README.md
+++ b/README.md
@@ -749,6 +749,11 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 - Chat con colores únicos automáticos para cada jugador basados en hash del nombre.
 - Navegación automática a la página donde está ubicado el token del jugador.
 
+**Resumen de cambios v2.4.12:**
+
+- El Mapa de Batalla para jugadores ahora incluye un chat integrado que admite
+  los mismos comandos de la calculadora de dados.
+
 ### 🛠️ **Características Técnicas**
 
 - **Interfaz responsive** - Optimizada para móviles y escritorio con TailwindCSS

--- a/src/App.js
+++ b/src/App.js
@@ -33,6 +33,7 @@ import InitiativeTracker from './components/InitiativeTracker';
 import MapCanvas from './components/MapCanvas';
 import EnemyViewModal from './components/EnemyViewModal';
 import AssetSidebar from './components/AssetSidebar';
+import ChatPanel from './components/ChatPanel';
 import sanitize from './utils/sanitize';
 import PageSelector from './components/PageSelector';
 import { nanoid } from 'nanoid';
@@ -2794,8 +2795,9 @@ function App() {
             </Boton>
           </div>
         </div>
-        <div className="flex-1 overflow-hidden">
-          <MapCanvas
+        <div className="flex-1 overflow-hidden flex">
+          <div className="flex-1 overflow-hidden">
+            <MapCanvas
             userType="player"
             playerName={playerName}
             playerViewMode={true}
@@ -2847,6 +2849,8 @@ function App() {
             isPlayerView={true}
             pageId={playerVisiblePageId}
           />
+          </div>
+          <ChatPanel playerName={playerName} isMaster={false} />
         </div>
       </div>
     );

--- a/src/components/ChatPanel.jsx
+++ b/src/components/ChatPanel.jsx
@@ -1,0 +1,172 @@
+import React, { useState, useEffect, useRef } from 'react';
+import PropTypes from 'prop-types';
+import { nanoid } from 'nanoid';
+import { FiTrash } from 'react-icons/fi';
+import { doc, onSnapshot, setDoc } from 'firebase/firestore';
+import { db } from '../firebase';
+import Input from './Input';
+import { rollExpression } from '../utils/dice';
+
+const ChatPanel = ({ playerName = '', isMaster = false }) => {
+  const [messages, setMessages] = useState([]);
+  const [message, setMessage] = useState('');
+  const [chatLoaded, setChatLoaded] = useState(false);
+  const prevMessagesRef = useRef([]);
+  const initialChat = useRef(true);
+
+  // Load chat messages
+  useEffect(() => {
+    const ref = doc(db, 'assetSidebar', 'chat');
+    const unsub = onSnapshot(
+      ref,
+      (snap) => {
+        if (snap.exists()) {
+          setMessages(snap.data().messages || []);
+        } else {
+          const stored = localStorage.getItem('sidebarChat');
+          if (stored) {
+            try {
+              setMessages(JSON.parse(stored));
+            } catch {
+              // ignore
+            }
+          }
+        }
+        setChatLoaded(true);
+      },
+      (error) => {
+        console.error(error);
+        const stored = localStorage.getItem('sidebarChat');
+        if (stored) {
+          try {
+            setMessages(JSON.parse(stored));
+          } catch {
+            // ignore
+          }
+        }
+        setChatLoaded(true);
+      }
+    );
+    return () => unsub();
+  }, []);
+
+  // Persist chat messages
+  useEffect(() => {
+    if (!chatLoaded) return;
+    if (initialChat.current) {
+      initialChat.current = false;
+      prevMessagesRef.current = messages;
+      return;
+    }
+    if (JSON.stringify(prevMessagesRef.current) === JSON.stringify(messages)) return;
+    localStorage.setItem('sidebarChat', JSON.stringify(messages));
+    setDoc(doc(db, 'assetSidebar', 'chat'), { messages }).catch(console.error);
+    prevMessagesRef.current = messages;
+  }, [messages, chatLoaded]);
+
+  const getPlayerColor = (name) => {
+    if (!name || name === 'Master') return '#10b981';
+    let hash = 0;
+    for (let i = 0; i < name.length; i++) {
+      hash = name.charCodeAt(i) + ((hash << 5) - hash);
+    }
+    const hue = Math.abs(hash) % 360;
+    const saturation = 65 + (Math.abs(hash) % 20);
+    const lightness = 55 + (Math.abs(hash) % 15);
+    return `hsl(${hue}, ${saturation}%, ${lightness}%)`;
+  };
+
+  const sendMessage = () => {
+    const text = message.trim();
+    if (!text) return;
+    const author = isMaster ? 'Master' : playerName || 'Anónimo';
+    let result = null;
+    if (/^[0-9dD+\-*/().,% ]+$/.test(text) && /\d/.test(text)) {
+      try {
+        result = rollExpression(text);
+      } catch {
+        result = null;
+      }
+    }
+    const newMsg = { id: nanoid(), author, text, result };
+    setMessages((msgs) => [...msgs, newMsg]);
+    setMessage('');
+  };
+
+  const deleteMessage = (id) => {
+    setMessages((msgs) => msgs.filter((m) => m.id !== id));
+  };
+
+  return (
+    <div className="w-[320px] bg-[#1f2937] border-l border-[#2d3748] p-3 flex flex-col overflow-y-auto overscroll-y-contain scrollbar-thin scrollbar-thumb-gray-600 scrollbar-track-transparent">
+      <div className="flex-1 overflow-y-auto space-y-2 mb-2">
+        {messages.map((m) => (
+          <div key={m.id} className="bg-gray-700/50 p-2 rounded flex items-start gap-2">
+            <div className="flex-1 mr-2 min-w-0 space-y-1">
+              <div>
+                <span className="font-semibold mr-1" style={{ color: getPlayerColor(m.author) }}>
+                  {m.author}:
+                </span>
+                <span className="text-gray-200 break-words">{m.text}</span>
+              </div>
+              {m.result && (
+                <div className="bg-green-900/20 border border-green-600/50 rounded p-2 ml-4 text-xs text-gray-100 space-y-1">
+                  <p className="text-center text-green-400 font-semibold">🎲 Resultado</p>
+                  <div className="space-y-1">
+                    {m.result.details.map((d, i) => {
+                      const match = d.type === 'dice' ? d.formula.match(/d(\d+)/) : null;
+                      const sides = match ? match[1] : null;
+                      const img = sides && [4, 6, 8, 10, 12, 20, 100].includes(Number(sides)) ? `/dados/calculadora/calculadora-D${sides}.png` : null;
+                      return (
+                        <div key={i} className="bg-gray-800/50 rounded p-1 text-center">
+                          {d.type === 'dice' && (
+                            <span className="flex items-center justify-center gap-1">
+                              {img && <img src={img} alt={`d${sides}`} className="w-4 h-4" />}
+                              {d.formula}: [{d.rolls.join(', ')}] = {d.subtotal}
+                            </span>
+                          )}
+                          {d.type === 'modifier' && <span>Modificador: {d.formula}</span>}
+                          {d.type === 'calc' && <span>Resultado: {d.value}</span>}
+                        </div>
+                      );
+                    })}
+                  </div>
+                  <div className="text-center text-green-400 font-bold">Total: {m.result.total}</div>
+                </div>
+              )}
+            </div>
+            {isMaster && (
+              <button onClick={() => deleteMessage(m.id)} className="text-red-400 hover:text-red-300 flex-shrink-0">
+                <FiTrash />
+              </button>
+            )}
+          </div>
+        ))}
+      </div>
+      <div className="flex gap-2">
+        <Input
+          className="flex-1"
+          placeholder="Mensaje..."
+          value={message}
+          onChange={(e) => setMessage(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') sendMessage();
+          }}
+        />
+        <button
+          className="text-xs bg-[#374151] hover:bg-[#4b5563] rounded px-2 py-1 transition-colors duration-150"
+          onClick={sendMessage}
+        >
+          Enviar
+        </button>
+      </div>
+    </div>
+  );
+};
+
+ChatPanel.propTypes = {
+  playerName: PropTypes.string,
+  isMaster: PropTypes.bool,
+};
+
+export default ChatPanel;


### PR DESCRIPTION
## Summary
- add ChatPanel component derived from AssetSidebar chat logic
- integrate ChatPanel in player battle map page
- document new integrated chat feature in README

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687ae7db5b808326a5ae4a93bb6f5be0