### PR TITLE
Enable persistent attacker selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -864,6 +864,9 @@ src/
 - **Guardado exclusivo para el máster** - Los tokens, líneas y otros datos del mapa solo se guardan si el usuario es máster
 - **Menús de token robustos** - Se eliminan IDs obsoletos al abrir configuraciones o estados, evitando errores si la ficha fue borrada
 - **Sincronización de puertas** - Abrir o cerrar puertas se guarda correctamente al mover un token
+- **Mirilla funcional para ataques** - Los jugadores pueden seleccionar objetivos enemigos con un clic y atacar con un segundo clic
+- **La mirilla apunta a tokens ajenos** - Ahora también puedes fijar como objetivo fichas controladas por otros jugadores o por el máster
+- **Doble clic seguro en mirilla** - Al usar la mirilla, el doble clic ya no abre el menú de ajustes del token
 
 #### v2.1.1 (junio 2024)
 
@@ -1034,7 +1037,10 @@ src/
 - ✅ Ventanas de ataque y defensa con tiradas automáticas
 - ✅ Las barras de vida de fichas de otros jugadores ahora se cargan
   automáticamente
-- ✅ Selección automática del atacante y línea que sigue al cursor
+- ✅ Debes elegir tu propio token como atacante y la selección se mantiene hasta cambiar de herramienta
+- ✅ Puede apuntar a tokens controlados por otros jugadores o el máster
+- ✅ Un clic fija el objetivo y el siguiente inicia el ataque
+- ✅ El doble clic no abre ajustes de token cuando se usa la mirilla
 
 ### 🔄 **Sincronización automática de fichas (Octubre 2026) - v2.4.22**
 

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -338,6 +338,7 @@ const Token = forwardRef(
       onTransformEnd,
       onRotate,
       onSettings,
+      activeTool = 'select',
       onStates,
       onHoverChange,
       tokenSheetId,
@@ -670,7 +671,9 @@ const Token = forwardRef(
         ref={groupRef}
         onMouseEnter={() => onHoverChange?.(true)}
         onMouseLeave={() => onHoverChange?.(false)}
-        onDblClick={() => onSettings?.(id)}
+        onDblClick={() => {
+          if (activeTool !== 'target') onSettings?.(id);
+        }}
       >
         {auraRadius > 0 &&
           showAura &&
@@ -868,6 +871,7 @@ Token.propTypes = {
   onHoverChange: PropTypes.func,
   estados: PropTypes.array,
   tokenSheetId: PropTypes.string,
+  activeTool: PropTypes.string,
 };
 
 /**
@@ -945,10 +949,20 @@ const MapCanvas = ({
 
   // Estados para sistema de ataque
   const [attackSourceId, setAttackSourceId] = useState(null);
+  const attackSourceIdRef = useRef(null);
   const [attackTargetId, setAttackTargetId] = useState(null);
+  const attackTargetIdRef = useRef(null);
   const [attackLine, setAttackLine] = useState(null);
   const [attackResult, setAttackResult] = useState(null);
   const [attackReady, setAttackReady] = useState(false);
+
+  useEffect(() => {
+    attackSourceIdRef.current = attackSourceId;
+  }, [attackSourceId]);
+
+  useEffect(() => {
+    attackTargetIdRef.current = attackTargetId;
+  }, [attackTargetId]);
 
   useEffect(() => {
     if (activeTool !== 'target') {
@@ -2553,17 +2567,6 @@ const MapCanvas = ({
   // Iniciar acciones según la herramienta seleccionada
   const handleMouseDown = (e) => {
     if (activeTool === 'target' && e.evt.button === 0) {
-      // Autoseleccionar atacante si solo hay un token en la selección
-      if (!attackSourceId) {
-        const candidates = selectedTokens.length === 1
-          ? selectedTokens
-          : selectedTokens.length === 0 && selectedId != null
-            ? [selectedId]
-            : [];
-        if (candidates.length === 1) {
-          setAttackSourceId(candidates[0]);
-        }
-      }
 
       const pointer = stageRef.current.getPointerPosition();
       let relX = (pointer.x - groupPos.x) / (baseScale * zoom);
@@ -2574,17 +2577,18 @@ const MapCanvas = ({
         cellX >= t.x && cellX < t.x + (t.w || 1) &&
         cellY >= t.y && cellY < t.y + (t.h || 1)
       );
-      if (clicked && canSelectElement(clicked, 'token')) {
-        const sourceId = attackSourceId || (selectedTokens.length === 1
-          ? selectedTokens[0]
-          : selectedTokens.length === 0 && selectedId != null
-            ? selectedId
-            : null);
+      if (clicked) {
+        const sourceId = attackSourceIdRef.current;
+        const isOwnToken = clicked.controlledBy === playerName;
+
         if (!sourceId) {
-          setAttackSourceId(clicked.id);
-        } else if (attackTargetId == null && clicked.id !== sourceId) {
-          setAttackSourceId(sourceId);
+          if (isOwnToken && canSelectElement(clicked, 'token')) {
+            setAttackSourceId(clicked.id);
+            attackSourceIdRef.current = clicked.id;
+          }
+        } else if (attackTargetIdRef.current == null && !isOwnToken && clicked.id !== sourceId) {
           setAttackTargetId(clicked.id);
+          attackTargetIdRef.current = clicked.id;
           const source = tokens.find(t => t.id === sourceId);
           if (source) {
             const sx = cellToPx(source.x + (source.w || 1) / 2, gridOffsetX);
@@ -2594,10 +2598,11 @@ const MapCanvas = ({
             setAttackLine([sx, sy, tx, ty]);
           }
           setAttackReady(false);
-        } else if (attackTargetId === clicked.id) {
+        } else if (attackTargetIdRef.current === clicked.id) {
           if (!attackReady) setAttackReady(true);
-        } else if (clicked.id !== sourceId) {
+        } else if (!isOwnToken && clicked.id !== sourceId) {
           setAttackTargetId(clicked.id);
+          attackTargetIdRef.current = clicked.id;
           const source = tokens.find(t => t.id === sourceId);
           if (source) {
             const sx = cellToPx(source.x + (source.w || 1) / 2, gridOffsetX);
@@ -3159,7 +3164,12 @@ const MapCanvas = ({
       // Cancelar mirilla o deseleccionar con Escape
       if (e.key === 'Escape') {
         e.preventDefault();
-        if (attackSourceId || attackTargetId) {
+        if (activeTool === 'target' && (attackSourceId || attackTargetId)) {
+          setAttackTargetId(null);
+          setAttackLine(null);
+          setAttackResult(null);
+          setAttackReady(false);
+        } else if (attackSourceId || attackTargetId) {
           setAttackSourceId(null);
           setAttackTargetId(null);
           setAttackLine(null);
@@ -3698,6 +3708,7 @@ const MapCanvas = ({
                     activeTool === 'select' && canSelectElement(token, 'token')
                   }
                   listening={activeTool === 'select' || activeTool === 'target'}
+                  activeTool={activeTool}
                 />
               ))}
               {filteredLines.map((ln) => (
@@ -4378,7 +4389,6 @@ const MapCanvas = ({
             if (res) setAttackResult(res);
             setAttackReady(false);
             if (!res) {
-              setAttackSourceId(null);
               setAttackTargetId(null);
               setAttackLine(null);
             }
@@ -4396,7 +4406,6 @@ const MapCanvas = ({
           )) : 0}
           attackResult={attackResult}
           onClose={() => {
-            setAttackSourceId(null);
             setAttackTargetId(null);
             setAttackLine(null);
             setAttackResult(null);

--- a/src/components/__tests__/AttackTool.test.js
+++ b/src/components/__tests__/AttackTool.test.js
@@ -3,7 +3,7 @@ import React from 'react';
 import userEvent from '@testing-library/user-event';
 import AttackModal from '../AttackModal';
 
-function AttackToolDemo({ selectedId } = {}) {
+function AttackToolDemo({ selectedId, playerName = 'player', onSettings } = {}) {
   const [activeTool, setActiveTool] = React.useState('select');
   const [attackSourceId, setAttackSourceId] = React.useState(null);
   const [attackTargetId, setAttackTargetId] = React.useState(null);
@@ -11,32 +11,31 @@ function AttackToolDemo({ selectedId } = {}) {
   const [attackReady, setAttackReady] = React.useState(false);
 
   const tokens = [
-    { id: 'a', x: 10, y: 10 },
-    { id: 'b', x: 80, y: 10 },
+    { id: 'a', x: 10, y: 10, controlledBy: playerName },
+    { id: 'b', x: 80, y: 10, controlledBy: 'other' },
   ];
 
   const handleClick = (id) => {
     if (activeTool !== 'target') return;
-    const attacker = attackSourceId || selectedId;
+    const attacker = attackSourceId;
+    const clicked = tokens.find((t) => t.id === id);
+    const isOwn = clicked.controlledBy === playerName;
     if (!attacker) {
-      setAttackSourceId(id);
-    } else if (attackTargetId == null && id !== attacker) {
-      setAttackSourceId(attacker);
+      if (isOwn) setAttackSourceId(id);
+    } else if (attackTargetId == null && !isOwn && id !== attacker) {
       setAttackTargetId(id);
       const source = tokens.find((t) => t.id === attacker);
-      const target = tokens.find((t) => t.id === id);
-      if (source && target) {
-        setAttackLine([source.x, source.y, target.x, target.y]);
+      if (source && clicked) {
+        setAttackLine([source.x, source.y, clicked.x, clicked.y]);
       }
       setAttackReady(false);
     } else if (attackTargetId === id) {
       if (!attackReady) setAttackReady(true);
-    } else if (id !== attacker) {
+    } else if (!isOwn && id !== attacker) {
       setAttackTargetId(id);
       const source = tokens.find((t) => t.id === attacker);
-      const target = tokens.find((t) => t.id === id);
-      if (source && target) {
-        setAttackLine([source.x, source.y, target.x, target.y]);
+      if (source && clicked) {
+        setAttackLine([source.x, source.y, clicked.x, clicked.y]);
       }
       setAttackReady(false);
     }
@@ -63,6 +62,9 @@ function AttackToolDemo({ selectedId } = {}) {
             key={t.id}
             data-testid={t.id}
             onClick={() => handleClick(t.id)}
+            onDoubleClick={() => {
+              if (activeTool !== 'target') onSettings?.(t.id);
+            }}
             style={{
               position: 'absolute',
               left: t.x,
@@ -109,12 +111,22 @@ test('crosshair tool selects source and target', async () => {
   expect(screen.queryByText('Ataque')).toBeNull();
 });
 
-test('auto selects attacker if a token was preselected', async () => {
+test('does not auto select attacker from previous selection', async () => {
   render(<AttackToolDemo selectedId="a" />);
   await userEvent.click(screen.getByTestId('target-tool'));
   await userEvent.click(screen.getByTestId('b'));
+  expect(screen.queryByTestId('line')).toBeNull();
+  await userEvent.click(screen.getByTestId('a'));
+  await userEvent.click(screen.getByTestId('b'));
   expect(screen.getByTestId('line')).toBeInTheDocument();
-  expect(screen.queryByText('Ataque')).toBeNull();
+});
+
+test('allows targeting tokens controlled by another player', async () => {
+  render(<AttackToolDemo playerName="alice" />);
+  await userEvent.click(screen.getByTestId('target-tool'));
+  await userEvent.click(screen.getByTestId('a'));
+  await userEvent.click(screen.getByTestId('b'));
+  expect(screen.getByTestId('line')).toBeInTheDocument();
 });
 
 test('attack modal appears on second click over same target', async () => {
@@ -125,4 +137,13 @@ test('attack modal appears on second click over same target', async () => {
   expect(screen.queryByText('Ataque')).toBeNull();
   await userEvent.click(screen.getByTestId('b'));
   expect(screen.getByText('Ataque')).toBeInTheDocument();
+});
+
+test('double click does not open settings while targeting', async () => {
+  const onSettings = jest.fn();
+  render(<AttackToolDemo onSettings={onSettings} />);
+  await userEvent.click(screen.getByTestId('target-tool'));
+  await userEvent.click(screen.getByTestId('a'));
+  await userEvent.dblClick(screen.getByTestId('b'));
+  expect(onSettings).not.toHaveBeenCalled();
 });


### PR DESCRIPTION
## Summary
- keep attacker selected when targeting until tool changes
- ignore clicks on owned tokens once attacker is chosen
- require manually picking attacker instead of auto selection
- update tests for revised targeting flow
- document the persistent attacker selection

## Testing
- `npm install --silent`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_687a2705b8648326b139a993427fb40f