### PR TITLE
Mostrar consumo de velocidad en ataque y defensa

### DIFF
--- a/README.md
+++ b/README.md
@@ -1161,6 +1161,10 @@ src/
 - ✅ El icono de puerta tiene un área de clic más grande y visible
 - ✅ Se cambia el cursor a puntero al pasar sobre el icono
 
+### ⚡ **Consumo de velocidad en ataque y defensa (Enero 2027) - v2.4.37**
+
+- ✅ Los modales de Ataque y Defensa muestran el consumo de velocidad del arma o poder seleccionado
+
 ### 🎯 **Alcance de armas y poderes (Enero 2027) - v2.4.25**
 
 - ✅ El menú de ataque y defensa solo muestra armas o poderes al alcance

--- a/src/components/AttackModal.jsx
+++ b/src/components/AttackModal.jsx
@@ -58,6 +58,15 @@ const AttackModal = ({
     return String(val).split(/[ (]/)[0];
   };
 
+  const getSpeedConsumption = (equipment) => {
+    if (!equipment) return 0;
+    const consumo = equipment.consumo || '';
+    const yellowDotCount = (consumo.match(/🟡/g) || []).length;
+    if (yellowDotCount) return yellowDotCount;
+    const parsed = parseInt(consumo, 10);
+    return isNaN(parsed) ? 0 : parsed;
+  };
+
   const mapItem = (it, catalog) => {
     if (!it) return null;
     if (typeof it === 'string') {
@@ -96,6 +105,7 @@ const AttackModal = ({
 
   const [choice, setChoice] = useState('');
   const [damage, setDamage] = useState('');
+  const [speedCost, setSpeedCost] = useState(0);
   const [loading, setLoading] = useState(false);
 
   const hasEquip = useMemo(() => {
@@ -231,6 +241,7 @@ const AttackModal = ({
                     );
                     const dmg = item?.dano ?? item?.poder ?? '';
                     setDamage(parseDamage(dmg));
+                    setSpeedCost(getSpeedConsumption(item));
                   }}
                   className="w-full bg-gray-700 text-white"
                 >
@@ -247,13 +258,16 @@ const AttackModal = ({
                   ))}
                 </select>
                 {choice && (
-                  <input
-                    type="text"
-                    value={damage}
-                    onChange={(e) => setDamage(e.target.value)}
-                    className="w-full mt-2 bg-gray-700 text-white px-2 py-1"
-                    placeholder="Daño"
-                  />
+                  <>
+                    <input
+                      type="text"
+                      value={damage}
+                      onChange={(e) => setDamage(e.target.value)}
+                      className="w-full mt-2 bg-gray-700 text-white px-2 py-1"
+                      placeholder="Daño"
+                    />
+                    <p className="text-sm text-gray-300 mt-1">Consumo: 🟡{speedCost}</p>
+                  </>
                 )}
               </>
             ) : (

--- a/src/components/DefenseModal.jsx
+++ b/src/components/DefenseModal.jsx
@@ -48,6 +48,14 @@ const DefenseModal = ({
     if (!val) return '';
     return String(val).split(/[ (]/)[0];
   };
+  const getSpeedConsumption = (equipment) => {
+    if (!equipment) return 0;
+    const consumo = equipment.consumo || '';
+    const yellowDotCount = (consumo.match(/🟡/g) || []).length;
+    if (yellowDotCount) return yellowDotCount;
+    const parsed = parseInt(consumo, 10);
+    return isNaN(parsed) ? 0 : parsed;
+  };
   const mapItem = (it, catalog) => {
     if (!it) return null;
     if (typeof it === 'string') {
@@ -86,6 +94,7 @@ const DefenseModal = ({
 
   const [choice, setChoice] = useState('');
   const [damage, setDamage] = useState('');
+  const [speedCost, setSpeedCost] = useState(0);
   const [loading, setLoading] = useState(false);
 
   const hasEquip = useMemo(() => {
@@ -232,6 +241,7 @@ const DefenseModal = ({
                     );
                     const dmg = item?.dano ?? item?.poder ?? '';
                     setDamage(parseDamage(dmg));
+                    setSpeedCost(getSpeedConsumption(item));
                   }}
                   className="w-full bg-gray-700 text-white"
                 >
@@ -248,13 +258,16 @@ const DefenseModal = ({
                   ))}
                 </select>
                 {choice && (
-                  <input
-                    type="text"
-                    value={damage}
-                    onChange={(e) => setDamage(e.target.value)}
-                    className="w-full mt-2 bg-gray-700 text-white px-2 py-1"
-                    placeholder="Daño"
-                  />
+                  <>
+                    <input
+                      type="text"
+                      value={damage}
+                      onChange={(e) => setDamage(e.target.value)}
+                      className="w-full mt-2 bg-gray-700 text-white px-2 py-1"
+                      placeholder="Daño"
+                    />
+                    <p className="text-sm text-gray-300 mt-1">Consumo: 🟡{speedCost}</p>
+                  </>
                 )}
               </>
             ) : (


### PR DESCRIPTION
## Summary
- display speed cost when picking weapons and powers in AttackModal
- display speed cost when picking weapons and powers in DefenseModal
- document the new feature in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687fd57de8248326b63b407c96c58903