### PR TITLE
Add synced damage popups

### DIFF
--- a/README.md
+++ b/README.md
@@ -793,6 +793,8 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 **Resumen de cambios v2.4.17:**
 
 - En el chat, las frases **recibe daño**, **bloquea el ataque** y **contraataca** ahora se resaltan con colores.
+- Al recibir daño se muestran animaciones "-X" para **cada** tipo de bloque perdido, con el color de la barra afectada. Los contraataques y defensas perfectas también tienen su propia animación.
+- Las animaciones de daño se sincronizan entre pestañas y ahora se ven durante más tiempo para apreciarlas mejor.
 
 ### 🛠️ **Características Técnicas**
 

--- a/src/components/AttackModal.jsx
+++ b/src/components/AttackModal.jsx
@@ -162,6 +162,22 @@ const AttackModal = ({
               }
             }
           }
+          ['postura', 'armadura', 'vida'].forEach((stat) => {
+            if (lost[stat] > 0) {
+              const anim = {
+                tokenId: target.id,
+                value: lost[stat],
+                stat,
+                ts: Date.now(),
+              };
+              window.dispatchEvent(
+                new CustomEvent('damageAnimation', { detail: anim })
+              );
+              try {
+                localStorage.setItem('damageAnimation', JSON.stringify(anim));
+              } catch {}
+            }
+          });
           let msgs = [];
           try {
             const chatSnap = await getDoc(doc(db, 'assetSidebar', 'chat'));

--- a/src/components/DefenseModal.jsx
+++ b/src/components/DefenseModal.jsx
@@ -156,6 +156,36 @@ const DefenseModal = ({
         }
       }
 
+      if (diff === 0) {
+        const anim = { tokenId: target.id, type: 'perfect', ts: Date.now() };
+        window.dispatchEvent(
+          new CustomEvent('damageAnimation', { detail: anim })
+        );
+        try {
+          localStorage.setItem('damageAnimation', JSON.stringify(anim));
+        } catch {}
+      } else {
+        const id = diff < 0 ? target.id : attacker.id;
+        const type = diff > 0 ? 'counter' : undefined;
+        ['postura', 'armadura', 'vida'].forEach((stat) => {
+          if (lost[stat] > 0) {
+            const anim = {
+              tokenId: id,
+              value: lost[stat],
+              stat,
+              ts: Date.now(),
+              ...(type ? { type } : {}),
+            };
+            window.dispatchEvent(
+              new CustomEvent('damageAnimation', { detail: anim })
+            );
+            try {
+              localStorage.setItem('damageAnimation', JSON.stringify(anim));
+            } catch {}
+          }
+        });
+      }
+
       const vigor = parseDieValue(affectedSheet?.atributos?.vigor);
       const destreza = parseDieValue(affectedSheet?.atributos?.destreza);
       let text;

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -31,6 +31,7 @@ import TokenEstadoMenu from './TokenEstadoMenu';
 import TokenSheetModal from './TokenSheetModal';
 import { ESTADOS } from './EstadoSelector';
 import { nanoid } from 'nanoid';
+import { motion } from 'framer-motion';
 import { createToken, cloneTokenSheet } from '../utils/token';
 import TokenBars from './TokenBars';
 import LoadingSpinner from './LoadingSpinner';
@@ -947,6 +948,7 @@ const MapCanvas = ({
   const [isPanning, setIsPanning] = useState(false);
   const [selectedId, setSelectedId] = useState(null);
   const [hoveredId, setHoveredId] = useState(null);
+  const [damagePopups, setDamagePopups] = useState([]);
   const [dragShadow, setDragShadow] = useState(null);
   const [settingsTokenIds, setSettingsTokenIds] = useState([]);
   const [estadoTokenIds, setEstadoTokenIds] = useState([]);
@@ -1062,6 +1064,39 @@ const MapCanvas = ({
     window.addEventListener('tokenSheetSaved', syncHandler);
     return () => window.removeEventListener('tokenSheetSaved', syncHandler);
   }, [tokens]);
+
+  useEffect(() => {
+    const handler = (e) => {
+      const { tokenId, value, stat, type } = e.detail || {};
+      if (!tokenId || !tokenRefs.current[tokenId] || !stageRef.current || !containerRef.current) return;
+      const rect = tokenRefs.current[tokenId].node.getClientRect({ relativeTo: stageRef.current });
+      const stageRect = stageRef.current.container().getBoundingClientRect();
+      const containerRect = containerRef.current.getBoundingClientRect();
+      const x = rect.x + rect.width / 2 + stageRect.left - containerRect.left;
+      const y = rect.y + stageRect.top - containerRect.top;
+      const id = nanoid();
+      setDamagePopups((prev) => [...prev, { id, x, y, value, stat, type }]);
+      setTimeout(() => {
+        setDamagePopups((prev) => prev.filter((p) => p.id !== id));
+      }, 2000);
+    };
+    window.addEventListener('damageAnimation', handler);
+    return () => window.removeEventListener('damageAnimation', handler);
+  }, [tokens]);
+
+  useEffect(() => {
+    const onStorage = (e) => {
+      if (e.key !== 'damageAnimation' || !e.newValue) return;
+      try {
+        const data = JSON.parse(e.newValue);
+        if (data && data.ts) {
+          window.dispatchEvent(new CustomEvent('damageAnimation', { detail: data }));
+        }
+      } catch {}
+    };
+    window.addEventListener('storage', onStorage);
+    return () => window.removeEventListener('storage', onStorage);
+  }, []);
 
   useEffect(() => {
     const prev = prevTokensRef.current || [];
@@ -4339,6 +4374,39 @@ const MapCanvas = ({
             </Layer>
           )}
         </Stage>
+      </div>
+      <div className="absolute inset-0 pointer-events-none z-40">
+        {damagePopups.map((p) => {
+          const colors = {
+            postura: '#34d399',
+            vida: '#f87171',
+            armadura: '#9ca3af',
+            counter: '#facc15',
+            perfect: '#60a5fa',
+          };
+          const color = p.type ? colors[p.type] || '#fff' : colors[p.stat] || '#fff';
+          const text = p.type === 'counter' ? '¡Contraataque!' : p.type === 'perfect' ? '¡Defensa perfecta!' : `-${p.value}`;
+          return (
+            <motion.div
+              key={p.id}
+              initial={{ opacity: 1, y: 0 }}
+              animate={{ opacity: 0, y: -20 }}
+              transition={{ duration: 2 }}
+              style={{
+                position: 'absolute',
+                left: p.x,
+                top: p.y,
+                transform: 'translate(-50%, -100%)',
+                color,
+                fontSize: 20,
+                fontWeight: 'bold',
+                textShadow: '0 0 2px #000',
+              }}
+            >
+              {text}
+            </motion.div>
+          );
+        })}
       </div>
       <Toolbar
         activeTool={activeTool}


### PR DESCRIPTION
## Summary
- dispatch damageAnimation to localStorage so all tabs sync
- listen for storage events and animate damage popups at the right spot
- enlarge popup text and correct offset calculations
- document real-time damage animation sync
- show popups for each damaged stat type

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687f567e24e08326a72b2f03fe1ad5ae