### PR TITLE
Implement Firestore attack requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1111,6 +1111,15 @@ src/
 - ✅ Los mensajes de ataque y defensa muestran el nombre del token si está definido
 - ✅ Si el token no tiene nombre, se usa el del asset correspondiente
 
+### 🛡️ **Defensa remota mediante Firestore (Enero 2027) - v2.4.33**
+
+- ✅ Tras lanzar el ataque se crea una solicitud en la colección `attacks`
+- ✅ El jugador objetivo o el máster reciben la notificación y abren la defensa
+- ✅ Solo se activa para jugadores con el mapa abierto controlando un token
+- ✅ Optimizado el listener para evitar conexiones repetidas a Firestore
+- ✅ Suscripción estable para prevenir reconexiones al renderizar el mapa
+- ✅ La defensa se resuelve automáticamente si nadie responde
+
 ### 🎯 **Alcance de armas y poderes (Enero 2027) - v2.4.25**
 
 - ✅ El menú de ataque y defensa solo muestra armas o poderes al alcance

--- a/src/components/AttackModal.jsx
+++ b/src/components/AttackModal.jsx
@@ -3,9 +3,11 @@ import PropTypes from 'prop-types';
 import Modal from './Modal';
 import Boton from './Boton';
 import { rollExpression } from '../utils/dice';
-import { doc, getDoc, setDoc } from 'firebase/firestore';
+import { doc, getDoc, setDoc, collection, addDoc, updateDoc, serverTimestamp } from 'firebase/firestore';
 import { db } from '../firebase';
 import { nanoid } from 'nanoid';
