### PR TITLE
Improve measure tool snapping behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 - **Mapa desplazado** - El mapa se ajusta para que la barra de herramientas no oculte la cabecera ni los controles
 - **Ajustes de dibujo** - Selector de color y tamaño de pincel con menú ajustado al contenido
 - **Ajustes de regla** - Formas (línea, cuadrado, círculo, cono, haz), opciones de cuadrícula, visibilidad para todos y menú más amplio
+- **Medición precisa y fluida** - La distancia se calcula con ajuste a la cuadrícula pero la regla sigue al cursor en tiempo real
 - **Dibujos editables** - Selecciona con el cursor para mover, redimensionar o borrar con Delete. Cada página guarda sus propios trazos con deshacer (Ctrl+Z) y rehacer (Ctrl+Y)
 - **Muros dibujables** - Herramienta para crear segmentos de longitud fija con extremos siempre visibles como círculos. Cada muro muestra una puerta en su punto medio y puedes alargarlo moviendo sus extremos en modo selección; los cambios se guardan al soltar.
 - **Puertas configurables** - Al pulsar la puerta de un muro puedes abrir un menú para marcarla como secreta, cerrada u abierta y cambiar el color del muro; los ajustes se guardan en Firebase.

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -2652,9 +2652,8 @@ const MapCanvas = ({
     }
     if (activeTool === 'measure' && e.evt.button === 0) {
       const pointer = stageRef.current.getPointerPosition();
-      let relX = (pointer.x - groupPos.x) / (baseScale * zoom);
-      let relY = (pointer.y - groupPos.y) / (baseScale * zoom);
-      [relX, relY] = snapPoint(relX, relY);
+      const relX = (pointer.x - groupPos.x) / (baseScale * zoom);
+      const relY = (pointer.y - groupPos.y) / (baseScale * zoom);
       setMeasureLine([relX, relY, relX, relY]);
     }
     if (activeTool === 'text' && e.evt.button === 0) {
@@ -2720,7 +2719,6 @@ const MapCanvas = ({
       return;
     }
     if (measureLine) {
-      [relX, relY] = snapPoint(relX, relY);
       setMeasureLine(([x1, y1]) => [x1, y1, relX, relY]);
       return;
     }
@@ -2830,11 +2828,13 @@ const MapCanvas = ({
     measureVisible &&
     (() => {
       const [x1, y1, x2, y2] = measureLine;
+      const [sx1, sy1] = snapPoint(x1, y1);
+      const [sx2, sy2] = snapPoint(x2, y2);
       const cellDx = Math.abs(
-        pxToCell(x2, gridOffsetX) - pxToCell(x1, gridOffsetX)
+        pxToCell(sx2, gridOffsetX) - pxToCell(sx1, gridOffsetX)
       );
       const cellDy = Math.abs(
-        pxToCell(y2, gridOffsetY) - pxToCell(y1, gridOffsetY)
+        pxToCell(sy2, gridOffsetY) - pxToCell(sy1, gridOffsetY)
       );
       let distance = Math.hypot(cellDx, cellDy);
       const dx = x2 - x1;


### PR DESCRIPTION
## Summary
- tweak measure start and move events so snapping only affects distance calculation
- compute distance with snapped coordinates but draw using raw pointer positions
- document new behaviour in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687d43648c6c8326a3565816154860dd