### PR TITLE
Add missing sheets for player token bars

### DIFF
--- a/README.md
+++ b/README.md
@@ -1016,6 +1016,13 @@ src/
 - ✅ Ventanas de ficha movibles para los jugadores
 - ✅ Armas, armaduras y poderes se muestran correctamente en su ficha del mapa
 
+### 🎯 **Modo Mirilla (Septiembre 2026) - v2.4.21**
+
+- ✅ Nueva herramienta de ataque con línea de distancia
+- ✅ Ventanas de ataque y defensa con tiradas automáticas
+- ✅ Las barras de vida de fichas de otros jugadores ahora se cargan
+  automáticamente
+
 ## 🔄 Historial de cambios previos
 
 <details>

--- a/src/components/AttackModal.jsx
+++ b/src/components/AttackModal.jsx
@@ -1,0 +1,99 @@
+import React, { useState, useMemo } from 'react';
+import PropTypes from 'prop-types';
+import Modal from './Modal';
+import Boton from './Boton';
+import { rollExpression } from '../utils/dice';
+import { doc, getDoc, setDoc } from 'firebase/firestore';
+import { db } from '../firebase';
+import { nanoid } from 'nanoid';
+
+const AttackModal = ({ isOpen, attacker, target, distance, onClose }) => {
+  const sheet = useMemo(() => {
+    if (!attacker?.tokenSheetId) return null;
+    const stored = localStorage.getItem('tokenSheets');
+    if (!stored) return null;
+    const sheets = JSON.parse(stored);
+    return sheets[attacker.tokenSheetId] || null;
+  }, [attacker]);
+
+  const weapons = useMemo(() => {
+    if (!sheet) return [];
+    return (sheet.weapons || []).filter(w => {
+      const alc = parseInt(w.alcance, 10);
+      return isNaN(alc) || distance <= alc;
+    });
+  }, [sheet, distance]);
+
+  const powers = useMemo(() => {
+    if (!sheet) return [];
+    return (sheet.poderes || []).filter(p => {
+      const alc = parseInt(p.alcance, 10);
+      return isNaN(alc) || distance <= alc;
+    });
+  }, [sheet, distance]);
+
+  const [choice, setChoice] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  if (!attacker || !target) return null;
+
+  const handleRoll = async () => {
+    const item = [...weapons, ...powers].find(i => i.nombre === choice);
+    const formula = item?.dano || '1d20';
+    setLoading(true);
+    try {
+      const result = rollExpression(formula);
+      let messages = [];
+      try {
+        const snap = await getDoc(doc(db, 'assetSidebar', 'chat'));
+        if (snap.exists()) messages = snap.data().messages || [];
+      } catch (err) {
+        console.error(err);
+      }
+      const text = `${attacker.name || 'Atacante'} ataca a ${target.name || ''}`;
+      messages.push({ id: nanoid(), author: attacker.name || 'Atacante', text, result });
+      await setDoc(doc(db, 'assetSidebar', 'chat'), { messages });
+      setLoading(false);
+      onClose(result);
+    } catch (e) {
+      setLoading(false);
+      alert('Fórmula inválida');
+    }
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={() => onClose(null)} title="Ataque" size="sm">
+      <div className="space-y-4">
+        <div>
+          <p className="text-sm text-gray-300 mb-1">Distancia: {distance} casillas</p>
+          <select
+            value={choice}
+            onChange={e => setChoice(e.target.value)}
+            className="w-full bg-gray-700 text-white"
+          >
+            <option value="">Selecciona arma o poder</option>
+            {weapons.map(w => (
+              <option key={`w-${w.nombre}`} value={w.nombre}>{w.nombre}</option>
+            ))}
+            {powers.map(p => (
+              <option key={`p-${p.nombre}`} value={p.nombre}>{p.nombre}</option>
+            ))}
+          </select>
+        </div>
+        <Boton color="green" onClick={handleRoll} loading={loading} className="w-full">
+          Lanzar
+        </Boton>
+      </div>
+    </Modal>
+  );
+};
+
+AttackModal.propTypes = {
+  isOpen: PropTypes.bool,
+  attacker: PropTypes.object,
+  target: PropTypes.object,
+  distance: PropTypes.number,
+  onClose: PropTypes.func,
+};
+
+export default AttackModal;

