### PR TITLE
Update damage order handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -785,6 +785,10 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
   más pequeño y usa el mismo color verde que el botón de los jugadores en el
   mapa de batalla.
 
+**Resumen de cambios v2.4.16:**
+
+- Ajuste de daño: ahora se aplica primero a la Postura, luego a la Armadura y por último a la Vida. El daño sobrante no se transfiere a la siguiente estadística.
+
 ### 🛠️ **Características Técnicas**
 
 - **Interfaz responsive** - Optimizada para móviles y escritorio con TailwindCSS
@@ -1132,7 +1136,8 @@ src/
 
 ### ⚔️ **Daño escalado y contraataque (Enero 2027) - v2.4.35**
 
-- ✅ El daño se calcula como `floor(daño / atributo)` y se aplica primero a la armadura, pasando a postura y vida solo si queda daño
+- ✅ El daño se calcula como `floor(daño / atributo)` y se aplica primero a la postura, luego a la armadura y finalmente a la vida
+- ✅ El daño restante no pasa a la siguiente estadística si quedan bloques disponibles en la actual
 - ✅ Si la defensa supera al ataque se produce un contraataque automático
 - ✅ Los mensajes de chat muestran tiradas, diferencia y bloques perdidos
 

--- a/src/components/AttackModal.jsx
+++ b/src/components/AttackModal.jsx
@@ -148,7 +148,7 @@ const AttackModal = ({
               if (sheet) {
                 let updated = sheet;
                 let remaining = result.total;
-                ['armadura', 'postura', 'vida'].forEach((stat) => {
+                ['postura', 'armadura', 'vida'].forEach((stat) => {
                   const res = applyDamage(updated, remaining, stat);
                   remaining = res.remaining;
                   updated = res.sheet;

--- a/src/components/DefenseModal.jsx
+++ b/src/components/DefenseModal.jsx
@@ -119,7 +119,7 @@ const DefenseModal = ({
       if (diff < 0 && sheet) {
         let updated = sheet;
         let remaining = Math.abs(diff);
-        ['armadura', 'postura', 'vida'].forEach((stat) => {
+        ['postura', 'armadura', 'vida'].forEach((stat) => {
           const res = applyDamage(updated, remaining, stat);
           remaining = res.remaining;
           updated = res.sheet;
@@ -140,7 +140,7 @@ const DefenseModal = ({
           let atkSheet = sheets[attacker.tokenSheetId];
           if (atkSheet) {
             let remaining = diff;
-            ['armadura', 'postura', 'vida'].forEach((stat) => {
+            ['postura', 'armadura', 'vida'].forEach((stat) => {
               const res = applyDamage(atkSheet, remaining, stat);
               remaining = res.remaining;
               atkSheet = res.sheet;

--- a/src/components/__tests__/DamageLogic.test.js
+++ b/src/components/__tests__/DamageLogic.test.js
@@ -47,14 +47,14 @@ test('damage is applied sequentially across stats', () => {
     atributos: { destreza: 'D4', vigor: 'D4' },
     stats: { armadura: { actual: 1 }, postura: { actual: 2 }, vida: { actual: 2 } },
   };
-  let remaining = 4;
+  let remaining = 5;
   let updated = sheet;
-  ['armadura', 'postura', 'vida'].forEach((stat) => {
+  ['postura', 'armadura', 'vida'].forEach((stat) => {
     const res = applyDamage(updated, remaining, stat);
     remaining = res.remaining;
     updated = res.sheet;
   });
-  expect(updated.stats.armadura.actual).toBe(0);
-  expect(updated.stats.postura.actual).toBe(2);
+  expect(updated.stats.armadura.actual).toBe(1);
+  expect(updated.stats.postura.actual).toBe(1);
   expect(updated.stats.vida.actual).toBe(2);
 });

--- a/src/utils/damage.js
+++ b/src/utils/damage.js
@@ -26,5 +26,9 @@ export const applyDamage = (sheet, damage, stat) => {
     stats: { ...sheet.stats, [stat]: { ...sheet.stats[stat] } },
   };
   updated.stats[stat].actual = available - blocks;
-  return { sheet: updated, blocks, remaining: Math.max(0, damage - usedDamage) };
+  let remaining = Math.max(0, damage - usedDamage);
+  if (remaining > 0 && available - blocks > 0) {
+    remaining = 0;
+  }
+  return { sheet: updated, blocks, remaining };
 };


### PR DESCRIPTION
## Summary
- adjust damage application order to start with posture
- prevent damage overflow when blocks remain
- update unit tests for new logic
- document new rule and version entry in README

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687eeaa784d08326b7e88082b879e4cb