### PR TITLE
Sync token states from player sheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 - **Permisos granulares** - Jugadores pueden eliminar sus propios participantes
 - **Interfaz color-coded** - Identificación visual por jugador y tipo de equipamiento
 - **Sincronización en tiempo real** - Cambios instantáneos para todos los participantes
+- **Eventos de guardado de ficha de jugador** - Al modificar estados en el mapa se actualiza automáticamente la ficha del jugador sin provocar bucles
+- **Estados sincronizados de la ficha al token** - Al activar condiciones desde la ficha se aplican inmediatamente al token controlado
 - **Modo Master y Jugador** - Controles especializados según el rol del usuario
 - **Mapa de Batalla integrado** - VTT sencillo con grid y tokens arrastrables
 - **Fichas de token personalizadas** - Cada token puede tener su propia hoja de personaje

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -959,6 +959,8 @@ const MapCanvas = ({
   }, [activeTool]);
 
   // Sincronizar cambios de fichas de tokens controlados con la ficha del jugador
+  const prevTokensRef = useRef(tokens);
+
   useEffect(() => {
     const syncHandler = async (e) => {
       const sheet = e.detail;
@@ -977,6 +979,11 @@ const MapCanvas = ({
             `player_${token.controlledBy}`,
             JSON.stringify(sheet)
           );
+          window.dispatchEvent(
+            new CustomEvent('playerSheetSaved', {
+              detail: { name: token.controlledBy, sheet, origin: 'mapSync' },
+            })
+          );
         }
       } catch (err) {
         console.error('sync player sheet', err);
@@ -987,8 +994,57 @@ const MapCanvas = ({
   }, [tokens]);
 
   useEffect(() => {
+    const prev = prevTokensRef.current || [];
+    const checkStates = async () => {
+      for (const token of tokens) {
+        const prevToken = prev.find((t) => t.id === token.id);
+        if (
+          prevToken &&
+          token.controlledBy &&
+          token.controlledBy !== 'master' &&
+          !deepEqual(prevToken.estados, token.estados)
+        ) {
+          const stored =
+            typeof window !== 'undefined'
+              ? window.localStorage.getItem(
+                  `player_${token.controlledBy}`
+                )
+              : null;
+          const sheet = stored ? JSON.parse(stored) : null;
+          if (!sheet) continue;
+          if (deepEqual(sheet.estados || [], token.estados || [])) continue;
+          const updated = { ...sheet, estados: token.estados || [] };
+          try {
+            await setDoc(doc(db, 'players', token.controlledBy), updated);
+            if (typeof window !== 'undefined') {
+              window.localStorage.setItem(
+                `player_${token.controlledBy}`,
+                JSON.stringify(updated)
+              );
+              window.dispatchEvent(
+                new CustomEvent('playerSheetSaved', {
+                  detail: {
+                    name: token.controlledBy,
+                    sheet: updated,
+                    origin: 'mapSync',
+                  },
+                })
+              );
+            }
+          } catch (err) {
+            console.error('sync player estados', err);
+          }
+        }
+      }
+      prevTokensRef.current = tokens;
+    };
+    checkStates();
+  }, [tokens]);
+
+  useEffect(() => {
     const handler = (e) => {
-      const { name, sheet } = e.detail || {};
+      const { name, sheet, origin } = e.detail || {};
+      if (origin === 'mapSync') return;
       const affected = tokens.filter(
         (t) => t.controlledBy === name && t.tokenSheetId
       );
@@ -1004,10 +1060,19 @@ const MapCanvas = ({
         );
       });
       localStorage.setItem('tokenSheets', JSON.stringify(sheets));
+
+      const updatedTokens = tokens.map((t) =>
+        t.controlledBy === name
+          ? { ...t, estados: sheet.estados || [] }
+          : t
+      );
+      if (!deepEqual(updatedTokens, tokens)) {
+        handleTokensChange(updatedTokens);
+      }
     };
     window.addEventListener('playerSheetSaved', handler);
     return () => window.removeEventListener('playerSheetSaved', handler);
-  }, [tokens]);
+  }, [tokens, handleTokensChange]);
 
   // Estados para selección múltiple
   const [selectedTokens, setSelectedTokens] = useState([]);

