### PR TITLE
Add manual defense option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1147,6 +1147,7 @@ src/
 - ✅ Optimizado el listener para evitar conexiones repetidas a Firestore
 - ✅ Suscripción estable para prevenir reconexiones al renderizar el mapa
 - ✅ La defensa se resuelve automáticamente si nadie responde
+- ✅ Si no hay armas o poderes disponibles, el defensor puede introducir un valor manual de defensa
 
 ### ⚔️ **Daño escalado y contraataque (Enero 2027) - v2.4.35**
 

--- a/src/components/DefenseModal.jsx
+++ b/src/components/DefenseModal.jsx
@@ -258,14 +258,32 @@ const DefenseModal = ({
                 )}
               </>
             ) : (
-              <p className="text-red-400 text-sm">
-                No hay ningún arma disponible al alcance
-              </p>
+              <>
+                <p className="text-red-400 text-sm">
+                  No hay ningún arma disponible al alcance
+                </p>
+                <input
+                  type="text"
+                  value={damage}
+                  onChange={(e) => setDamage(e.target.value)}
+                  className="w-full mt-2 bg-gray-700 text-white px-2 py-1"
+                  placeholder="Defensa opcional"
+                />
+              </>
             )
           ) : (
-            <p className="text-red-400 text-sm">
-              No hay armas o poderes equipados
-            </p>
+            <>
+              <p className="text-red-400 text-sm">
+                No hay armas o poderes equipados
+              </p>
+              <input
+                type="text"
+                value={damage}
+                onChange={(e) => setDamage(e.target.value)}
+                className="w-full mt-2 bg-gray-700 text-white px-2 py-1"
+                placeholder="Defensa opcional"
+              />
+            </>
           )}
         </div>
         <Boton
@@ -273,7 +291,6 @@ const DefenseModal = ({
           onClick={handleRoll}
           loading={loading}
           className="w-full"
-          disabled={!hasAvailable}
         >
           Lanzar
         </Boton>


### PR DESCRIPTION
## Summary
- allow entering a custom defense value when no weapon or power is available
- document manual defense values in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687fd12f15c08326b6f4f0e0b4f584f2