### PR TITLE
Enable editable damage field

### DIFF
--- a/README.md
+++ b/README.md
@@ -864,6 +864,9 @@ src/
 - **Guardado exclusivo para el máster** - Los tokens, líneas y otros datos del mapa solo se guardan si el usuario es máster
 - **Menús de token robustos** - Se eliminan IDs obsoletos al abrir configuraciones o estados, evitando errores si la ficha fue borrada
 - **Sincronización de puertas** - Abrir o cerrar puertas se guarda correctamente al mover un token
+- **Mirilla funcional para ataques** - Los jugadores pueden seleccionar objetivos enemigos con un clic y atacar con un segundo clic
+- **La mirilla apunta a tokens ajenos** - Ahora también puedes fijar como objetivo fichas controladas por otros jugadores o por el máster
+- **Doble clic seguro en mirilla** - Al usar la mirilla, el doble clic ya no abre el menú de ajustes del token
 
 #### v2.1.1 (junio 2024)
 
@@ -1034,7 +1037,12 @@ src/
 - ✅ Ventanas de ataque y defensa con tiradas automáticas
 - ✅ Las barras de vida de fichas de otros jugadores ahora se cargan
   automáticamente
-- ✅ Selección automática del atacante y línea que sigue al cursor
+- ✅ Debes elegir tu propio token como atacante y la selección se mantiene hasta cambiar de herramienta
+- ✅ Puede apuntar a tokens controlados por otros jugadores o el máster
+- ✅ Un clic fija el objetivo y el siguiente inicia el ataque
+- ✅ El doble clic no abre ajustes de token cuando se usa la mirilla
+- ✅ El objetivo se reconoce al pulsar en cualquier punto de su casilla
+- ✅ El atacante y el objetivo se destacan con un marco de color
 
 ### 🔄 **Sincronización automática de fichas (Octubre 2026) - v2.4.22**
 
@@ -1050,6 +1058,33 @@ src/
 - ✅ La ficha de jugador se actualiza automáticamente al recibir el evento `playerSheetSaved` desde otras pestañas o tokens
 - ✅ Al detectar cambios en `localStorage`, la ficha se actualiza sin recargar la página
 - ✅ Los estados de los tokens controlados se sincronizan al instante al modificarse `localStorage`
+
+### 🐞 **Corrección de la mirilla para el máster (Diciembre 2026) - v2.4.24**
+
+- ✅ El máster puede seleccionar cualquier token como atacante sin fijar objetivo automáticamente
+- ✅ El objetivo solo se fija al hacer clic sobre otro token, permitiendo cambiarlo fácilmente
+- ✅ Prueba unitaria garantiza el funcionamiento correcto
+
+### 🎯 **Alcance de armas y poderes (Enero 2027) - v2.4.25**
+
+- ✅ El menú de ataque y defensa solo muestra armas o poderes al alcance
+- ✅ Mensajes claros cuando no hay equipamiento o ningún arma puede utilizarse
+
+### 🛠️ **Corrección de nombres y daño de armas (Enero 2027) - v2.4.26**
+
+- ✅ Los menús de ataque y defensa listan correctamente las armas y poderes equipados
+- ✅ Se tiene en cuenta el alcance aún cuando proviene de valores como "Cuerpo a cuerpo" o "Media"
+- ✅ Las tiradas utilizan el daño definido para cada arma o poder
+
+### 🎯 **Ajuste de valores de alcance (Enero 2027) - v2.4.27**
+
+- ✅ Los alcances se limitan a cinco categorías: Toque, Cercano, Intermedio, Lejano y Extremo
+- ✅ Se eliminan sinónimos como "corto" o "media" para evitar confusiones
+
+### ⚔️ **Daño editable en ataques (Enero 2027) - v2.4.28**
+
+- ✅ Al escoger un arma o poder aparece un campo con su daño por defecto
+- ✅ Dicho campo es editable para modificar la tirada de ataque o defensa
 
 
 

--- a/src/components/AttackModal.jsx
+++ b/src/components/AttackModal.jsx
@@ -7,7 +7,15 @@ import { doc, getDoc, setDoc } from 'firebase/firestore';
 import { db } from '../firebase';
 import { nanoid } from 'nanoid';
 