--- a/src/components/__tests__/PlayerSheetSync.test.js
+++ b/src/components/__tests__/PlayerSheetSync.test.js
@@ -1,10 +1,11 @@
-import { render } from '@testing-library/react';
+import { render, act } from '@testing-library/react';
 import React from 'react';
 
-function SyncListener({ tokens }) {
+function SyncListener({ tokens, onTokensChange }) {
   React.useEffect(() => {
     const handler = (e) => {
-      const { name, sheet } = e.detail || {};
+      const { name, sheet, origin } = e.detail || {};
+      if (origin === 'mapSync') return;
       const affected = tokens.filter(
         (t) => t.controlledBy === name && t.tokenSheetId
       );
@@ -20,10 +21,15 @@ function SyncListener({ tokens }) {
         );
       });
       localStorage.setItem('tokenSheets', JSON.stringify(sheets));
+
+      const updated = tokens.map((t) =>
+        t.controlledBy === name ? { ...t, estados: sheet.estados || [] } : t
+      );
+      onTokensChange(updated);
     };
     window.addEventListener('playerSheetSaved', handler);
     return () => window.removeEventListener('playerSheetSaved', handler);
-  }, [tokens]);
+  }, [tokens, onTokensChange]);
   return null;
 }
 
@@ -35,16 +41,51 @@ function savePlayer(name, data) {
 }
 
 test('controlled token updates on player sheet save', () => {
-  const tokens = [{ id: 't1', controlledBy: 'Alice', tokenSheetId: 's1' }];
-  const saved = jest.fn();
-  window.addEventListener('tokenSheetSaved', saved);
-  render(<SyncListener tokens={tokens} />);
+  const initial = [{ id: 't1', controlledBy: 'Alice', tokenSheetId: 's1' }];
+  let renderedTokens = initial;
+  const Wrapper = () => {
+    const [tokens, setTokens] = React.useState(initial);
+    renderedTokens = tokens;
+    return <SyncListener tokens={tokens} onTokensChange={setTokens} />;
+  };
 
-  const sheet = { stats: { vida: { base: 5 } } };
-  savePlayer('Alice', sheet);
+  const saved = jest.fn();
+  localStorage.clear();
+  window.addEventListener('tokenSheetSaved', saved);
+  render(<Wrapper />);
+
+  const sheet = { stats: { vida: { base: 5 } }, estados: ['cansado'] };
+  act(() => {
+    savePlayer('Alice', sheet);
+  });
 
   const stored = JSON.parse(localStorage.getItem('tokenSheets'));
   expect(stored.s1.stats.vida.base).toBe(5);
+  expect(renderedTokens[0].estados).toEqual(['cansado']);
   expect(saved).toHaveBeenCalledTimes(1);
+  window.removeEventListener('tokenSheetSaved', saved);
+});
+
+test('mapSync events are ignored to avoid loops', () => {
+  const initial = [{ id: 't1', controlledBy: 'Bob', tokenSheetId: 's2' }];
+  const Wrapper = () => {
+    const [tokens, setTokens] = React.useState(initial);
+    return <SyncListener tokens={tokens} onTokensChange={setTokens} />;
+  };
+  const saved = jest.fn();
+  localStorage.clear();
+  window.addEventListener('tokenSheetSaved', saved);
+  render(<Wrapper />);
+
+  act(() => {
+    window.dispatchEvent(
+      new CustomEvent('playerSheetSaved', {
+        detail: { name: 'Bob', sheet: { stats: {} }, origin: 'mapSync' },
+      })
+    );
+  });
+
+  expect(localStorage.getItem('tokenSheets')).toBeNull();
+  expect(saved).not.toHaveBeenCalled();
   window.removeEventListener('tokenSheetSaved', saved);
 });


### PR DESCRIPTION
## Summary
- dispatch `playerSheetSaved` with the updated sheet from token sync
- skip redundant updates when token states already match the player sheet
- apply player sheet `estados` to controlled tokens
- test new sync behavior and ignore mapSync events
- document automatic state propagation

## Testing
- `npm install`
- `CI=1 npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_687c3c23c86883268a0903c3ff9e42ca