### PR TITLE
Add EquipmentSync test

### DIFF
--- a/README.md
+++ b/README.md
@@ -776,6 +776,8 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
   al navegar velozmente (`QuickPageSwitch.test.js`).
 - *Nuevo:* prueba de sincronización de movimiento de tokens entre jugador y máster
   usando un listener activo (`TokenListenerSync.test.js`).
+- *Nuevo:* prueba de mapeo de nombres de equipo al guardar fichas de tokens
+  (`EquipmentSync.test.js`).
 
 ## 🚀 Instalación y uso
 

--- a/src/components/__tests__/EquipmentSync.test.js
+++ b/src/components/__tests__/EquipmentSync.test.js
@@ -1,0 +1,66 @@
+import { render, act } from '@testing-library/react';
+import React from 'react';
+
+function EquipmentSyncListener({ tokens }) {
+  React.useEffect(() => {
+    const handler = (e) => {
+      const sheet = e.detail;
+      if (!sheet || !sheet.id) return;
+      const token = tokens.find(
+        (t) =>
+          t.tokenSheetId === sheet.id &&
+          t.controlledBy &&
+          t.controlledBy !== 'master'
+      );
+      if (!token) return;
+      const mapNames = (arr) =>
+        (arr || [])
+          .map((it) => (typeof it === 'string' ? it : it.nombre))
+          .filter(Boolean);
+      const playerSheet = {
+        ...sheet,
+        weapons: mapNames(sheet.weapons),
+        armaduras: mapNames(sheet.armaduras),
+        poderes: mapNames(sheet.poderes),
+      };
+      localStorage.setItem(
+        `player_${token.controlledBy}`,
+        JSON.stringify(playerSheet)
+      );
+      window.dispatchEvent(
+        new CustomEvent('playerSheetSaved', {
+          detail: { name: token.controlledBy, sheet: playerSheet, origin: 'mapSync' },
+        })
+      );
+    };
+    window.addEventListener('tokenSheetSaved', handler);
+    return () => window.removeEventListener('tokenSheetSaved', handler);
+  }, [tokens]);
+  return null;
+}
+
+test('equipment names are mapped on tokenSheetSaved', () => {
+  const tokens = [{ id: 't1', controlledBy: 'Alice', tokenSheetId: 's1' }];
+  const saved = jest.fn();
+  localStorage.clear();
+  window.addEventListener('playerSheetSaved', saved);
+  render(<EquipmentSyncListener tokens={tokens} />);
+
+  const sheet = {
+    id: 's1',
+    weapons: [{ nombre: 'Espada' }],
+    armaduras: [{ nombre: 'Armadura' }],
+    poderes: [{ nombre: 'Fuego' }],
+  };
+
+  act(() => {
+    window.dispatchEvent(new CustomEvent('tokenSheetSaved', { detail: sheet }));
+  });
+
+  const stored = JSON.parse(localStorage.getItem('player_Alice'));
+  expect(stored.weapons).toEqual(['Espada']);
+  expect(stored.armaduras).toEqual(['Armadura']);
+  expect(stored.poderes).toEqual(['Fuego']);
+  expect(saved).toHaveBeenCalledTimes(1);
+  window.removeEventListener('playerSheetSaved', saved);
+});


### PR DESCRIPTION
## Summary
- add unit test EquipmentSync to verify player sheets store only equipment names
- document new test in README

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687cd48cd48c8326a2aeb565cfdc742e