### PR TITLE
Improve attack tool interaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 - **Control de capas** - Desde Ajustes puedes subir o bajar un token para colocarlo encima o debajo de otros
 - **Auras siempre debajo** - El aura de un token nunca se superpone sobre los demás, incluso al cambiar su capa
 - **Barra de herramientas vertical** - Modos de selección, dibujo, medición y texto independientes del zoom
+- **Herramienta de mirilla** - Selecciona atacante y objetivo mostrando una línea roja
 - **Mapa desplazado** - El mapa se ajusta para que la barra de herramientas no oculte la cabecera ni los controles
 - **Ajustes de dibujo** - Selector de color y tamaño de pincel con menú ajustado al contenido
 - **Ajustes de regla** - Formas (línea, cuadrado, círculo, cono, haz), opciones de cuadrícula, visibilidad para todos y menú más amplio

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -3792,7 +3792,6 @@ const MapCanvas = ({
                 />
               )}
               {measureElement}
-              {attackElement}
             </Group>
           </Layer>
           <Layer>
@@ -3950,7 +3949,20 @@ const MapCanvas = ({
               />
             ))}
           </Layer>
-          
+
+          {attackElement && (
+            <Layer listening>
+              <Group
+                x={groupPos.x}
+                y={groupPos.y}
+                scaleX={groupScale}
+                scaleY={groupScale}
+              >
+                {attackElement}
+              </Group>
+            </Layer>
+          )}
+
           {/* Capa de iluminación */}
           <Layer listening={false}>
             <Group

--- a/src/components/Toolbar.jsx
+++ b/src/components/Toolbar.jsx
@@ -78,7 +78,11 @@ const Toolbar = ({
           key={id}
           onClick={() => onSelect(id)}
           className={`w-10 h-10 flex items-center justify-center rounded transition-colors ${
-            activeTool === id ? 'bg-gray-700' : 'bg-gray-800 hover:bg-gray-700'
+            activeTool === id
+              ? id === 'target'
+                ? 'bg-red-700'
+                : 'bg-gray-700'
+              : 'bg-gray-800 hover:bg-gray-700'
           }`}
         >
           <Icon />

--- a/src/components/__tests__/AttackTool.test.js
+++ b/src/components/__tests__/AttackTool.test.js
@@ -1,8 +1,82 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import React from 'react';
+import userEvent from '@testing-library/user-event';
 import AttackModal from '../AttackModal';
+
+function AttackToolDemo() {
+  const [activeTool, setActiveTool] = React.useState('select');
+  const [attackSourceId, setAttackSourceId] = React.useState(null);
+  const [attackTargetId, setAttackTargetId] = React.useState(null);
+  const [attackLine, setAttackLine] = React.useState(null);
+
+  const tokens = [
+    { id: 'a', x: 10, y: 10 },
+    { id: 'b', x: 80, y: 10 },
+  ];
+
+  const handleClick = (id) => {
+    if (activeTool !== 'target') return;
+    if (!attackSourceId) setAttackSourceId(id);
+    else if (id !== attackSourceId) setAttackTargetId(id);
+  };
+
+  const handleMove = (e) => {
+    if (activeTool === 'target' && attackSourceId && !attackTargetId) {
+      const source = tokens.find(t => t.id === attackSourceId);
+      const rect = e.currentTarget.getBoundingClientRect();
+      setAttackLine([
+        source.x,
+        source.y,
+        e.clientX - rect.left,
+        e.clientY - rect.top,
+      ]);
+    }
+  };
+
+  return (
+    <div>
+      <button data-testid="target-tool" onClick={() => setActiveTool('target')}>Target</button>
+      <div
+        data-testid="canvas"
+        onMouseMove={handleMove}
+        style={{ position: 'relative', width: 100, height: 40 }}
+      >
+        {tokens.map(t => (
+          <div
+            key={t.id}
+            data-testid={t.id}
+            onClick={() => handleClick(t.id)}
+            style={{ position: 'absolute', left: t.x, top: t.y, width: 10, height: 10 }}
+          />
+        ))}
+        <svg>{attackLine && <line data-testid="line" />}</svg>
+      </div>
+      {attackTargetId && (
+        <AttackModal
+          isOpen
+          attacker={{ name: 'A', tokenSheetId: '1' }}
+          target={{ name: 'B', tokenSheetId: '2' }}
+          distance={5}
+          onClose={() => {}}
+        />
+      )}
+    </div>
+  );
+}
 
 test('attack modal renders distance', () => {
   render(<AttackModal isOpen attacker={{ name: 'A', tokenSheetId: '1' }} target={{ name: 'B', tokenSheetId: '2' }} distance={5} onClose={() => {}} />);
   expect(screen.getByText(/5 casillas/)).toBeInTheDocument();
+});
+
+test('crosshair tool selects source and target', async () => {
+  render(<AttackToolDemo />);
+  await userEvent.click(screen.getByTestId('target-tool'));
+  const canvas = screen.getByTestId('canvas');
+  await userEvent.click(screen.getByTestId('a'));
+  // simulate mouse move to draw line
+  fireEvent.mouseMove(canvas, { clientX: 90, clientY: 20 });
+  await userEvent.click(screen.getByTestId('b'));
+  expect(screen.getByTestId('line')).toBeInTheDocument();
+  expect(screen.getByText('Ataque')).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- highlight crosshair tool when active
- render attack line above tokens
- test attack workflow via simple demo component
- document new crosshair feature

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687d391fadac8326b3cae90f40a353d5