### PR TITLE
Enable crosshair targeting for enemy tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -864,6 +864,7 @@ src/
 - **Guardado exclusivo para el máster** - Los tokens, líneas y otros datos del mapa solo se guardan si el usuario es máster
 - **Menús de token robustos** - Se eliminan IDs obsoletos al abrir configuraciones o estados, evitando errores si la ficha fue borrada
 - **Sincronización de puertas** - Abrir o cerrar puertas se guarda correctamente al mover un token
+- **Mirilla funcional para ataques** - Los jugadores pueden seleccionar objetivos enemigos con un clic y atacar con un segundo clic
 
 #### v2.1.1 (junio 2024)
 

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -2574,14 +2574,16 @@ const MapCanvas = ({
         cellX >= t.x && cellX < t.x + (t.w || 1) &&
         cellY >= t.y && cellY < t.y + (t.h || 1)
       );
-      if (clicked && canSelectElement(clicked, 'token')) {
+      if (clicked) {
         const sourceId = attackSourceId || (selectedTokens.length === 1
           ? selectedTokens[0]
           : selectedTokens.length === 0 && selectedId != null
             ? selectedId
             : null);
         if (!sourceId) {
-          setAttackSourceId(clicked.id);
+          if (canSelectElement(clicked, 'token')) {
+            setAttackSourceId(clicked.id);
+          }
         } else if (attackTargetId == null && clicked.id !== sourceId) {
           setAttackSourceId(sourceId);
           setAttackTargetId(clicked.id);


### PR DESCRIPTION
## Summary
- allow players to target enemy tokens with crosshair tool
- document improved crosshair behaviour in README

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_687a2705b8648326b139a993427fb40f