### PR TITLE
Update token selector alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 - **Estados sincronizados de la ficha al token** - Al activar condiciones desde la ficha se aplican inmediatamente al token controlado
 - **Modo Master y Jugador** - Controles especializados según el rol del usuario
 - **Modo "hot seat"** - Alterna entre fichas controladas con Tab o el selector
+- **Selector de ficha centrado** - Muestra el nombre personalizado de cada token
 - **Mapa de Batalla integrado** - VTT sencillo con grid y tokens arrastrables
 - **Fichas de token personalizadas** - Cada token puede tener su propia hoja de personaje
 - **Copiar tokens conserva su hoja personalizada** - Al duplicar un token se clona su ficha con los mismos ajustes

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -4525,16 +4525,16 @@ const MapCanvas = ({
       )}
 
       {(userType === 'player' || playerViewMode) && tokens.some(t => t.controlledBy === (userType === 'player' ? playerName : simulatedPlayer)) && (
-        <div className="absolute top-16 left-4 bg-blue-600 text-white px-3 py-2 rounded-lg shadow-lg z-50">
+        <div className="absolute top-16 left-1/2 transform -translate-x-1/2 bg-blue-600 text-white px-3 py-2 rounded-lg shadow-lg z-50">
           <div className="flex items-center gap-2">
-            <span className="text-sm font-medium">🎯 Ficha activa:</span>
+            <span className="text-sm font-medium">Ficha activa:</span>
             <select
               className="text-black text-sm"
               value={activeTokenId || ''}
               onChange={e => setActiveTokenId(e.target.value)}
             >
               {tokens.filter(t => t.controlledBy === (userType === 'player' ? playerName : simulatedPlayer)).map(t => (
-                <option key={t.id} value={t.id}>{t.name || t.id}</option>
+                <option key={t.id} value={t.id}>{t.customName || t.name || t.id}</option>
               ))}
             </select>
             <span className="text-xs opacity-75">(Tab para alternar)</span>


### PR DESCRIPTION
## Summary
- replace emoji in active token selector header with text
- show `customName` if present in selector options
- center active token selector below the header
- document centered selector in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6880a406228c8326a196178e00119fe4