### PR TITLE
Add resist attack message

### DIFF
--- a/README.md
+++ b/README.md
@@ -798,6 +798,10 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 - Las animaciones de pérdida de varios bloques se muestran ahora una al lado de otra para mayor claridad y la vida se reduce de forma más lenta, desapareciendo tras 5 segundos.
 El Máster ahora también ve estas animaciones cuando los jugadores reciben daño.
 
+**Resumen de cambios v2.4.18:**
+
+- Si un ataque no rompe ni reduce bloques ahora se muestra "**resiste el ataque**" en azul en el chat.
+
 ### 🛠️ **Características Técnicas**
 
 - **Interfaz responsive** - Optimizada para móviles y escritorio con TailwindCSS

--- a/src/components/AssetSidebar.jsx
+++ b/src/components/AssetSidebar.jsx
@@ -30,6 +30,10 @@ const highlightBattleText = (text) =>
       '<span class="text-green-400 font-semibold">$1</span>'
     )
     .replace(
+      /(resiste el ataque)/gi,
+      '<span class="text-blue-400 font-semibold">$1</span>'
+    )
+    .replace(
       /(contraataca)/gi,
       '<span class="text-yellow-400 font-semibold">$1</span>'
     );

--- a/src/components/DefenseModal.jsx
+++ b/src/components/DefenseModal.jsx
@@ -197,11 +197,16 @@ const DefenseModal = ({
 
       const vigor = parseDieValue(affectedSheet?.atributos?.vigor);
       const destreza = parseDieValue(affectedSheet?.atributos?.destreza);
+      const totalLost = lost.armadura + lost.postura + lost.vida;
       let text;
       if (diff > 0) {
         text = `${targetName} contraataca. Ataque ${attackResult?.total || 0} Defensa ${result.total} Dif ${diff} (V${vigor} D${destreza}) Bloques A-${lost.armadura} P-${lost.postura} V-${lost.vida}`;
       } else if (diff < 0) {
-        text = `${targetName} recibe daño. Ataque ${attackResult?.total || 0} Defensa ${result.total} Dif ${Math.abs(diff)} (V${vigor} D${destreza}) Bloques A-${lost.armadura} P-${lost.postura} V-${lost.vida}`;
+        if (totalLost === 0) {
+          text = `${targetName} resiste el ataque. Ataque ${attackResult?.total || 0} Defensa ${result.total}`;
+        } else {
+          text = `${targetName} recibe daño. Ataque ${attackResult?.total || 0} Defensa ${result.total} Dif ${Math.abs(diff)} (V${vigor} D${destreza}) Bloques A-${lost.armadura} P-${lost.postura} V-${lost.vida}`;
+        }
       } else {
         text = `${targetName} bloquea el ataque. Ataque ${attackResult?.total || 0} Defensa ${result.total}`;
       }


### PR DESCRIPTION
## Summary
- show `resiste el ataque` when damage doesn't break blocks
- highlight this message in chat with blue color
- document the change in README

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687fef36e87c83268911ae87fc7cdfd4