### PR TITLE
Fix door icon rotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -882,6 +882,7 @@ src/
 - **Mirilla funcional para ataques** - Los jugadores pueden seleccionar objetivos enemigos con un clic y atacar con un segundo clic
 - **La mirilla apunta a tokens ajenos** - Ahora también puedes fijar como objetivo fichas controladas por otros jugadores o por el máster
 - **Doble clic seguro en mirilla** - Al usar la mirilla, el doble clic ya no abre el menú de ajustes del token
+- **Iconos de puerta siempre orientados** - Los SVG de las puertas se muestran correctamente aunque el muro se dibuje al revés
 
 #### v2.1.1 (junio 2024)
 

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -156,6 +156,13 @@ const DOOR_PATHS = {
   ],
 };
 
+const normalizeWallRotation = (x1, y1, x2, y2) => {
+  let deg = (Math.atan2(y2 - y1, x2 - x1) * 180) / Math.PI;
+  deg = (deg + 360) % 180;
+  if (deg > 90) deg -= 180;
+  return Math.abs(deg);
+};
+
 // Componente para mostrar puertas interactivas en la capa fichas
 const InteractiveDoor = ({ wall, effectiveGridSize, onToggle }) => {
   const [x1, y1, x2, y2] = wall.points;
@@ -3962,14 +3969,12 @@ const MapCanvas = ({
                   <Group
                     x={wl.x + (wl.points[0] + wl.points[2]) / 2}
                     y={wl.y + (wl.points[1] + wl.points[3]) / 2}
-                    rotation={
-                      (Math.atan2(
-                        wl.points[3] - wl.points[1],
-                        wl.points[2] - wl.points[0]
-                      ) /
-                        Math.PI) *
-                      180
-                    }
+                    rotation={normalizeWallRotation(
+                      wl.points[0],
+                      wl.points[1],
+                      wl.points[2],
+                      wl.points[3]
+                    )}
                     onClick={() => setDoorMenuWallId(wl.id)}
                     onTap={() => setDoorMenuWallId(wl.id)}
                     onMouseEnter={() =>


### PR DESCRIPTION
## Summary
- ensure door icons show upright regardless of wall direction
- document door icon orientation fix

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687e877d60a8832697fb689f038919a8