### PR TITLE
Add hot seat token switching

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 - **Eventos de guardado de ficha de jugador** - Al modificar estados en el mapa se actualiza automáticamente la ficha del jugador sin provocar bucles
 - **Estados sincronizados de la ficha al token** - Al activar condiciones desde la ficha se aplican inmediatamente al token controlado
 - **Modo Master y Jugador** - Controles especializados según el rol del usuario
+- **Modo "hot seat"** - Alterna entre fichas controladas con Tab o el selector
 - **Mapa de Batalla integrado** - VTT sencillo con grid y tokens arrastrables
 - **Fichas de token personalizadas** - Cada token puede tener su propia hoja de personaje
 - **Copiar tokens conserva su hoja personalizada** - Al duplicar un token se clona su ficha con los mismos ajustes

--- a/src/components/__tests__/HotSeatVisibility.test.js
+++ b/src/components/__tests__/HotSeatVisibility.test.js
@@ -1,0 +1,17 @@
+import { isTokenVisible } from '../../utils/playerVisibility';
+
+describe('hot seat vision', () => {
+  const tokens = [
+    { id: 'a', x: 0, y: 0, w: 1, h: 1, controlledBy: 'p1', vision: { enabled: true } },
+    { id: 'b', x: 5, y: 0, w: 1, h: 1, controlledBy: 'p1', vision: { enabled: true } }
+  ];
+  const playerVisionPolygons = {
+    a: { polygon: [{ x: -1, y: -1 }, { x: 1, y: -1 }, { x: 1, y: 1 }, { x: -1, y: 1 }] },
+    b: { polygon: [{ x: 4, y: -1 }, { x: 6, y: -1 }, { x: 6, y: 1 }, { x: 4, y: 1 }] }
+  };
+
+  test('token visibility switches with active token', () => {
+    expect(isTokenVisible(tokens[1], 'a', tokens, playerVisionPolygons, 1)).toBe(false);
+    expect(isTokenVisible(tokens[1], 'b', tokens, playerVisionPolygons, 1)).toBe(true);
+  });
+});

--- a/src/utils/playerVisibility.js
+++ b/src/utils/playerVisibility.js
@@ -1,0 +1,26 @@
+import { isPointVisible } from './visibility';
+
+export function isTokenVisible(token, activeTokenId, tokens, playerVisionPolygons, gridSize) {
+  const playerToken = tokens.find(t => t.id === activeTokenId);
+  if (!playerToken) return true;
+  if (token.id === activeTokenId) return true;
+  if (playerToken.vision?.enabled === false) return false;
+  const vision = playerVisionPolygons[playerToken.id];
+  if (!vision || !vision.polygon || vision.polygon.length < 3) return true;
+  const center = {
+    x: (token.x + token.w / 2) * gridSize,
+    y: (token.y + token.h / 2) * gridSize,
+  };
+  return isPointVisible(center, vision.polygon);
+}
+
+export function isDoorVisible(wall, activeTokenId, tokens, playerVisionPolygons) {
+  const playerToken = tokens.find(t => t.id === activeTokenId);
+  if (!playerToken) return true;
+  if (playerToken.vision?.enabled === false) return false;
+  const vision = playerVisionPolygons[playerToken.id];
+  if (!vision || !vision.polygon || vision.polygon.length < 3) return true;
+  const [x1, y1, x2, y2] = wall.points;
+  const center = { x: wall.x + (x1 + x2) / 2, y: wall.y + (y1 + y2) / 2 };
+  return isPointVisible(center, vision.polygon);
+}


### PR DESCRIPTION
## Summary
- add activeTokenId state to MapCanvas
- cycle active token with Tab and selector overlay
- compute visibility using activeTokenId
- document hot seat mode
- test utility for active token vision

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68809b644b688326a109bdc3dfe06ca8