--- a/src/components/DefenseModal.jsx
+++ b/src/components/DefenseModal.jsx
@@ -1,0 +1,120 @@
+import React, { useState, useMemo } from 'react';
+import PropTypes from 'prop-types';
+import Modal from './Modal';
+import Boton from './Boton';
+import { rollExpression } from '../utils/dice';
+import { doc, getDoc, setDoc } from 'firebase/firestore';
+import { db } from '../firebase';
+import { nanoid } from 'nanoid';
+
+const DefenseModal = ({ isOpen, attacker, target, distance, attackResult, onClose }) => {
+  const sheet = useMemo(() => {
+    if (!target?.tokenSheetId) return null;
+    const stored = localStorage.getItem('tokenSheets');
+    if (!stored) return null;
+    const sheets = JSON.parse(stored);
+    return sheets[target.tokenSheetId] || null;
+  }, [target]);
+
+  const weapons = useMemo(() => {
+    if (!sheet) return [];
+    return (sheet.weapons || []).filter(w => {
+      const alc = parseInt(w.alcance, 10);
+      return isNaN(alc) || distance <= alc;
+    });
+  }, [sheet, distance]);
+
+  const powers = useMemo(() => {
+    if (!sheet) return [];
+    return (sheet.poderes || []).filter(p => {
+      const alc = parseInt(p.alcance, 10);
+      return isNaN(alc) || distance <= alc;
+    });
+  }, [sheet, distance]);
+
+  const [choice, setChoice] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  if (!attacker || !target) return null;
+
+  const handleRoll = async () => {
+    const item = [...weapons, ...powers].find(i => i.nombre === choice);
+    const formula = item?.dano || '1d20';
+    setLoading(true);
+    try {
+      const result = rollExpression(formula);
+      let messages = [];
+      try {
+        const snap = await getDoc(doc(db, 'assetSidebar', 'chat'));
+        if (snap.exists()) messages = snap.data().messages || [];
+      } catch (err) {
+        console.error(err);
+      }
+      const success = result.total >= (attackResult?.total || 0);
+      const text = `${target.name || 'Defensor'} se defiende ${success ? 'con exito' : 'sin exito'}`;
+      messages.push({ id: nanoid(), author: target.name || 'Defensor', text, result });
+      await setDoc(doc(db, 'assetSidebar', 'chat'), { messages });
+
+      if (sheet && attackResult) {
+        let dmg = Math.max(0, attackResult.total - result.total);
+        const order = ['armadura', 'postura', 'vida'];
+        const updated = { ...sheet, stats: { ...sheet.stats } };
+        order.forEach(stat => {
+          if (!updated.stats[stat]) return;
+          const current = updated.stats[stat].actual ?? 0;
+          const newVal = Math.max(0, current - dmg);
+          dmg -= current - newVal;
+          updated.stats[stat].actual = newVal;
+        });
+        const stored = localStorage.getItem('tokenSheets');
+        const sheets = stored ? JSON.parse(stored) : {};
+        sheets[updated.id] = updated;
+        localStorage.setItem('tokenSheets', JSON.stringify(sheets));
+        window.dispatchEvent(new CustomEvent('tokenSheetSaved', { detail: updated }));
+      }
+
+      setLoading(false);
+      onClose(result);
+    } catch (e) {
+      setLoading(false);
+      alert('Fórmula inválida');
+    }
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={() => onClose(null)} title="Defensa" size="sm">
+      <div className="space-y-4">
+        <div>
+          <p className="text-sm text-gray-300 mb-1">Distancia: {distance} casillas</p>
+          <select
+            value={choice}
+            onChange={e => setChoice(e.target.value)}
+            className="w-full bg-gray-700 text-white"
+          >
+            <option value="">Selecciona arma o poder</option>
+            {weapons.map(w => (
+              <option key={`w-${w.nombre}`} value={w.nombre}>{w.nombre}</option>
+            ))}
+            {powers.map(p => (
+              <option key={`p-${p.nombre}`} value={p.nombre}>{p.nombre}</option>
+            ))}
+          </select>
+        </div>
+        <Boton color="green" onClick={handleRoll} loading={loading} className="w-full">
+          Lanzar
+        </Boton>
+      </div>
+    </Modal>
+  );
+};
+
+DefenseModal.propTypes = {
+  isOpen: PropTypes.bool,
+  attacker: PropTypes.object,
+  target: PropTypes.object,
+  distance: PropTypes.number,
+  attackResult: PropTypes.object,
+  onClose: PropTypes.func,
+};
+
+export default DefenseModal;

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -39,9 +39,11 @@ import Konva from 'konva';
 import Toolbar from './Toolbar';
 import WallDoorMenu from './WallDoorMenu';
 import DoorCheckModal from './DoorCheckModal';
