### PR TITLE
Sync player sheet instantly across tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1033,6 +1033,10 @@ src/
 - ✅ Activar condiciones desde la ficha ahora refleja el estado al instante en el token correspondiente
 - ✅ Guardar la ficha envía el evento de actualización sin esperar a Firebase para evitar retrasos
 
+### 🔄 **Sincronización entre pestañas (Noviembre 2026) - v2.4.23**
+
+- ✅ La ficha de jugador se actualiza automáticamente al recibir el evento `playerSheetSaved` desde otras pestañas o tokens
+
 
 ## 🔄 Historial de cambios previos
 

--- a/src/App.js
+++ b/src/App.js
@@ -1558,6 +1558,19 @@ function App() {
     loadPlayer();
   }, [loadPlayer]);
 
+  useEffect(() => {
+    const handler = (e) => {
+      const { name, sheet } = e.detail || {};
+      if (name !== playerName) return;
+      setPlayerData(sheet);
+      setResourcesList(sheet.resourcesList || []);
+      setClaves(sheet.claves || []);
+      setEstados(sheet.estados || []);
+    };
+    window.addEventListener('playerSheetSaved', handler);
+    return () => window.removeEventListener('playerSheetSaved', handler);
+  }, [playerName]);
+
   // Debug: Monitorear cambios en playerData
   useEffect(() => {
     // playerData actualizado


### PR DESCRIPTION
## Summary
- update README with sync info
- refresh player data when `playerSheetSaved` event fires

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c595734e4832692253097de443b70