### PR TITLE
Add blue resist damage message

### DIFF
--- a/README.md
+++ b/README.md
@@ -800,7 +800,7 @@ El Máster ahora también ve estas animaciones cuando los jugadores reciben dañ
 
 **Resumen de cambios v2.4.18:**
 
-- Si un ataque no rompe ni reduce bloques ahora se muestra "**resiste el ataque**" en azul en el chat.
+ - Si un ataque no rompe ni reduce bloques ahora se muestra "**resiste el daño**" en azul en el chat.
 
 ### 🛠️ **Características Técnicas**
 

--- a/src/components/AssetSidebar.jsx
+++ b/src/components/AssetSidebar.jsx
@@ -30,7 +30,7 @@ const highlightBattleText = (text) =>
       '<span class="text-green-400 font-semibold">$1</span>'
     )
     .replace(
-      /(resiste el ataque)/gi,
+      /(resiste el ataque|resiste el daño)/gi,
       '<span class="text-blue-400 font-semibold">$1</span>'
     )
     .replace(

--- a/src/components/AttackModal.jsx
+++ b/src/components/AttackModal.jsx
@@ -197,10 +197,13 @@ const AttackModal = ({
           const vigor = parseDieValue(sheet?.atributos?.vigor);
           const destreza = parseDieValue(sheet?.atributos?.destreza);
           const diff = result.total;
+          const totalLost = lost.armadura + lost.postura + lost.vida;
+          const noDamageText = `${targetName} resiste el daño. Ataque ${result.total} Defensa 0 Dif ${diff} (V${vigor} D${destreza}) Bloques A-${lost.armadura} P-${lost.postura} V-${lost.vida}`;
+          const damageText = `${targetName} no se defendió. Ataque ${result.total} Defensa 0 Dif ${diff} (V${vigor} D${destreza}) Bloques A-${lost.armadura} P-${lost.postura} V-${lost.vida}`;
           msgs.push({
             id: nanoid(),
             author: targetName,
-            text: `${targetName} no se defendió. Ataque ${result.total} Defensa 0 Dif ${diff} (V${vigor} D${destreza}) Bloques A-${lost.armadura} P-${lost.postura} V-${lost.vida}`,
+            text: totalLost === 0 ? noDamageText : damageText,
           });
           await setDoc(doc(db, 'assetSidebar', 'chat'), { messages: msgs });
           await updateDoc(docRef, { completed: true, auto: true });

--- a/src/components/DefenseModal.jsx
+++ b/src/components/DefenseModal.jsx
@@ -203,7 +203,7 @@ const DefenseModal = ({
         text = `${targetName} contraataca. Ataque ${attackResult?.total || 0} Defensa ${result.total} Dif ${diff} (V${vigor} D${destreza}) Bloques A-${lost.armadura} P-${lost.postura} V-${lost.vida}`;
       } else if (diff < 0) {
         if (totalLost === 0) {
-          text = `${targetName} resiste el ataque. Ataque ${attackResult?.total || 0} Defensa ${result.total}`;
+          text = `${targetName} resiste el daño. Ataque ${attackResult?.total || 0} Defensa ${result.total} Dif ${Math.abs(diff)} (V${vigor} D${destreza}) Bloques A-${lost.armadura} P-${lost.postura} V-${lost.vida}`;
         } else {
           text = `${targetName} recibe daño. Ataque ${attackResult?.total || 0} Defensa ${result.total} Dif ${Math.abs(diff)} (V${vigor} D${destreza}) Bloques A-${lost.armadura} P-${lost.postura} V-${lost.vida}`;
         }


### PR DESCRIPTION
## Summary
- highlight "resiste el daño" in blue
- display a "resiste el daño" message when attacks cause no block loss
- include same logic for auto-resolved attacks
- document feature in README

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6880975fd6008326bf5f6d9e17e6fa04