+import AttackModal from './AttackModal';
+import DefenseModal from './DefenseModal';
 import { applyDoorCheck } from '../utils/door';
 import { computeVisibility, combineVisibilityPolygons, isPointVisible } from '../utils/visibility';
-import { doc, updateDoc } from 'firebase/firestore';
+import { doc, updateDoc, getDoc } from 'firebase/firestore';
 import { db } from '../firebase';
 import { deepEqual } from '../utils/deepEqual';
 
@@ -941,6 +943,21 @@ const MapCanvas = ({
   const [texts, setTexts] = useState(propTexts);
   const [selectedTextId, setSelectedTextId] = useState(null);
 
+  // Estados para sistema de ataque
+  const [attackSourceId, setAttackSourceId] = useState(null);
+  const [attackTargetId, setAttackTargetId] = useState(null);
+  const [attackLine, setAttackLine] = useState(null);
+  const [attackResult, setAttackResult] = useState(null);
+
+  useEffect(() => {
+    if (activeTool !== 'target') {
+      setAttackSourceId(null);
+      setAttackTargetId(null);
+      setAttackLine(null);
+      setAttackResult(null);
+    }
+  }, [activeTool]);
+
   // Estados para selección múltiple
   const [selectedTokens, setSelectedTokens] = useState([]);
   const [selectedLines, setSelectedLines] = useState([]);
@@ -1508,6 +1525,48 @@ const MapCanvas = ({
     },
     [playerName, userType]
   );
+
+  useEffect(() => {
+    const loadSheets = async () => {
+      const stored = localStorage.getItem('tokenSheets');
+      const sheets = stored ? JSON.parse(stored) : {};
+      const promises = [];
+      tokens.forEach(tk => {
+        if (!tk.tokenSheetId || sheets[tk.tokenSheetId] || !canSeeBars(tk)) return;
+        if (tk.controlledBy && tk.controlledBy !== 'master') {
+          promises.push(
+            getDoc(doc(db, 'players', tk.controlledBy))
+              .then(snap => {
+                if (snap.exists()) {
+                  const sheet = { id: tk.tokenSheetId, ...snap.data() };
+                  sheets[tk.tokenSheetId] = sheet;
+                }
+              })
+              .catch(err => console.error('load player sheet', err))
+          );
+        } else if (tk.enemyId) {
+          promises.push(
+            getDoc(doc(db, 'enemies', tk.enemyId))
+              .then(snap => {
+                if (snap.exists()) {
+                  const sheet = { id: tk.tokenSheetId, ...snap.data() };
+                  sheets[tk.tokenSheetId] = sheet;
+                }
+              })
+              .catch(err => console.error('load enemy sheet', err))
+          );
+        }
+      });
+      if (promises.length > 0) {
+        await Promise.all(promises);
+        localStorage.setItem('tokenSheets', JSON.stringify(sheets));
+        Object.values(sheets).forEach(sh =>
+          window.dispatchEvent(new CustomEvent('tokenSheetSaved', { detail: sh }))
+        );
+      }
+    };
+    loadSheets();
+  }, [tokens, playerName, userType]);
 
   // Si se especifica el número de casillas, calculamos el tamaño de cada celda
   const effectiveGridSize =
@@ -2329,6 +2388,33 @@ const MapCanvas = ({
 
   // Iniciar acciones según la herramienta seleccionada
   const handleMouseDown = (e) => {
+    if (activeTool === 'target' && e.evt.button === 0) {
+      const pointer = stageRef.current.getPointerPosition();
+      let relX = (pointer.x - groupPos.x) / (baseScale * zoom);
+      let relY = (pointer.y - groupPos.y) / (baseScale * zoom);
+      const cellX = pxToCell(relX, gridOffsetX);
+      const cellY = pxToCell(relY, gridOffsetY);
+      const clicked = tokens.find(t =>
+        cellX >= t.x && cellX < t.x + (t.w || 1) &&
+        cellY >= t.y && cellY < t.y + (t.h || 1)
+      );
+      if (clicked && canSelectElement(clicked, 'token')) {
+        if (!attackSourceId) {
+          setAttackSourceId(clicked.id);
+        } else if (clicked.id !== attackSourceId) {
+          setAttackTargetId(clicked.id);
+          const source = tokens.find(t => t.id === attackSourceId);
+          if (source) {
+            const sx = cellToPx(source.x + (source.w || 1) / 2, gridOffsetX);
+            const sy = cellToPx(source.y + (source.h || 1) / 2, gridOffsetY);
+            const tx = cellToPx(clicked.x + (clicked.w || 1) / 2, gridOffsetX);
+            const ty = cellToPx(clicked.y + (clicked.h || 1) / 2, gridOffsetY);
+            setAttackLine([sx, sy, tx, ty]);
+          }
+        }
+      }
+      return;
+    }
     if (activeTool === 'select' && e.evt.button === 1) {
       e.evt.preventDefault();
       setIsPanning(true);
@@ -2441,6 +2527,16 @@ const MapCanvas = ({
         ...wl,
         points: [wl.points[0], wl.points[1], relX, relY],
       }));
+      return;
+    }
+    if (activeTool === 'target' && attackSourceId && !attackTargetId) {
+      [relX, relY] = snapPoint(relX, relY);
+      const source = tokens.find(t => t.id === attackSourceId);
+      if (source) {
+        const sx = cellToPx(source.x + (source.w || 1) / 2, gridOffsetX);
+        const sy = cellToPx(source.y + (source.h || 1) / 2, gridOffsetY);
+        setAttackLine([sx, sy, relX, relY]);
+      }
       return;
     }
     if (measureLine) {
@@ -2652,6 +2748,25 @@ const MapCanvas = ({
       );
     })();
 
+  const attackElement =
+    attackLine &&
+    (() => {
+      const [x1, y1, x2, y2] = attackLine;
+      const cellDx = Math.abs(
+        pxToCell(x2, gridOffsetX) - pxToCell(x1, gridOffsetX)
+      );
+      const cellDy = Math.abs(
+        pxToCell(y2, gridOffsetY) - pxToCell(y1, gridOffsetY)
+      );
+      const distance = Math.round(Math.hypot(cellDx, cellDy));
+      return (
+        <>
+          <Line points={attackLine} stroke="red" strokeWidth={2} />
+          <Text x={x2} y={y2} text={`${distance} casillas`} fontSize={16} fill="red" />
+        </>
+      );
+    })();
+
   const handleKeyDown = useCallback(
     (e) => {
       // Avoid moving the token when typing inside inputs or editable fields
@@ -2844,10 +2959,17 @@ const MapCanvas = ({
         return;
       }
 
-      // Deseleccionar todo con Escape
+      // Cancelar mirilla o deseleccionar con Escape
       if (e.key === 'Escape') {
         e.preventDefault();
-        clearAllSelections();
+        if (attackSourceId || attackTargetId) {
+          setAttackSourceId(null);
+          setAttackTargetId(null);
+          setAttackLine(null);
+          setAttackResult(null);
+        } else {
+          clearAllSelections();
+        }
         return;
       }
 
@@ -3378,7 +3500,7 @@ const MapCanvas = ({
                   draggable={
                     activeTool === 'select' && canSelectElement(token, 'token')
                   }
-                  listening={activeTool === 'select'}
+                  listening={activeTool === 'select' || activeTool === 'target'}
                 />
               ))}
               {filteredLines.map((ln) => (
@@ -3508,6 +3630,7 @@ const MapCanvas = ({
                 />
               )}
               {measureElement}
+              {attackElement}
             </Group>
           </Layer>
           <Layer>
@@ -3658,7 +3781,7 @@ const MapCanvas = ({
                 }
                 transformKey={`${groupPos.x},${groupPos.y},${groupScale},${token.x},${token.y},${token.w},${token.h},${token.angle}`}
                 visible={
-                  activeTool === 'select' &&
+                  (activeTool === 'select' || activeTool === 'target') &&
                   hoveredId === token.id &&
                   canSeeBars(token)
                 }
@@ -4031,6 +4154,43 @@ const MapCanvas = ({
           onClose={handleDoorCheckResult}
           playerName={playerName}
           difficulty={(walls.find((w) => w.id === doorCheckWallId)?.difficulty) || 1}
+        />
+      )}
+      {attackTargetId && (
+        <AttackModal
+          isOpen
+          attacker={tokens.find(t => t.id === attackSourceId)}
+          target={tokens.find(t => t.id === attackTargetId)}
+          distance={attackLine ? Math.round(Math.hypot(
+            pxToCell(attackLine[2], gridOffsetX) - pxToCell(attackLine[0], gridOffsetX),
+            pxToCell(attackLine[3], gridOffsetY) - pxToCell(attackLine[1], gridOffsetY)
+          )) : 0}
+          onClose={(res) => {
+            if (res) setAttackResult(res);
+            else {
+              setAttackSourceId(null);
+              setAttackTargetId(null);
+              setAttackLine(null);
+            }
+          }}
+        />
+      )}
+      {attackResult && (
+        <DefenseModal
+          isOpen
+          attacker={tokens.find(t => t.id === attackSourceId)}
+          target={tokens.find(t => t.id === attackTargetId)}
+          distance={attackLine ? Math.round(Math.hypot(
+            pxToCell(attackLine[2], gridOffsetX) - pxToCell(attackLine[0], gridOffsetX),
+            pxToCell(attackLine[3], gridOffsetY) - pxToCell(attackLine[1], gridOffsetY)
+          )) : 0}
+          attackResult={attackResult}
+          onClose={() => {
+            setAttackSourceId(null);
+            setAttackTargetId(null);
+            setAttackLine(null);
+            setAttackResult(null);
+          }}
         />
       )}
 

--- a/src/components/Toolbar.jsx
+++ b/src/components/Toolbar.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { FiMousePointer, FiEdit2, FiType, FiUsers, FiShield } from 'react-icons/fi';
 import { FaRuler, FaSun } from 'react-icons/fa';
-import { GiBrickWall } from 'react-icons/gi';
+import { GiBrickWall, GiCrosshair } from 'react-icons/gi';
 import { motion, AnimatePresence } from 'framer-motion';
 
 const tools = [
@@ -11,6 +11,7 @@ const tools = [
   { id: 'wall', icon: GiBrickWall },
   { id: 'measure', icon: FaRuler },
   { id: 'text', icon: FiType },
+  { id: 'target', icon: GiCrosshair },
 ];
 
 const brushOptions = [
@@ -66,7 +67,7 @@ const Toolbar = ({
 }) => {
   // Filtrar herramientas para jugadores
   const availableTools = isPlayerView
-    ? tools.filter(tool => ['select', 'draw', 'measure', 'text'].includes(tool.id))
+    ? tools.filter(tool => ['select', 'draw', 'measure', 'text', 'target'].includes(tool.id))
     : tools;
 
   return (

--- a/src/components/__tests__/AttackTool.test.js
+++ b/src/components/__tests__/AttackTool.test.js
@@ -1,0 +1,8 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import AttackModal from '../AttackModal';
+
+test('attack modal renders distance', () => {
+  render(<AttackModal isOpen attacker={{ name: 'A', tokenSheetId: '1' }} target={{ name: 'B', tokenSheetId: '2' }} distance={5} onClose={() => {}} />);
+  expect(screen.getByText(/5 casillas/)).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- ensure missing token sheets load from Firebase so bars show for other players
- document fix in README

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_687c192c2d948326a1f82e23c4ca7663