### PR TITLE
Add toggle to hide vision ranges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1116,6 +1116,11 @@ src/
 - ✅ El campo de daño solo muestra valores como `1d8` o `2d6`, ocultando el tipo de daño
 - ✅ También se rellena correctamente el daño de los poderes al seleccionarlos
 
+### 👁️ **Rangos de visión opcionales (Enero 2027) - v2.4.30**
+
+- ✅ Nueva casilla "Rangos de visión" en el mapa de batalla del máster
+- ✅ Permite ocultar el contorno amarillo de visión de los tokens
+
 ### 🔄 **Barras por página (Enero 2027) - v2.4.30**
 
 - ✅ Los eventos de visibilidad de barras incluyen la página de origen

--- a/src/App.js
+++ b/src/App.js
@@ -490,6 +490,7 @@ function App() {
   const [gridOffsetX, setGridOffsetX] = useState(0);
   const [gridOffsetY, setGridOffsetY] = useState(0);
   const [enableDarkness, setEnableDarkness] = useState(true);
+  const [showVisionRanges, setShowVisionRanges] = useState(true);
 
   // Control de visibilidad de páginas para jugadores
   const [playerVisiblePageId, setPlayerVisiblePageId] = useState(null);
@@ -4514,6 +4515,14 @@ function App() {
             >
               Herramientas
             </Boton>
+            <label className="flex items-center gap-1 text-sm ml-2">
+              <input
+                type="checkbox"
+                checked={showVisionRanges}
+                onChange={(e) => setShowVisionRanges(e.target.checked)}
+              />
+              Rangos de visión
+            </label>
           </div>
         </div>
         <div className="mb-4 mr-80">
@@ -4583,6 +4592,7 @@ function App() {
               onLayerChange={setActiveLayer}
               enableDarkness={enableDarkness}
               darknessOpacity={pages[currentPage]?.darknessOpacity || 0.7}
+              showVisionPolygons={showVisionRanges}
             />
           </div>
           <AssetSidebar isMaster={authenticated} playerName={playerName} />

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -929,6 +929,7 @@ const MapCanvas = ({
   onLayerChange = () => {},
   enableDarkness = true,
   darknessOpacity = 0.7,
+  showVisionPolygons = true,
   // Nuevas props para sincronización bidireccional
   pageId = null,
   isPlayerView = false,
@@ -4181,7 +4182,7 @@ const MapCanvas = ({
           )}
 
           {/* Capa de visión - mostrar polígonos de visión de tokens (solo en modo master) */}
-          {!playerViewMode && userType === 'master' && (
+          {showVisionPolygons && !playerViewMode && userType === 'master' && (
             <Layer listening={false}>
               <Group
                 x={groupPos.x}
@@ -4601,6 +4602,7 @@ MapCanvas.propTypes = {
   onLayerChange: PropTypes.func,
   enableDarkness: PropTypes.bool,
   darknessOpacity: PropTypes.number,
+  showVisionPolygons: PropTypes.bool,
 };
 
 export default MapCanvas;


### PR DESCRIPTION
## Summary
- add `showVisionRanges` option to master battle map
- support `showVisionPolygons` prop in `MapCanvas`
- document optional vision ranges in README

## Testing
- `npm test --silent -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_687f51583cbc8326b975ed9692790ce7