+
+const AUTO_RESOLVE_MS = 10000;
 
 const AttackModal = ({
   isOpen,
@@ -117,6 +119,52 @@ const AttackModal = ({
       const text = `${attackerName} ataca a ${targetName}`;
       messages.push({ id: nanoid(), author: attackerName, text, result });
       await setDoc(doc(db, 'assetSidebar', 'chat'), { messages });
+      const docRef = await addDoc(collection(db, 'attacks'), {
+        attackerId: attacker.id,
+        targetId: target.id,
+        result,
+        timestamp: serverTimestamp(),
+        completed: false,
+      });
+      setTimeout(async () => {
+        try {
+          const snap = await getDoc(docRef);
+          if (!snap.exists() || snap.data().completed) return;
+          if (target.tokenSheetId) {
+            const stored = localStorage.getItem('tokenSheets');
+            if (stored) {
+              const sheets = JSON.parse(stored);
+              const sheet = sheets[target.tokenSheetId];
+              if (sheet) {
+                let dmg = result.total;
+                const order = ['armadura', 'postura', 'vida'];
+                const updated = { ...sheet, stats: { ...sheet.stats } };
+                order.forEach(stat => {
+                  if (!updated.stats[stat]) return;
+                  const current = updated.stats[stat].actual ?? 0;
+                  const newVal = Math.max(0, current - dmg);
+                  dmg -= current - newVal;
+                  updated.stats[stat].actual = newVal;
+                });
+                sheets[updated.id] = updated;
+                localStorage.setItem('tokenSheets', JSON.stringify(sheets));
+                window.dispatchEvent(new CustomEvent('tokenSheetSaved', { detail: updated }));
+              }
+            }
+          }
+          let msgs = [];
+          try {
+            const chatSnap = await getDoc(doc(db, 'assetSidebar', 'chat'));
+            if (chatSnap.exists()) msgs = chatSnap.data().messages || [];
+          } catch (err) {}
+          const targetName = target.customName || target.name || 'Defensor';
+          msgs.push({ id: nanoid(), author: targetName, text: `${targetName} no se defendió a tiempo` });
+          await setDoc(doc(db, 'assetSidebar', 'chat'), { messages: msgs });
+          await updateDoc(docRef, { completed: true, auto: true });
+        } catch (err) {
+          console.error(err);
+        }
+      }, AUTO_RESOLVE_MS);
       setLoading(false);
       onClose(result);
     } catch (e) {

--- a/src/components/__tests__/AttackFlow.test.js
+++ b/src/components/__tests__/AttackFlow.test.js
@@ -1,0 +1,134 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import AttackModal from '../AttackModal';
+import DefenseModal from '../DefenseModal';
+import useAttackRequests from '../../hooks/useAttackRequests';
+import { act } from 'react';
+
+jest.mock('firebase/firestore', () => ({
+  doc: jest.fn(),
+  getDoc: jest.fn().mockResolvedValue({ exists: () => false }),
+  setDoc: jest.fn().mockResolvedValue(),
+  addDoc: jest.fn().mockResolvedValue(),
+  updateDoc: jest.fn().mockResolvedValue(),
+  collection: jest.fn(),
+  query: jest.fn(),
+  where: jest.fn(),
+  onSnapshot: jest.fn(),
+  serverTimestamp: jest.fn(() => 'ts'),
+  deleteDoc: jest.fn().mockResolvedValue(),
+}));
+
+jest.mock('../../firebase', () => ({ db: {} }));
+
+jest.mock('../DefenseModal', () => jest.fn(() => null));
+
+const { addDoc, onSnapshot, updateDoc, getDoc } = require('firebase/firestore');
+
+function ListenerDemo({ playerName = 'p2', userType = 'player' }) {
+  const [req, setReq] = React.useState(null);
+  const tokens = [
+    { id: 'a', controlledBy: 'p1', x: 0, y: 0 },
+    { id: 'b', controlledBy: 'p2', x: 1, y: 1 },
+  ];
+  useAttackRequests({ tokens, playerName, userType, onAttack: setReq });
+  return req ? (
+    <DefenseModal
+      isOpen
+      attacker={{ id: req.attackerId }}
+      target={{ id: req.targetId }}
+      distance={0}
+      attackResult={req.result}
+      armas={[]}
+      poderesCatalog={[]}
+      onClose={() => {}}
+    />
+  ) : null;
+}
+
+describe('Attack flow', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    localStorage.setItem(
+      'tokenSheets',
+      JSON.stringify({ '1': { id: '1', weapons: [{ nombre: 'Espada', alcance: 'Toque', dano: '1d4' }], poderes: [] } })
+    );
+  });
+
+  test('writes attack request to firestore', async () => {
+    render(
+      <AttackModal
+        isOpen
+        attacker={{ id: 'a', name: 'A', tokenSheetId: '1' }}
+        target={{ id: 'b', name: 'B', tokenSheetId: '2' }}
+        distance={1}
+        armas={[]}
+        poderesCatalog={[]}
+        onClose={() => {}}
+      />
+    );
+    await userEvent.click(screen.getByRole('button', { name: /lanzar/i }));
+    await waitFor(() => expect(addDoc).toHaveBeenCalled());
+  });
+
+  test('opens defense modal for targeted player', () => {
+    let snapCb;
+    onSnapshot.mockImplementation((col, cb) => {
+      snapCb = cb;
+      return () => {};
+    });
+    render(<ListenerDemo />);
+    const doc = {
+      id: 'req1',
+      data: () => ({ attackerId: 'a', targetId: 'b', result: { total: 5 } }),
+    };
+    act(() => {
+      snapCb({ docChanges: () => [{ type: 'added', doc }] });
+    });
+    expect(DefenseModal).toHaveBeenCalled();
+  });
+
+  test('ignores attacks for other players', () => {
+    let snapCb;
+    onSnapshot.mockImplementation((col, cb) => {
+      snapCb = cb;
+      return () => {};
+    });
+    render(<ListenerDemo playerName="p1" />);
+    const doc = {
+      id: 'req1',
+      data: () => ({ attackerId: 'a', targetId: 'b', result: { total: 5 } }),
+    };
+    act(() => {
+      snapCb({ docChanges: () => [{ type: 'added', doc }] });
+    });
+    expect(DefenseModal).not.toHaveBeenCalled();
+  });
+
+  test('auto resolves if defense is unanswered', async () => {
+    jest.useFakeTimers();
+    addDoc.mockResolvedValue({ id: 'r1' });
+    getDoc
+      .mockResolvedValueOnce({ exists: () => false })
+      .mockResolvedValueOnce({ exists: () => true, data: () => ({ completed: false }) });
+    render(
+      <AttackModal
+        isOpen
+        attacker={{ id: 'a', name: 'A', tokenSheetId: '1' }}
+        target={{ id: 'b', name: 'B', tokenSheetId: '2' }}
+        distance={1}
+        armas={[]}
+        poderesCatalog={[]}
+        onClose={() => {}}
+      />
+    );
+    await userEvent.click(screen.getByRole('button', { name: /lanzar/i }));
+    await waitFor(() => expect(addDoc).toHaveBeenCalled());
+    await act(async () => {
+      jest.runAllTimers();
+    });
+    await waitFor(() => expect(updateDoc).toHaveBeenCalled());
+    jest.useRealTimers();
+  });
+});

--- a/src/hooks/useAttackRequests.js
+++ b/src/hooks/useAttackRequests.js
@@ -1,0 +1,36 @@
+import { useEffect, useRef } from 'react';
+import { collection, onSnapshot, query, where } from 'firebase/firestore';
+import { db } from '../firebase';
+
+export default function useAttackRequests({ tokens, playerName, userType, onAttack }) {
+  const tokensRef = useRef(tokens);
+  const callbackRef = useRef(onAttack);
+
+  // Mantener referencia actualizada sin recrear el listener
+  useEffect(() => {
+    tokensRef.current = tokens;
+  }, [tokens]);
+
+  useEffect(() => {
+    callbackRef.current = onAttack;
+  }, [onAttack]);
+
+  useEffect(() => {
+    const q = query(collection(db, 'attacks'), where('completed', '==', false));
+    const unsub = onSnapshot(q, snapshot => {
+      snapshot.docChanges().forEach(change => {
+        if (change.type !== 'added') return;
+        const data = change.doc.data();
+        const currentTokens = tokensRef.current || [];
+        const target = currentTokens.find(t => t.id === data.targetId);
+        if (!target) return;
+        const isTargetPlayer = target.controlledBy === playerName;
+        const isMaster = userType === 'master';
+        if (isTargetPlayer || isMaster) {
+          callbackRef.current && callbackRef.current({ id: change.doc.id, ...data });
+        }
+      });
+    });
+    return () => unsub();
+  }, [playerName, userType]);
+}


### PR DESCRIPTION
## Summary
- log attack rolls in new `attacks` collection
- listen for attack requests to open DefenseModal remotely
- clean up request after resolution
- add `useAttackRequests` hook
- document remote defense flow
- test attack request flow
- ensure defense is ignored by other players
- optimize listener to avoid repeated Firestore connections
- auto-resolve defense if unanswered via timer
- stabilize attack request subscription to stop reconnections

## Testing
- `npm install --no-audit --progress=false`
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687daa6947788326959691708163cfbf