### PR TITLE
Fix token name in combat messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1106,6 +1106,11 @@ src/
 - ✅ El objetivo solo se fija al hacer clic sobre otro token, permitiendo cambiarlo fácilmente
 - ✅ Prueba unitaria garantiza el funcionamiento correcto
 
+### 🏷️ **Nombre de token en chat (Enero 2027) - v2.4.31**
+
+- ✅ Los mensajes de ataque y defensa muestran el nombre del token si está definido
+- ✅ Si el token no tiene nombre, se usa el del asset correspondiente
+
 ### 🎯 **Alcance de armas y poderes (Enero 2027) - v2.4.25**
 
 - ✅ El menú de ataque y defensa solo muestra armas o poderes al alcance

--- a/src/components/AttackModal.jsx
+++ b/src/components/AttackModal.jsx
@@ -112,8 +112,10 @@ const AttackModal = ({
       } catch (err) {
         console.error(err);
       }
-      const text = `${attacker.name || 'Atacante'} ataca a ${target.name || ''}`;
-      messages.push({ id: nanoid(), author: attacker.name || 'Atacante', text, result });
+      const attackerName = attacker.customName || attacker.name || 'Atacante';
+      const targetName = target.customName || target.name || '';
+      const text = `${attackerName} ataca a ${targetName}`;
+      messages.push({ id: nanoid(), author: attackerName, text, result });
       await setDoc(doc(db, 'assetSidebar', 'chat'), { messages });
       setLoading(false);
       onClose(result);

--- a/src/components/DefenseModal.jsx
+++ b/src/components/DefenseModal.jsx
@@ -112,8 +112,9 @@ const DefenseModal = ({
         console.error(err);
       }
       const success = result.total >= (attackResult?.total || 0);
-      const text = `${target.name || 'Defensor'} se defiende ${success ? 'con exito' : 'sin exito'}`;
-      messages.push({ id: nanoid(), author: target.name || 'Defensor', text, result });
+      const targetName = target.customName || target.name || 'Defensor';
+      const text = `${targetName} se defiende ${success ? 'con exito' : 'sin exito'}`;
+      messages.push({ id: nanoid(), author: targetName, text, result });
       await setDoc(doc(db, 'assetSidebar', 'chat'), { messages });
 
       if (sheet && attackResult) {


### PR DESCRIPTION
## Summary
- show token custom names in attack and defense chat messages
- document new behaviour in README

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687da61c7ff08326b51a5bb5a4f6e060