### PR TITLE
Enable attack range filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -864,6 +864,9 @@ src/
 - **Guardado exclusivo para el máster** - Los tokens, líneas y otros datos del mapa solo se guardan si el usuario es máster
 - **Menús de token robustos** - Se eliminan IDs obsoletos al abrir configuraciones o estados, evitando errores si la ficha fue borrada
 - **Sincronización de puertas** - Abrir o cerrar puertas se guarda correctamente al mover un token
+- **Mirilla funcional para ataques** - Los jugadores pueden seleccionar objetivos enemigos con un clic y atacar con un segundo clic
+- **La mirilla apunta a tokens ajenos** - Ahora también puedes fijar como objetivo fichas controladas por otros jugadores o por el máster
+- **Doble clic seguro en mirilla** - Al usar la mirilla, el doble clic ya no abre el menú de ajustes del token
 
 #### v2.1.1 (junio 2024)
 
@@ -1034,7 +1037,12 @@ src/
 - ✅ Ventanas de ataque y defensa con tiradas automáticas
 - ✅ Las barras de vida de fichas de otros jugadores ahora se cargan
   automáticamente
-- ✅ Selección automática del atacante y línea que sigue al cursor
+- ✅ Debes elegir tu propio token como atacante y la selección se mantiene hasta cambiar de herramienta
+- ✅ Puede apuntar a tokens controlados por otros jugadores o el máster
+- ✅ Un clic fija el objetivo y el siguiente inicia el ataque
+- ✅ El doble clic no abre ajustes de token cuando se usa la mirilla
+- ✅ El objetivo se reconoce al pulsar en cualquier punto de su casilla
+- ✅ El atacante y el objetivo se destacan con un marco de color
 
 ### 🔄 **Sincronización automática de fichas (Octubre 2026) - v2.4.22**
 
@@ -1050,6 +1058,17 @@ src/
 - ✅ La ficha de jugador se actualiza automáticamente al recibir el evento `playerSheetSaved` desde otras pestañas o tokens
 - ✅ Al detectar cambios en `localStorage`, la ficha se actualiza sin recargar la página
 - ✅ Los estados de los tokens controlados se sincronizan al instante al modificarse `localStorage`
+
+### 🐞 **Corrección de la mirilla para el máster (Diciembre 2026) - v2.4.24**
+
+- ✅ El máster puede seleccionar cualquier token como atacante sin fijar objetivo automáticamente
+- ✅ El objetivo solo se fija al hacer clic sobre otro token, permitiendo cambiarlo fácilmente
+- ✅ Prueba unitaria garantiza el funcionamiento correcto
+
+### 🎯 **Alcance de armas y poderes (Enero 2027) - v2.4.25**
+
+- ✅ El menú de ataque y defensa solo muestra armas o poderes al alcance
+- ✅ Mensajes claros cuando no hay equipamiento o ningún arma puede utilizarse
 
 
 

--- a/src/components/DefenseModal.jsx
+++ b/src/components/DefenseModal.jsx
@@ -16,24 +16,52 @@ const DefenseModal = ({ isOpen, attacker, target, distance, attackResult, onClos
     return sheets[target.tokenSheetId] || null;
   }, [target]);
 
+  const parseRange = (val) => {
+    if (!val && val !== 0) return Infinity;
+    const map = {
+      toque: 1,
+      cercano: 2,
+      intermedio: 3,
+      lejano: 4,
+      extremo: 5,
+    };
+    if (typeof val === 'string') {
+      const key = val.trim().toLowerCase();
+      if (map[key]) return map[key];
+      const n = parseInt(key, 10);
+      if (!isNaN(n)) return n;
+    }
+    const n = parseInt(val, 10);
+    return isNaN(n) ? Infinity : n;
+  };
+
   const weapons = useMemo(() => {
     if (!sheet) return [];
     return (sheet.weapons || []).filter(w => {
-      const alc = parseInt(w.alcance, 10);
-      return isNaN(alc) || distance <= alc;
+      const alc = parseRange(w.alcance);
+      return distance <= alc;
     });
   }, [sheet, distance]);
 
   const powers = useMemo(() => {
     if (!sheet) return [];
     return (sheet.poderes || []).filter(p => {
-      const alc = parseInt(p.alcance, 10);
-      return isNaN(alc) || distance <= alc;
+      const alc = parseRange(p.alcance);
+      return distance <= alc;
     });
   }, [sheet, distance]);
 
   const [choice, setChoice] = useState('');
   const [loading, setLoading] = useState(false);
