### PR TITLE
Sync player sheet updates with tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -1026,6 +1026,7 @@ src/
 ### 🔄 **Sincronización automática de fichas (Octubre 2026) - v2.4.22**
 
 - ✅ Los cambios en la ficha de un token controlado actualizan al instante la ficha de su jugador
+- ✅ Las fichas de jugador se sincronizan automáticamente con los tokens controlados tras editar la ficha
 
 ## 🔄 Historial de cambios previos
 

--- a/src/App.js
+++ b/src/App.js
@@ -1600,6 +1600,11 @@ function App() {
           `player_${playerName}`,
           JSON.stringify(fullData)
         );
+        window.dispatchEvent(
+          new CustomEvent('playerSheetSaved', {
+            detail: { name: playerName, sheet: fullData },
+          })
+        );
       }
     } catch (e) {
       // Error guardando en Firestore
@@ -1607,6 +1612,11 @@ function App() {
         window.localStorage.setItem(
           `player_${playerName}`,
           JSON.stringify(fullData)
+        );
+        window.dispatchEvent(
+          new CustomEvent('playerSheetSaved', {
+            detail: { name: playerName, sheet: fullData },
+          })
         );
       }
     }

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -986,6 +986,29 @@ const MapCanvas = ({
     return () => window.removeEventListener('tokenSheetSaved', syncHandler);
   }, [tokens]);
 
+  useEffect(() => {
+    const handler = (e) => {
+      const { name, sheet } = e.detail || {};
+      const affected = tokens.filter(
+        (t) => t.controlledBy === name && t.tokenSheetId
+      );
+      if (!affected.length) return;
+
+      const stored = localStorage.getItem('tokenSheets');
+      const sheets = stored ? JSON.parse(stored) : {};
+      affected.forEach((t) => {
+        const copy = { ...sheet, id: t.tokenSheetId };
+        sheets[t.tokenSheetId] = copy;
+        window.dispatchEvent(
+          new CustomEvent('tokenSheetSaved', { detail: copy })
+        );
+      });
+      localStorage.setItem('tokenSheets', JSON.stringify(sheets));
+    };
+    window.addEventListener('playerSheetSaved', handler);
+    return () => window.removeEventListener('playerSheetSaved', handler);
+  }, [tokens]);
+
   // Estados para selección múltiple
   const [selectedTokens, setSelectedTokens] = useState([]);
   const [selectedLines, setSelectedLines] = useState([]);

--- a/src/components/__tests__/PlayerSheetSync.test.js
+++ b/src/components/__tests__/PlayerSheetSync.test.js
@@ -1,0 +1,50 @@
+import { render } from '@testing-library/react';
+import React from 'react';
+
+function SyncListener({ tokens }) {
+  React.useEffect(() => {
+    const handler = (e) => {
+      const { name, sheet } = e.detail || {};
+      const affected = tokens.filter(
+        (t) => t.controlledBy === name && t.tokenSheetId
+      );
+      if (!affected.length) return;
+
+      const stored = localStorage.getItem('tokenSheets');
+      const sheets = stored ? JSON.parse(stored) : {};
+      affected.forEach((t) => {
+        const copy = { ...sheet, id: t.tokenSheetId };
+        sheets[t.tokenSheetId] = copy;
+        window.dispatchEvent(
+          new CustomEvent('tokenSheetSaved', { detail: copy })
+        );
+      });
+      localStorage.setItem('tokenSheets', JSON.stringify(sheets));
+    };
+    window.addEventListener('playerSheetSaved', handler);
+    return () => window.removeEventListener('playerSheetSaved', handler);
+  }, [tokens]);
+  return null;
+}
+
+function savePlayer(name, data) {
+  localStorage.setItem(`player_${name}`, JSON.stringify(data));
+  window.dispatchEvent(
+    new CustomEvent('playerSheetSaved', { detail: { name, sheet: data } })
+  );
+}
+
+test('controlled token updates on player sheet save', () => {
+  const tokens = [{ id: 't1', controlledBy: 'Alice', tokenSheetId: 's1' }];
+  const saved = jest.fn();
+  window.addEventListener('tokenSheetSaved', saved);
+  render(<SyncListener tokens={tokens} />);
+
+  const sheet = { stats: { vida: { base: 5 } } };
+  savePlayer('Alice', sheet);
+
+  const stored = JSON.parse(localStorage.getItem('tokenSheets'));
+  expect(stored.s1.stats.vida.base).toBe(5);
+  expect(saved).toHaveBeenCalledTimes(1);
+  window.removeEventListener('tokenSheetSaved', saved);
+});


### PR DESCRIPTION
## Summary
- emit `playerSheetSaved` event when saving players
- sync tokens on `playerSheetSaved` in `MapCanvas`
- test automatic token updates
- document player-token sync in README

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687c3540d3a083268b7b0a552e2a3ed2