### PR TITLE
Sync player sheet on token state change

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 - **Permisos granulares** - Jugadores pueden eliminar sus propios participantes
 - **Interfaz color-coded** - Identificación visual por jugador y tipo de equipamiento
 - **Sincronización en tiempo real** - Cambios instantáneos para todos los participantes
+- **Eventos de guardado de ficha de jugador** - Al modificar estados en el mapa se actualiza automáticamente la ficha del jugador
 - **Modo Master y Jugador** - Controles especializados según el rol del usuario
 - **Mapa de Batalla integrado** - VTT sencillo con grid y tokens arrastrables
 - **Fichas de token personalizadas** - Cada token puede tener su propia hoja de personaje


### PR DESCRIPTION
## Summary
- dispatch `playerSheetSaved` event when saving token sheet
- sync player sheets when their controlled tokens change `estados`
- document new automatic sheet update event in README

## Testing
- `npm test` *(fails: `react-scripts` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c3c23c86883268a0903c3ff9e42ca