### PR TITLE
Restore measure snap behavior

### DIFF
--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -2654,7 +2654,9 @@ const MapCanvas = ({
       const pointer = stageRef.current.getPointerPosition();
       let relX = (pointer.x - groupPos.x) / (baseScale * zoom);
       let relY = (pointer.y - groupPos.y) / (baseScale * zoom);
-      [relX, relY] = snapPoint(relX, relY);
+      if (measureSnap !== 'free') {
+        [relX, relY] = snapPoint(relX, relY);
+      }
       setMeasureLine([relX, relY, relX, relY]);
     }
     if (activeTool === 'text' && e.evt.button === 0) {
@@ -2720,8 +2722,12 @@ const MapCanvas = ({
       return;
     }
     if (measureLine) {
-      [relX, relY] = snapPoint(relX, relY);
-      setMeasureLine(([x1, y1]) => [x1, y1, relX, relY]);
+      let nx = relX;
+      let ny = relY;
+      if (measureSnap !== 'free') {
+        [nx, ny] = snapPoint(relX, relY);
+      }
+      setMeasureLine(([x1, y1]) => [x1, y1, nx, ny]);
       return;
     }
     if (!isPanning) return;
@@ -2830,11 +2836,13 @@ const MapCanvas = ({
     measureVisible &&
     (() => {
       const [x1, y1, x2, y2] = measureLine;
+      const [sx1, sy1] = snapPoint(x1, y1);
+      const [sx2, sy2] = snapPoint(x2, y2);
       const cellDx = Math.abs(
-        pxToCell(x2, gridOffsetX) - pxToCell(x1, gridOffsetX)
+        pxToCell(sx2, gridOffsetX) - pxToCell(sx1, gridOffsetX)
       );
       const cellDy = Math.abs(
-        pxToCell(y2, gridOffsetY) - pxToCell(y1, gridOffsetY)
+        pxToCell(sy2, gridOffsetY) - pxToCell(sy1, gridOffsetY)
       );
       let distance = Math.hypot(cellDx, cellDy);
       const dx = x2 - x1;


### PR DESCRIPTION
## Summary
- keep ruler snap logic when grid snapping is enabled
- revert README bullet for measurement feature

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687d43648c6c8326a3565816154860dd