### PR TITLE
Fix attack listener stale callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -1117,6 +1117,7 @@ src/
 - ✅ El jugador objetivo o el máster reciben la notificación y abren la defensa
 - ✅ Solo se activa para jugadores con el mapa abierto controlando un token
 - ✅ Optimizado el listener para evitar conexiones repetidas a Firestore
+- ✅ Se mantiene la referencia del callback con `useRef` para no reiniciar el listener al cambiar `onAttack`
 
 ### 🎯 **Alcance de armas y poderes (Enero 2027) - v2.4.25**
 

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -987,11 +987,8 @@ const MapCanvas = ({
     }
   }, [activeTool]);
 
-  useAttackRequests({
-    tokens,
-    playerName,
-    userType,
-    onAttack: ({ id, attackerId, targetId, result }) => {
+  const handleIncomingAttack = useCallback(
+    ({ id, attackerId, targetId, result }) => {
       setAttackRequestId(id);
       setAttackSourceId(attackerId);
       setAttackTargetId(targetId);
@@ -1002,6 +999,14 @@ const MapCanvas = ({
         setAttackLine([source.x, source.y, target.x, target.y]);
       }
     },
+    [tokens]
+  );
+
+  useAttackRequests({
+    tokens,
+    playerName,
+    userType,
+    onAttack: handleIncomingAttack,
   });
 
   // Sincronizar cambios de fichas de tokens controlados con la ficha del jugador

--- a/src/components/__tests__/AttackFlow.test.js
+++ b/src/components/__tests__/AttackFlow.test.js
@@ -102,4 +102,19 @@ describe('Attack flow', () => {
     });
     expect(DefenseModal).not.toHaveBeenCalled();
   });
+
+  test('listener is not reconnected when callback changes', () => {
+    const unsub = jest.fn();
+    onSnapshot.mockReturnValue(unsub);
+    function Wrapper() {
+      const [cb, setCb] = React.useState(() => {});
+      useAttackRequests({ tokens: [], playerName: 'p2', userType: 'player', onAttack: cb });
+      return <button onClick={() => setCb(() => {})}>change</button>;
+    }
+    render(<Wrapper />);
+    expect(onSnapshot).toHaveBeenCalledTimes(1);
+    userEvent.click(screen.getByRole('button', { name: 'change' }));
+    expect(onSnapshot).toHaveBeenCalledTimes(1);
+    expect(unsub).not.toHaveBeenCalled();
+  });
 });

--- a/src/hooks/useAttackRequests.js
+++ b/src/hooks/useAttackRequests.js
@@ -4,11 +4,16 @@ import { db } from '../firebase';
 
 export default function useAttackRequests({ tokens, playerName, userType, onAttack }) {
   const tokensRef = useRef(tokens);
+  const onAttackRef = useRef(onAttack);
 
   // Mantener referencia actualizada sin recrear el listener
   useEffect(() => {
     tokensRef.current = tokens;
   }, [tokens]);
+
+  useEffect(() => {
+    onAttackRef.current = onAttack;
+  }, [onAttack]);
 
   useEffect(() => {
     const q = collection(db, 'attacks');
@@ -22,10 +27,10 @@ export default function useAttackRequests({ tokens, playerName, userType, onAtta
         const isTargetPlayer = target.controlledBy === playerName;
         const isMaster = userType === 'master';
         if (isTargetPlayer || isMaster) {
-          onAttack && onAttack({ id: change.doc.id, ...data });
+          onAttackRef.current && onAttackRef.current({ id: change.doc.id, ...data });
         }
       });
     });
     return () => unsub();
-  }, [playerName, userType, onAttack]);
+  }, [playerName, userType]);
 }


### PR DESCRIPTION
## Summary
- keep onAttack callback stable in `useAttackRequests`
- memoize MapCanvas attack handler with `useCallback`
- avoid reconnecting Firestore listener when callback changes and test it
- document listener stability in README

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_687db5c7064c8326ae452ebfa4467688