### PR TITLE
Improve attack tool auto selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1028,6 +1028,7 @@ src/
 - ✅ Ventanas de ataque y defensa con tiradas automáticas
 - ✅ Las barras de vida de fichas de otros jugadores ahora se cargan
   automáticamente
+- ✅ Selección automática del atacante y línea que sigue al cursor
 
 ### 🔄 **Sincronización automática de fichas (Octubre 2026) - v2.4.22**
 


### PR DESCRIPTION
## Summary
- auto-select attacker if only one token is selected
- keep attack line following the cursor without snapping
- test auto-selection behavior
- document the new mirilla feature

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687d3e07f2108326989cfdcfc1bbb7d4