-const AttackModal = ({ isOpen, attacker, target, distance, onClose }) => {
+const AttackModal = ({
+  isOpen,
+  attacker,
+  target,
+  distance,
+  armas = [],
+  poderesCatalog = [],
+  onClose,
+}) => {
   const sheet = useMemo(() => {
     if (!attacker?.tokenSheetId) return null;
     const stored = localStorage.getItem('tokenSheets');
@@ -16,30 +24,79 @@ const AttackModal = ({ isOpen, attacker, target, distance, onClose }) => {
     return sheets[attacker.tokenSheetId] || null;
   }, [attacker]);
 
-  const weapons = useMemo(() => {
-    if (!sheet) return [];
-    return (sheet.weapons || []).filter(w => {
-      const alc = parseInt(w.alcance, 10);
-      return isNaN(alc) || distance <= alc;
-    });
-  }, [sheet, distance]);
+  const parseRange = (val) => {
+    if (!val && val !== 0) return Infinity;
+    const map = {
+      toque: 1,
+      cercano: 2,
+      intermedio: 3,
+      lejano: 4,
+      extremo: 5,
+    };
+    if (typeof val === 'string') {
+      const key = val.trim().toLowerCase();
+      if (map[key]) return map[key];
+      const n = parseInt(key, 10);
+      if (!isNaN(n)) return n;
+    }
+    const n = parseInt(val, 10);
+    return isNaN(n) ? Infinity : n;
+  };
 
-  const powers = useMemo(() => {
+  const mapItem = (it, catalog) => {
+    if (!it) return null;
+    if (typeof it === 'string') {
+      return catalog.find((c) => c.nombre === it) || { nombre: it };
+    }
+    return it;
+  };
+
+  const weaponObjs = useMemo(() => {
     if (!sheet) return [];
-    return (sheet.poderes || []).filter(p => {
-      const alc = parseInt(p.alcance, 10);
-      return isNaN(alc) || distance <= alc;
-    });
-  }, [sheet, distance]);
+    return (sheet.weapons || []).map((w) => mapItem(w, armas));
+  }, [sheet, armas]);
+
+  const weapons = useMemo(
+    () =>
+      weaponObjs.filter((w) => {
+        const alc = parseRange(w.alcance);
+        return distance <= alc;
+      }),
+    [weaponObjs, distance]
+  );
+
+  const powerObjs = useMemo(() => {
+    if (!sheet) return [];
+    return (sheet.poderes || []).map((p) => mapItem(p, poderesCatalog));
+  }, [sheet, poderesCatalog]);
+
+  const powers = useMemo(
+    () =>
+      powerObjs.filter((p) => {
+        const alc = parseRange(p.alcance);
+        return distance <= alc;
+      }),
+    [powerObjs, distance]
+  );
 
   const [choice, setChoice] = useState('');
+  const [damage, setDamage] = useState('');
   const [loading, setLoading] = useState(false);
+
+  const hasEquip = useMemo(() => {
+    if (!sheet) return false;
+    const w = sheet.weapons || [];
+    const p = sheet.poderes || [];
+    return w.length > 0 || p.length > 0;
+  }, [sheet]);
+
+  const hasAvailable = weapons.length > 0 || powers.length > 0;
 
   if (!attacker || !target) return null;
 
   const handleRoll = async () => {
     const item = [...weapons, ...powers].find(i => i.nombre === choice);
-    const formula = item?.dano || '1d20';
+    const formula = damage || item?.dano || '1d20';
     setLoading(true);
     try {
       const result = rollExpression(formula);
@@ -66,21 +123,51 @@ const AttackModal = ({ isOpen, attacker, target, distance, onClose }) => {
       <div className="space-y-4">
         <div>
           <p className="text-sm text-gray-300 mb-1">Distancia: {distance} casillas</p>
-          <select
-            value={choice}
-            onChange={e => setChoice(e.target.value)}
-            className="w-full bg-gray-700 text-white"
-          >
-            <option value="">Selecciona arma o poder</option>
-            {weapons.map(w => (
-              <option key={`w-${w.nombre}`} value={w.nombre}>{w.nombre}</option>
-            ))}
-            {powers.map(p => (
-              <option key={`p-${p.nombre}`} value={p.nombre}>{p.nombre}</option>
-            ))}
-          </select>
+          {hasEquip ? (
+            hasAvailable ? (
+              <>
+              <select
+                value={choice}
+                onChange={e => {
+                  const val = e.target.value;
+                  setChoice(val);
+                  const item = [...weapons, ...powers].find(i => i.nombre === val);
+                  setDamage(item?.dano || '');
+                }}
+                className="w-full bg-gray-700 text-white"
+              >
+                <option value="">Selecciona arma o poder</option>
+                {weapons.map(w => (
+                  <option key={`w-${w.nombre}`} value={w.nombre}>{w.nombre}</option>
+                ))}
+                {powers.map(p => (
+                  <option key={`p-${p.nombre}`} value={p.nombre}>{p.nombre}</option>
+                ))}
+              </select>
+              {choice && (
+                <input
+                  type="text"
+                  value={damage}
+                  onChange={e => setDamage(e.target.value)}
+                  className="w-full mt-2 bg-gray-700 text-white px-2 py-1"
+                  placeholder="Daño"
+                />
+              )}
+              </>
+            ) : (
+              <p className="text-red-400 text-sm">No hay ningún arma disponible al alcance</p>
+            )
+          ) : (
+            <p className="text-red-400 text-sm">No hay armas o poderes equipados</p>
+          )}
         </div>
-        <Boton color="green" onClick={handleRoll} loading={loading} className="w-full">
+        <Boton
+          color="green"
+          onClick={handleRoll}
+          loading={loading}
+          className="w-full"
+          disabled={!hasAvailable}
+        >
           Lanzar
         </Boton>
       </div>
@@ -93,6 +180,8 @@ AttackModal.propTypes = {
   attacker: PropTypes.object,
   target: PropTypes.object,
   distance: PropTypes.number,
+  armas: PropTypes.array,
+  poderesCatalog: PropTypes.array,
   onClose: PropTypes.func,
 };
 

--- a/src/components/DefenseModal.jsx
+++ b/src/components/DefenseModal.jsx
@@ -7,7 +7,16 @@ import { doc, getDoc, setDoc } from 'firebase/firestore';
 import { db } from '../firebase';
 import { nanoid } from 'nanoid';
 
-const DefenseModal = ({ isOpen, attacker, target, distance, attackResult, onClose }) => {
+const DefenseModal = ({
+  isOpen,
+  attacker,
+  target,
+  distance,
+  attackResult,
+  armas = [],
+  poderesCatalog = [],
+  onClose,
+}) => {
   const sheet = useMemo(() => {
     if (!target?.tokenSheetId) return null;
     const stored = localStorage.getItem('tokenSheets');
@@ -16,30 +25,79 @@ const DefenseModal = ({ isOpen, attacker, target, distance, attackResult, onClos
     return sheets[target.tokenSheetId] || null;
   }, [target]);
 
-  const weapons = useMemo(() => {
-    if (!sheet) return [];
-    return (sheet.weapons || []).filter(w => {
-      const alc = parseInt(w.alcance, 10);
-      return isNaN(alc) || distance <= alc;
-    });
-  }, [sheet, distance]);
+  const parseRange = (val) => {
+    if (!val && val !== 0) return Infinity;
+    const map = {
+      toque: 1,
+      cercano: 2,
+      intermedio: 3,
+      lejano: 4,
+      extremo: 5,
+    };
+    if (typeof val === 'string') {
+      const key = val.trim().toLowerCase();
+      if (map[key]) return map[key];
+      const n = parseInt(key, 10);
+      if (!isNaN(n)) return n;
+    }
+    const n = parseInt(val, 10);
+    return isNaN(n) ? Infinity : n;
+  };
 
-  const powers = useMemo(() => {
+  const mapItem = (it, catalog) => {
+    if (!it) return null;
+    if (typeof it === 'string') {
+      return catalog.find((c) => c.nombre === it) || { nombre: it };
+    }
+    return it;
+  };
+
+  const weaponObjs = useMemo(() => {
     if (!sheet) return [];
-    return (sheet.poderes || []).filter(p => {
-      const alc = parseInt(p.alcance, 10);
-      return isNaN(alc) || distance <= alc;
-    });
-  }, [sheet, distance]);
+    return (sheet.weapons || []).map((w) => mapItem(w, armas));
+  }, [sheet, armas]);
+
+  const weapons = useMemo(
+    () =>
+      weaponObjs.filter((w) => {
+        const alc = parseRange(w.alcance);
+        return distance <= alc;
+      }),
+    [weaponObjs, distance]
+  );
+
+  const powerObjs = useMemo(() => {
+    if (!sheet) return [];
+    return (sheet.poderes || []).map((p) => mapItem(p, poderesCatalog));
+  }, [sheet, poderesCatalog]);
+
+  const powers = useMemo(
+    () =>
+      powerObjs.filter((p) => {
+        const alc = parseRange(p.alcance);
+        return distance <= alc;
+      }),
+    [powerObjs, distance]
+  );
 
   const [choice, setChoice] = useState('');
+  const [damage, setDamage] = useState('');
   const [loading, setLoading] = useState(false);
+
+  const hasEquip = useMemo(() => {
+    if (!sheet) return false;
+    const w = sheet.weapons || [];
+    const p = sheet.poderes || [];
+    return w.length > 0 || p.length > 0;
+  }, [sheet]);
+
+  const hasAvailable = weapons.length > 0 || powers.length > 0;
 
   if (!attacker || !target) return null;
 
   const handleRoll = async () => {
     const item = [...weapons, ...powers].find(i => i.nombre === choice);
-    const formula = item?.dano || '1d20';
+    const formula = damage || item?.dano || '1d20';
     setLoading(true);
     try {
       const result = rollExpression(formula);
@@ -86,21 +144,51 @@ const DefenseModal = ({ isOpen, attacker, target, distance, attackResult, onClos
       <div className="space-y-4">
         <div>
           <p className="text-sm text-gray-300 mb-1">Distancia: {distance} casillas</p>
-          <select
-            value={choice}
-            onChange={e => setChoice(e.target.value)}
-            className="w-full bg-gray-700 text-white"
-          >
-            <option value="">Selecciona arma o poder</option>
-            {weapons.map(w => (
-              <option key={`w-${w.nombre}`} value={w.nombre}>{w.nombre}</option>
-            ))}
-            {powers.map(p => (
-              <option key={`p-${p.nombre}`} value={p.nombre}>{p.nombre}</option>
-            ))}
-          </select>
+          {hasEquip ? (
+            hasAvailable ? (
+              <>
+              <select
+                value={choice}
+                onChange={e => {
+                  const val = e.target.value;
+                  setChoice(val);
+                  const item = [...weapons, ...powers].find(i => i.nombre === val);
+                  setDamage(item?.dano || '');
+                }}
+                className="w-full bg-gray-700 text-white"
+              >
+                <option value="">Selecciona arma o poder</option>
+                {weapons.map(w => (
+                  <option key={`w-${w.nombre}`} value={w.nombre}>{w.nombre}</option>
+                ))}
+                {powers.map(p => (
+                  <option key={`p-${p.nombre}`} value={p.nombre}>{p.nombre}</option>
+                ))}
+              </select>
+              {choice && (
+                <input
+                  type="text"
+                  value={damage}
+                  onChange={e => setDamage(e.target.value)}
+                  className="w-full mt-2 bg-gray-700 text-white px-2 py-1"
+                  placeholder="Daño"
+                />
+              )}
+              </>
+            ) : (
+              <p className="text-red-400 text-sm">No hay ningún arma disponible al alcance</p>
+            )
+          ) : (
+            <p className="text-red-400 text-sm">No hay armas o poderes equipados</p>
+          )}
         </div>
-        <Boton color="green" onClick={handleRoll} loading={loading} className="w-full">
+        <Boton
+          color="green"
+          onClick={handleRoll}
+          loading={loading}
+          className="w-full"
+          disabled={!hasAvailable}
+        >
           Lanzar
         </Boton>
       </div>
@@ -114,6 +202,8 @@ DefenseModal.propTypes = {
   target: PropTypes.object,
   distance: PropTypes.number,
   attackResult: PropTypes.object,
+  armas: PropTypes.array,
+  poderesCatalog: PropTypes.array,
   onClose: PropTypes.func,
 };
 


### PR DESCRIPTION
## Summary
- add editable damage field in AttackModal and DefenseModal
- update tests with new damage field
- document feature in README

## Testing
- `npm install --silent`
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687a2705b8648326b139a993427fb40f