### PR TITLE
Sync player sheet instantly across tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1033,6 +1033,11 @@ src/
 - ✅ Activar condiciones desde la ficha ahora refleja el estado al instante en el token correspondiente
 - ✅ Guardar la ficha envía el evento de actualización sin esperar a Firebase para evitar retrasos
 
+### 🔄 **Sincronización entre pestañas (Noviembre 2026) - v2.4.23**
+
+- ✅ La ficha de jugador se actualiza automáticamente al recibir el evento `playerSheetSaved` desde otras pestañas o tokens
+- ✅ Al detectar cambios en `localStorage`, la ficha se actualiza sin recargar la página
+
 
 ## 🔄 Historial de cambios previos
 

--- a/src/App.js
+++ b/src/App.js
@@ -1558,6 +1558,38 @@ function App() {
     loadPlayer();
   }, [loadPlayer]);
 
+  useEffect(() => {
+    const updateFromSheet = (sheet) => {
+      setPlayerData(sheet);
+      setResourcesList(sheet.resourcesList || []);
+      setClaves(sheet.claves || []);
+      setEstados(sheet.estados || []);
+    };
+
+    const handler = (e) => {
+      const { name, sheet } = e.detail || {};
+      if (name !== playerName) return;
+      updateFromSheet(sheet);
+    };
+
+    const storageHandler = (e) => {
+      if (e.key !== `player_${playerName}` || !e.newValue) return;
+      try {
+        const sheet = JSON.parse(e.newValue);
+        updateFromSheet(sheet);
+      } catch (err) {
+        console.error('invalid sheet from storage', err);
+      }
+    };
+
+    window.addEventListener('playerSheetSaved', handler);
+    window.addEventListener('storage', storageHandler);
+    return () => {
+      window.removeEventListener('playerSheetSaved', handler);
+      window.removeEventListener('storage', storageHandler);
+    };
+  }, [playerName]);
+
   // Debug: Monitorear cambios en playerData
   useEffect(() => {
     // playerData actualizado


### PR DESCRIPTION
## Summary
- update README with cross-tab localStorage sync info
- refresh player data when `playerSheetSaved` fires or localStorage changes

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687c595734e4832692253097de443b70