### PR TITLE
Normalize player sheet before sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -843,6 +843,7 @@ src/
 - **Fichas de jugador completas** - Las estadísticas personalizadas y el equipamiento se muestran correctamente al enlazar
 - **Carga de imágenes optimizada** - Las tarjetas ya no hacen peticiones en bucle al equipar objetos
 - **Sincronización total de fichas de jugador** - Se respetan las posiciones personalizadas de estadísticas y se cargan armas, armaduras y poderes equipados
+- **Datos de jugador normalizados** - Armas, armaduras y poderes se guardan como nombres simples al sincronizar desde el mapa
 - **Mejoras en Sistema de Velocidad** - Los jugadores ahora pueden eliminar sus propios participantes, no solo el master
 - **Botón de papelera mejorado** - Color rojo consistente con el sistema de velocidad en inventario y línea de sucesos
 - **Corrección de error en MapCanvas** - Paréntesis faltante causaba fallo de compilación

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -973,15 +973,31 @@ const MapCanvas = ({
       );
       if (!token) return;
       try {
-        await setDoc(doc(db, 'players', token.controlledBy), sheet);
+        const mapNames = (arr) =>
+          (arr || [])
+            .map((it) => (typeof it === 'string' ? it : it.nombre))
+            .filter(Boolean);
+
+        const playerSheet = {
+          ...sheet,
+          weapons: mapNames(sheet.weapons),
+          armaduras: mapNames(sheet.armaduras),
+          poderes: mapNames(sheet.poderes),
+        };
+
+        await setDoc(doc(db, 'players', token.controlledBy), playerSheet);
         if (typeof window !== 'undefined') {
           window.localStorage.setItem(
             `player_${token.controlledBy}`,
-            JSON.stringify(sheet)
+            JSON.stringify(playerSheet)
           );
           window.dispatchEvent(
             new CustomEvent('playerSheetSaved', {
-              detail: { name: token.controlledBy, sheet, origin: 'mapSync' },
+              detail: {
+                name: token.controlledBy,
+                sheet: playerSheet,
+                origin: 'mapSync',
+              },
             })
           );
         }


### PR DESCRIPTION
## Summary
- normalize weapons, armaduras and poderes before saving player sheets in MapCanvas syncHandler
- document new normalization behavior in README

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687cd16e5f188326970fd4439a26a5f6