### PR TITLE
Update power card damage layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -769,6 +769,7 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 
 - El ataque con la herramienta de mirilla ahora requiere pulsar dos veces sobre
   el objetivo para mostrar el modal de ataque.
+- Las tarjetas de poderes equipados muestran ahora **Daño** justo debajo del nombre, antes de **Alcance**, usando el valor definido en el campo Poder al crear la habilidad.
 
 ### 🛠️ **Características Técnicas**
 

--- a/src/App.js
+++ b/src/App.js
@@ -3737,6 +3737,9 @@ function App() {
                     >
                       <p className="font-bold text-lg">{p.nombre}</p>
                       <p>
+                        <strong>Daño:</strong> {p.poder}
+                      </p>
+                      <p>
                         <strong>Alcance:</strong> {p.alcance}
                       </p>
                       <p>
@@ -3747,9 +3750,6 @@ function App() {
                       </p>
                       <p>
                         <strong>Mente:</strong> {p.mente}
-                      </p>
-                      <p>
-                        <strong>Poder:</strong> {p.poder}
                       </p>
                       {p.descripcion && (
                         <p className="italic">{highlightText(p.descripcion)}</p>
@@ -4370,16 +4370,16 @@ function App() {
                               <p className="font-bold">{power.nombre}</p>
                             </div>
                             <p className="text-xs mb-1">
+                              <span className="font-medium">Daño:</span>{' '}
+                              {power.poder}
+                            </p>
+                            <p className="text-xs mb-1">
                               <span className="font-medium">Alcance:</span>{' '}
                               {power.alcance}
                             </p>
                             <p className="text-xs mb-1">
                               <span className="font-medium">Consumo:</span>{' '}
                               {power.consumo}
-                            </p>
-                            <p className="text-xs mb-1">
-                              <span className="font-medium">Poder:</span>{' '}
-                              {power.poder}
                             </p>
                             {power.descripcion && (
                               <p className="text-xs text-gray-300">
@@ -4739,7 +4739,7 @@ function App() {
               }
             />
             <Input
-              placeholder="Poder"
+              placeholder="Daño"
               value={newAbility.poder}
               onChange={(e) =>
                 setNewAbility((a) => ({ ...a, poder: e.target.value }))
@@ -4961,7 +4961,7 @@ function App() {
                               <strong>Mente:</strong> {h.mente}
                             </p>
                             <p>
-                              <strong>Poder:</strong> {h.poder}
+                              <strong>Daño:</strong> {h.poder}
                             </p>
                             {h.descripcion && (
                               <p className="italic">

--- a/src/components/EnemyViewModal.jsx
+++ b/src/components/EnemyViewModal.jsx
@@ -235,13 +235,13 @@ const EnemyViewModal = ({ enemy, onClose, onEdit, highlightText = (t) => t, floa
                         <p className="font-bold text-sm">{power.nombre}</p>
                       </div>
                       <p className="mb-1">
+                        <span className="font-medium">Daño:</span> {power.poder}
+                      </p>
+                      <p className="mb-1">
                         <span className="font-medium">Alcance:</span> {power.alcance}
                       </p>
                       <p className="mb-1">
                         <span className="font-medium">Consumo:</span> {power.consumo}
-                      </p>
-                      <p className="mb-1">
-                        <span className="font-medium">Poder:</span> {power.poder}
                       </p>
                       {power.descripcion && (
                         <p className="text-gray-300 italic">

--- a/src/components/InitiativeTracker.jsx
+++ b/src/components/InitiativeTracker.jsx
@@ -1179,11 +1179,11 @@ const InitiativeTracker = ({ playerName, isMaster, enemies = [], glossary = [], 
                         <div key={index} className="bg-gray-700 p-3 rounded-lg">
                           <div className="font-semibold text-white mb-2">{power.nombre}</div>
                           <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 text-sm text-gray-300">
+                            <div><span className="font-medium">Daño:</span> {power.poder}</div>
                             <div><span className="font-medium">Alcance:</span> {power.alcance}</div>
                             <div><span className="font-medium">Consumo:</span> {power.consumo}</div>
                             <div><span className="font-medium">Cuerpo:</span> {power.cuerpo}</div>
                             <div><span className="font-medium">Mente:</span> {power.mente}</div>
-                            <div><span className="font-medium">Poder:</span> {power.poder}</div>
                           </div>
                           {power.descripcion && (
                             <div className="mt-2 text-gray-300 italic text-sm">


### PR DESCRIPTION
## Summary
- display **Daño** directly under the power name before other stats
- mention updated layout in the changelog

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687d8d9883248326aecb8b5a654a6ec1