### PR TITLE
Fix power damage autofill

### DIFF
--- a/README.md
+++ b/README.md
@@ -771,6 +771,11 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
   el objetivo para mostrar el modal de ataque.
 - Las tarjetas de poderes equipados muestran ahora **Daño** justo debajo del nombre, antes de **Alcance**, usando el valor definido en el campo Poder al crear la habilidad.
 
+**Resumen de cambios v2.4.14:**
+
+- Corrección: al seleccionar un poder en el modal de ataque o defensa se precarga
+  ahora el daño definido en la habilidad.
+
 ### 🛠️ **Características Técnicas**
 
 - **Interfaz responsive** - Optimizada para móviles y escritorio con TailwindCSS

--- a/src/components/AttackModal.jsx
+++ b/src/components/AttackModal.jsx
@@ -100,7 +100,8 @@ const AttackModal = ({
 
   const handleRoll = async () => {
     const item = [...weapons, ...powers].find(i => i.nombre === choice);
-    const formula = damage || parseDamage(item?.dano || "") || "1d20";
+    const itemDamage = item?.dano ?? item?.poder ?? "";
+    const formula = damage || parseDamage(itemDamage) || "1d20";
     setLoading(true);
     try {
       const result = rollExpression(formula);
@@ -136,7 +137,8 @@ const AttackModal = ({
                   const val = e.target.value;
                   setChoice(val);
                   const item = [...weapons, ...powers].find(i => i.nombre === val);
-                  setDamage(parseDamage(item?.dano || ""));
+                  const dmg = item?.dano ?? item?.poder ?? "";
+                  setDamage(parseDamage(dmg));
                 }}
                 className="w-full bg-gray-700 text-white"
               >

--- a/src/components/DefenseModal.jsx
+++ b/src/components/DefenseModal.jsx
@@ -100,7 +100,8 @@ const DefenseModal = ({
 
   const handleRoll = async () => {
     const item = [...weapons, ...powers].find(i => i.nombre === choice);
-    const formula = damage || parseDamage(item?.dano || "") || "1d20";
+    const itemDamage = item?.dano ?? item?.poder ?? "";
+    const formula = damage || parseDamage(itemDamage) || "1d20";
     try {
       const result = rollExpression(formula);
       let messages = [];
@@ -155,7 +156,8 @@ const DefenseModal = ({
                   const val = e.target.value;
                   setChoice(val);
                   const item = [...weapons, ...powers].find(i => i.nombre === val);
-                  setDamage(parseDamage(item?.dano || ""));
+                  const dmg = item?.dano ?? item?.poder ?? "";
+                  setDamage(parseDamage(dmg));
                 }}
                 className="w-full bg-gray-700 text-white"
               >


### PR DESCRIPTION
## Summary
- include power damage when rolling attacks or defenses
- document fix in README

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687da03186b08326b6429bf6042b735d