+
+  const hasEquip = useMemo(() => {
+    if (!sheet) return false;
+    const w = sheet.weapons || [];
+    const p = sheet.poderes || [];
+    return w.length > 0 || p.length > 0;
+  }, [sheet]);
+
+  const hasAvailable = weapons.length > 0 || powers.length > 0;
 
   if (!attacker || !target) return null;
 
@@ -86,21 +114,35 @@ const DefenseModal = ({ isOpen, attacker, target, distance, attackResult, onClos
       <div className="space-y-4">
         <div>
           <p className="text-sm text-gray-300 mb-1">Distancia: {distance} casillas</p>
-          <select
-            value={choice}
-            onChange={e => setChoice(e.target.value)}
-            className="w-full bg-gray-700 text-white"
-          >
-            <option value="">Selecciona arma o poder</option>
-            {weapons.map(w => (
-              <option key={`w-${w.nombre}`} value={w.nombre}>{w.nombre}</option>
-            ))}
-            {powers.map(p => (
-              <option key={`p-${p.nombre}`} value={p.nombre}>{p.nombre}</option>
-            ))}
-          </select>
+          {hasEquip ? (
+            hasAvailable ? (
+              <select
+                value={choice}
+                onChange={e => setChoice(e.target.value)}
+                className="w-full bg-gray-700 text-white"
+              >
+                <option value="">Selecciona arma o poder</option>
+                {weapons.map(w => (
+                  <option key={`w-${w.nombre}`} value={w.nombre}>{w.nombre}</option>
+                ))}
+                {powers.map(p => (
+                  <option key={`p-${p.nombre}`} value={p.nombre}>{p.nombre}</option>
+                ))}
+              </select>
+            ) : (
+              <p className="text-red-400 text-sm">No hay ningún arma disponible al alcance</p>
+            )
+          ) : (
+            <p className="text-red-400 text-sm">No hay armas o poderes equipados</p>
+          )}
         </div>
-        <Boton color="green" onClick={handleRoll} loading={loading} className="w-full">
+        <Boton
+          color="green"
+          onClick={handleRoll}
+          loading={loading}
+          className="w-full"
+          disabled={!hasAvailable}
+        >
           Lanzar
         </Boton>
       </div>

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -332,12 +332,15 @@ const Token = forwardRef(
       draggable = true,
       listening = true,
       opacity = 1,
+      isAttacker = false,
+      isTarget = false,
       onDragEnd,
       onDragStart,
       onClick,
       onTransformEnd,
       onRotate,
       onSettings,
+      activeTool = 'select',
       onStates,
       onHoverChange,
       tokenSheetId,
@@ -665,12 +668,20 @@ const Token = forwardRef(
       listening: false,
     };
 
+    const roleOutline = isAttacker
+      ? { stroke: '#f6e05e', strokeWidth: 3, dash: [4, 4] }
+      : isTarget
+        ? { stroke: '#f87171', strokeWidth: 3, dash: [4, 4] }
+        : null;
+
     return (
       <Group
         ref={groupRef}
         onMouseEnter={() => onHoverChange?.(true)}
         onMouseLeave={() => onHoverChange?.(false)}
-        onDblClick={() => onSettings?.(id)}
+        onDblClick={() => {
+          if (activeTool !== 'target') onSettings?.(id);
+        }}
       >
         {auraRadius > 0 &&
           showAura &&
@@ -715,6 +726,7 @@ const Token = forwardRef(
             )}
           </>
         )}
+        {roleOutline && <Rect {...outline} {...roleOutline} />}
         {selected && <Rect {...outline} />}
         {estadosInfo.length > 0 && (
           <Group listening={false}>
@@ -868,6 +880,9 @@ Token.propTypes = {
   onHoverChange: PropTypes.func,
   estados: PropTypes.array,
   tokenSheetId: PropTypes.string,
+  activeTool: PropTypes.string,
+  isAttacker: PropTypes.bool,
+  isTarget: PropTypes.bool,
 };
 
 /**
@@ -945,10 +960,20 @@ const MapCanvas = ({
 
   // Estados para sistema de ataque
   const [attackSourceId, setAttackSourceId] = useState(null);
+  const attackSourceIdRef = useRef(null);
   const [attackTargetId, setAttackTargetId] = useState(null);
+  const attackTargetIdRef = useRef(null);
   const [attackLine, setAttackLine] = useState(null);
   const [attackResult, setAttackResult] = useState(null);
   const [attackReady, setAttackReady] = useState(false);
+
+  useEffect(() => {
+    attackSourceIdRef.current = attackSourceId;
+  }, [attackSourceId]);
+
+  useEffect(() => {
+    attackTargetIdRef.current = attackTargetId;
+  }, [attackTargetId]);
 
   useEffect(() => {
     if (activeTool !== 'target') {
@@ -2553,38 +2578,31 @@ const MapCanvas = ({
   // Iniciar acciones según la herramienta seleccionada
   const handleMouseDown = (e) => {
     if (activeTool === 'target' && e.evt.button === 0) {
-      // Autoseleccionar atacante si solo hay un token en la selección
-      if (!attackSourceId) {
-        const candidates = selectedTokens.length === 1
-          ? selectedTokens
-          : selectedTokens.length === 0 && selectedId != null
-            ? [selectedId]
-            : [];
-        if (candidates.length === 1) {
-          setAttackSourceId(candidates[0]);
-        }
-      }
 
       const pointer = stageRef.current.getPointerPosition();
       let relX = (pointer.x - groupPos.x) / (baseScale * zoom);
       let relY = (pointer.y - groupPos.y) / (baseScale * zoom);
-      const cellX = pxToCell(relX, gridOffsetX);
-      const cellY = pxToCell(relY, gridOffsetY);
+      const cellX = Math.floor((relX - gridOffsetX) / effectiveGridSize);
+      const cellY = Math.floor((relY - gridOffsetY) / effectiveGridSize);
       const clicked = tokens.find(t =>
         cellX >= t.x && cellX < t.x + (t.w || 1) &&
         cellY >= t.y && cellY < t.y + (t.h || 1)
       );
-      if (clicked && canSelectElement(clicked, 'token')) {
-        const sourceId = attackSourceId || (selectedTokens.length === 1
-          ? selectedTokens[0]
-          : selectedTokens.length === 0 && selectedId != null
-            ? selectedId
-            : null);
+      if (clicked) {
+        const sourceId = attackSourceIdRef.current;
+        const isOwnToken = clicked.controlledBy === playerName;
+        const canSelectAsSource = userType === 'master' || isOwnToken;
+        const canSelectAsTarget = userType === 'master' ? clicked.id !== sourceId : (!isOwnToken && clicked.id !== sourceId);
+
         if (!sourceId) {
-          setAttackSourceId(clicked.id);
-        } else if (attackTargetId == null && clicked.id !== sourceId) {
-          setAttackSourceId(sourceId);
+          if (canSelectAsSource && canSelectElement(clicked, 'token')) {
+            setAttackSourceId(clicked.id);
+            attackSourceIdRef.current = clicked.id;
+            return;
+          }
+        } else if (attackTargetIdRef.current == null && canSelectAsTarget) {
           setAttackTargetId(clicked.id);
+          attackTargetIdRef.current = clicked.id;
           const source = tokens.find(t => t.id === sourceId);
           if (source) {
             const sx = cellToPx(source.x + (source.w || 1) / 2, gridOffsetX);
@@ -2594,10 +2612,11 @@ const MapCanvas = ({
             setAttackLine([sx, sy, tx, ty]);
           }
           setAttackReady(false);
-        } else if (attackTargetId === clicked.id) {
+        } else if (attackTargetIdRef.current === clicked.id) {
           if (!attackReady) setAttackReady(true);
-        } else if (clicked.id !== sourceId) {
+        } else if (canSelectAsTarget) {
           setAttackTargetId(clicked.id);
+          attackTargetIdRef.current = clicked.id;
           const source = tokens.find(t => t.id === sourceId);
           if (source) {
             const sx = cellToPx(source.x + (source.w || 1) / 2, gridOffsetX);
@@ -3159,7 +3178,12 @@ const MapCanvas = ({
       // Cancelar mirilla o deseleccionar con Escape
       if (e.key === 'Escape') {
         e.preventDefault();
-        if (attackSourceId || attackTargetId) {
+        if (activeTool === 'target' && (attackSourceId || attackTargetId)) {
+          setAttackTargetId(null);
+          setAttackLine(null);
+          setAttackResult(null);
+          setAttackReady(false);
+        } else if (attackSourceId || attackTargetId) {
           setAttackSourceId(null);
           setAttackTargetId(null);
           setAttackLine(null);
@@ -3663,6 +3687,8 @@ const MapCanvas = ({
                   auraShape={token.auraShape}
                   auraColor={token.auraColor}
                   auraOpacity={token.auraOpacity}
+                  isAttacker={activeTool === 'target' && token.id === attackSourceId}
+                  isTarget={activeTool === 'target' && token.id === attackTargetId}
                   selected={token.id === selectedId || selectedTokens.includes(token.id)}
                   onDragEnd={handleDragEnd}
                   onDragStart={handleDragStart}
@@ -3698,6 +3724,7 @@ const MapCanvas = ({
                     activeTool === 'select' && canSelectElement(token, 'token')
                   }
                   listening={activeTool === 'select' || activeTool === 'target'}
+                  activeTool={activeTool}
                 />
               ))}
               {filteredLines.map((ln) => (
@@ -4378,7 +4405,6 @@ const MapCanvas = ({
             if (res) setAttackResult(res);
             setAttackReady(false);
             if (!res) {
-              setAttackSourceId(null);
               setAttackTargetId(null);
               setAttackLine(null);
             }
@@ -4396,7 +4422,6 @@ const MapCanvas = ({
           )) : 0}
           attackResult={attackResult}
           onClose={() => {
-            setAttackSourceId(null);
             setAttackTargetId(null);
             setAttackLine(null);
             setAttackResult(null);

--- a/src/components/__tests__/AttackTool.test.js
+++ b/src/components/__tests__/AttackTool.test.js
@@ -3,7 +3,12 @@ import React from 'react';
 import userEvent from '@testing-library/user-event';
 import AttackModal from '../AttackModal';
 
-function AttackToolDemo({ selectedId } = {}) {
+function AttackToolDemo({
+  selectedId,
+  playerName = 'player',
+  userType = 'player',
+  onSettings,
+} = {}) {
   const [activeTool, setActiveTool] = React.useState('select');
   const [attackSourceId, setAttackSourceId] = React.useState(null);
   const [attackTargetId, setAttackTargetId] = React.useState(null);
@@ -11,32 +16,36 @@ function AttackToolDemo({ selectedId } = {}) {
   const [attackReady, setAttackReady] = React.useState(false);
 
   const tokens = [
-    { id: 'a', x: 10, y: 10 },
-    { id: 'b', x: 80, y: 10 },
+    { id: 'a', x: 10, y: 10, controlledBy: playerName },
+    { id: 'b', x: 80, y: 10, controlledBy: 'other' },
   ];
 
   const handleClick = (id) => {
     if (activeTool !== 'target') return;
-    const attacker = attackSourceId || selectedId;
+    const attacker = attackSourceId;
+    const clicked = tokens.find((t) => t.id === id);
+    const isOwn = clicked.controlledBy === playerName;
+    const canSource = userType === 'master' || isOwn;
+    const canTarget = userType === 'master' ? id !== attacker : (!isOwn && id !== attacker);
     if (!attacker) {
-      setAttackSourceId(id);
-    } else if (attackTargetId == null && id !== attacker) {
-      setAttackSourceId(attacker);
+      if (canSource) {
+        setAttackSourceId(id);
+        return;
+      }
+    } else if (attackTargetId == null && canTarget) {
       setAttackTargetId(id);
       const source = tokens.find((t) => t.id === attacker);
-      const target = tokens.find((t) => t.id === id);
-      if (source && target) {
-        setAttackLine([source.x, source.y, target.x, target.y]);
+      if (source && clicked) {
+        setAttackLine([source.x, source.y, clicked.x, clicked.y]);
       }
       setAttackReady(false);
     } else if (attackTargetId === id) {
       if (!attackReady) setAttackReady(true);
-    } else if (id !== attacker) {
+    } else if (canTarget) {
       setAttackTargetId(id);
       const source = tokens.find((t) => t.id === attacker);
-      const target = tokens.find((t) => t.id === id);
-      if (source && target) {
-        setAttackLine([source.x, source.y, target.x, target.y]);
+      if (source && clicked) {
+        setAttackLine([source.x, source.y, clicked.x, clicked.y]);
       }
       setAttackReady(false);
     }
@@ -58,20 +67,32 @@ function AttackToolDemo({ selectedId } = {}) {
         onMouseMove={handleMove}
         style={{ position: 'relative', width: 100, height: 40 }}
       >
-        {tokens.map((t) => (
-          <div
-            key={t.id}
-            data-testid={t.id}
-            onClick={() => handleClick(t.id)}
-            style={{
-              position: 'absolute',
-              left: t.x,
-              top: t.y,
-              width: 10,
-              height: 10,
-            }}
-          />
-        ))}
+        {tokens.map((t) => {
+          const border =
+            attackSourceId === t.id
+              ? '2px solid yellow'
+              : attackTargetId === t.id
+              ? '2px solid red'
+              : 'none';
+          return (
+            <div
+              key={t.id}
+              data-testid={t.id}
+              onClick={() => handleClick(t.id)}
+              onDoubleClick={() => {
+                if (activeTool !== 'target') onSettings?.(t.id);
+              }}
+              style={{
+                position: 'absolute',
+                left: t.x,
+                top: t.y,
+                width: 10,
+                height: 10,
+                border,
+              }}
+            />
+          );
+        })}
         <svg>{attackLine && <line data-testid="line" />}</svg>
       </div>
       {attackReady && attackTargetId && (
@@ -107,14 +128,26 @@ test('crosshair tool selects source and target', async () => {
   await userEvent.click(screen.getByTestId('b'));
   expect(screen.getByTestId('line')).toBeInTheDocument();
   expect(screen.queryByText('Ataque')).toBeNull();
+  expect(screen.getByTestId('a')).toHaveStyle('border: 2px solid yellow');
+  expect(screen.getByTestId('b')).toHaveStyle('border: 2px solid red');
 });
 
-test('auto selects attacker if a token was preselected', async () => {
+test('does not auto select attacker from previous selection', async () => {
   render(<AttackToolDemo selectedId="a" />);
   await userEvent.click(screen.getByTestId('target-tool'));
   await userEvent.click(screen.getByTestId('b'));
+  expect(screen.queryByTestId('line')).toBeNull();
+  await userEvent.click(screen.getByTestId('a'));
+  await userEvent.click(screen.getByTestId('b'));
   expect(screen.getByTestId('line')).toBeInTheDocument();
-  expect(screen.queryByText('Ataque')).toBeNull();
+});
+
+test('allows targeting tokens controlled by another player', async () => {
+  render(<AttackToolDemo playerName="alice" />);
+  await userEvent.click(screen.getByTestId('target-tool'));
+  await userEvent.click(screen.getByTestId('a'));
+  await userEvent.click(screen.getByTestId('b'));
+  expect(screen.getByTestId('line')).toBeInTheDocument();
 });
 
 test('attack modal appears on second click over same target', async () => {
@@ -125,4 +158,50 @@ test('attack modal appears on second click over same target', async () => {
   expect(screen.queryByText('Ataque')).toBeNull();
   await userEvent.click(screen.getByTestId('b'));
   expect(screen.getByText('Ataque')).toBeInTheDocument();
+});
+
+test('double click does not open settings while targeting', async () => {
+  const onSettings = jest.fn();
+  render(<AttackToolDemo onSettings={onSettings} />);
+  await userEvent.click(screen.getByTestId('target-tool'));
+  await userEvent.click(screen.getByTestId('a'));
+  await userEvent.dblClick(screen.getByTestId('b'));
+  expect(onSettings).not.toHaveBeenCalled();
+});
+
+test('master selects attacker then target without auto-targeting first click', async () => {
+  render(<AttackToolDemo userType="master" playerName="master" />);
+  await userEvent.click(screen.getByTestId('target-tool'));
+  await userEvent.click(screen.getByTestId('a')); // choose attacker
+  expect(screen.queryByTestId('line')).toBeNull();
+  await userEvent.click(screen.getByTestId('b')); // choose target
+  expect(screen.getByTestId('line')).toBeInTheDocument();
+});
+
+test('shows message when no equipment', () => {
+  localStorage.setItem('tokenSheets', JSON.stringify({ '1': { id: '1', weapons: [], poderes: [] } }));
+  render(
+    <AttackModal
+      isOpen
+      attacker={{ name: 'A', tokenSheetId: '1' }}
+      target={{ name: 'B', tokenSheetId: '2' }}
+      distance={2}
+      onClose={() => {}}
+    />
+  );
+  expect(screen.getByText(/no hay armas o poderes equipados/i)).toBeInTheDocument();
+});
+
+test('shows message when equipment out of range', () => {
+  localStorage.setItem('tokenSheets', JSON.stringify({ '1': { id: '1', weapons: [{ nombre: 'Espada', alcance: 'Toque' }], poderes: [] } }));
+  render(
+    <AttackModal
+      isOpen
+      attacker={{ name: 'A', tokenSheetId: '1' }}
+      target={{ name: 'B', tokenSheetId: '2' }}
+      distance={3}
+      onClose={() => {}}
+    />
+  );
+  expect(screen.getByText(/no hay ningún arma disponible al alcance/i)).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- parse categorical ranges for weapons and powers
- filter attack and defense options by distance
- display messages when no equipment or none in range
- document attack range filtering in README

## Testing
- `npm install --silent`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_687a2705b8648326b139a993427fb40f