### PR TITLE
Fix door icon click area

### DIFF
--- a/README.md
+++ b/README.md
@@ -1135,6 +1135,11 @@ src/
 - ✅ Si la defensa supera al ataque se produce un contraataque automático
 - ✅ Los mensajes de chat muestran tiradas, diferencia y bloques perdidos
 
+### 🏰 **Mejoras en botones de puertas y muros (Enero 2027) - v2.4.36**
+
+- ✅ El icono de puerta tiene un área de clic más grande y visible
+- ✅ Se cambia el cursor a puntero al pasar sobre el icono
+
 ### 🎯 **Alcance de armas y poderes (Enero 2027) - v2.4.25**
 
 - ✅ El menú de ataque y defensa solo muestra armas o poderes al alcance

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -3971,7 +3971,22 @@ const MapCanvas = ({
                       180
                     }
                     onClick={() => setDoorMenuWallId(wl.id)}
+                    onTap={() => setDoorMenuWallId(wl.id)}
+                    onMouseEnter={() =>
+                      (stageRef.current.container().style.cursor = 'pointer')
+                    }
+                    onMouseLeave={() =>
+                      (stageRef.current.container().style.cursor =
+                        activeTool === 'wall' ? 'crosshair' : 'default')
+                    }
                   >
+                    <Rect
+                      width={32}
+                      height={32}
+                      offsetX={16}
+                      offsetY={16}
+                      fill="transparent"
+                    />
                     {DOOR_PATHS[wl.door || 'closed'].map((d, i) => (
                       <Path
                         key={i}
@@ -3980,6 +3995,7 @@ const MapCanvas = ({
                         strokeWidth={1}
                         lineCap="round"
                         lineJoin="round"
+                        hitStrokeWidth={10}
                       />
                     ))}
                   </Group>


### PR DESCRIPTION
## Summary
- enlarge door icon hit area with a transparent rect
- show pointer cursor on hover
- update README with v2.4.36 notes

## Testing
- `npm install --silent`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_687e81aaad2c8326ad1d897b702ccd74