### PR TITLE
Add token sync toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -901,6 +901,7 @@ src/
 - **La mirilla apunta a tokens ajenos** - Ahora también puedes fijar como objetivo fichas controladas por otros jugadores o por el máster
 - **Doble clic seguro en mirilla** - Al usar la mirilla, el doble clic ya no abre el menú de ajustes del token
 - **Iconos de puerta siempre orientados** - Los SVG de las puertas se muestran correctamente aunque el muro se dibuje al revés
+- **Sincronización opcional por token** - Cada ficha incluye la propiedad `syncWithPlayer` para decidir si debe reflejar los cambios de la ficha de jugador
 
 #### v2.1.1 (junio 2024)
 

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -1026,7 +1026,8 @@ const MapCanvas = ({
         (t) =>
           t.tokenSheetId === sheet.id &&
           t.controlledBy &&
-          t.controlledBy !== 'master'
+          t.controlledBy !== 'master' &&
+          t.syncWithPlayer
       );
       if (!token) return;
       try {
@@ -1111,6 +1112,7 @@ const MapCanvas = ({
           prevToken &&
           token.controlledBy &&
           token.controlledBy !== 'master' &&
+          token.syncWithPlayer &&
           !deepEqual(prevToken.estados, token.estados)
         ) {
           const stored =
@@ -1291,7 +1293,7 @@ const MapCanvas = ({
       const { name, sheet, origin } = e.detail || {};
       if (origin === 'mapSync') return;
       const affected = tokens.filter(
-        (t) => t.controlledBy === name && t.tokenSheetId
+        (t) => t.controlledBy === name && t.tokenSheetId && t.syncWithPlayer
       );
       if (!affected.length) return;
 
@@ -1323,7 +1325,7 @@ const MapCanvas = ({
       if (!e.key || !e.key.startsWith('player_') || !e.newValue) return;
       const name = e.key.replace('player_', '');
       const affected = tokens.filter(
-        (t) => t.controlledBy === name && t.tokenSheetId
+        (t) => t.controlledBy === name && t.tokenSheetId && t.syncWithPlayer
       );
       if (!affected.length) return;
 
@@ -3090,7 +3092,8 @@ const MapCanvas = ({
               id: Date.now() + Math.random(),
               x: finalPos.x,
               y: finalPos.y,
-              layer: activeLayer
+              layer: activeLayer,
+              syncWithPlayer: true,
             });
             const stored = localStorage.getItem('tokenSheets');
             if (stored) {
@@ -3528,6 +3531,7 @@ const MapCanvas = ({
           tintOpacity: 0,
           estados: [],
           layer: activeLayer,
+          syncWithPlayer: true,
         });
         if (item.tokenSheetId) {
           const stored = localStorage.getItem('tokenSheets');

--- a/src/components/TokenSettings.jsx
+++ b/src/components/TokenSettings.jsx
@@ -64,6 +64,9 @@ const TokenSettings = ({
   const [tintOpacity, setTintOpacity] = useState(
     typeof token.tintOpacity === 'number' ? token.tintOpacity : 0
   );
+  const [syncWithPlayer, setSyncWithPlayer] = useState(
+    token.syncWithPlayer !== false
+  );
   
   // Estados para configuración de luz
   const [lightEnabled, setLightEnabled] = useState(token.light?.enabled || false);
@@ -134,13 +137,15 @@ const TokenSettings = ({
           enabled: visionEnabled,
           range: visionRange,
         },
+        syncWithPlayer,
       });
     }, 800); // Esperar 800ms antes de aplicar cambios (optimizado para evitar spam a Firebase)
   }, [
     token, enemyId, enemies, name, showName, controlledBy, barsVisibility,
     auraRadius, auraShape, auraColor, auraOpacity, auraVisibility,
     tokenOpacity, tintColor, tintOpacity, lightEnabled, lightRadius,
-    lightColor, lightOpacity, visionEnabled, visionRange, onUpdate
+    lightColor, lightOpacity, visionEnabled, visionRange, syncWithPlayer,
+    onUpdate
   ]);
 
   // Función inmediata para cambios que no requieren debouncing
@@ -173,6 +178,7 @@ const TokenSettings = ({
         enabled: visionEnabled,
         range: visionRange,
       },
+      syncWithPlayer,
     };
     if (controlledBy !== 'master' && token.tokenSheetId) {
       try {
@@ -212,6 +218,7 @@ const TokenSettings = ({
     lightEnabled,
     lightRadius,
     visionEnabled, // Cambio inmediato para visión
+    syncWithPlayer,
   ]);
 
   // useEffect con debouncing para cambios de texto y luz (para evitar spam a Firebase)
@@ -327,6 +334,15 @@ const TokenSettings = ({
                   </select>
                 )}
               </div>
+              <div className="flex items-center gap-2">
+                <input
+                  id="syncWithPlayer"
+                  type="checkbox"
+                  checked={syncWithPlayer}
+                  onChange={e => setSyncWithPlayer(e.target.checked)}
+                />
+                <label htmlFor="syncWithPlayer">Sincronizar con ficha de jugador</label>
+              </div>
               <div>
                 <label className="block mb-1">Barras visibles para</label>
                 <select value={barsVisibility} onChange={e => setBarsVisibility(e.target.value)} className="w-full bg-gray-700 text-white">
@@ -388,7 +404,8 @@ const TokenSettings = ({
                       auraVisibility,
                       opacity: tokenOpacity,
                       tintColor,
-                    tintOpacity,
+                      tintOpacity,
+                      syncWithPlayer,
                   };
                   onOpenSheet(updated);
                 }}

--- a/src/components/__tests__/PlayerSheetSync.test.js
+++ b/src/components/__tests__/PlayerSheetSync.test.js
@@ -69,7 +69,7 @@ function savePlayer(name, data) {
 }
 
 test('controlled token updates on player sheet save', () => {
-  const initial = [{ id: 't1', controlledBy: 'Alice', tokenSheetId: 's1' }];
+  const initial = [{ id: 't1', controlledBy: 'Alice', tokenSheetId: 's1', syncWithPlayer: true }];
   let renderedTokens = initial;
   const Wrapper = () => {
     const [tokens, setTokens] = React.useState(initial);
@@ -95,7 +95,7 @@ test('controlled token updates on player sheet save', () => {
 });
 
 test('mapSync events are ignored to avoid loops', () => {
-  const initial = [{ id: 't1', controlledBy: 'Bob', tokenSheetId: 's2' }];
+  const initial = [{ id: 't1', controlledBy: 'Bob', tokenSheetId: 's2', syncWithPlayer: true }];
   const Wrapper = () => {
     const [tokens, setTokens] = React.useState(initial);
     return <SyncListener tokens={tokens} onTokensChange={setTokens} />;
@@ -119,7 +119,7 @@ test('mapSync events are ignored to avoid loops', () => {
 });
 
 test('token estado changes update player sheet', () => {
-  const initial = [{ id: 't1', controlledBy: 'Carl', tokenSheetId: 's3', estados: [] }];
+  const initial = [{ id: 't1', controlledBy: 'Carl', tokenSheetId: 's3', estados: [], syncWithPlayer: true }];
   let setTokens;
   const Wrapper = () => {
     const [tokens, update] = React.useState(initial);
@@ -133,7 +133,7 @@ test('token estado changes update player sheet', () => {
   render(<Wrapper />);
 
   act(() => {
-    setTokens([{ id: 't1', controlledBy: 'Carl', tokenSheetId: 's3', estados: ['mareado'] }]);
+    setTokens([{ id: 't1', controlledBy: 'Carl', tokenSheetId: 's3', estados: ['mareado'], syncWithPlayer: true }]);
   });
 
   const updated = JSON.parse(localStorage.getItem('player_Carl'));

--- a/src/components/__tests__/StorageEventSync.test.js
+++ b/src/components/__tests__/StorageEventSync.test.js
@@ -35,7 +35,7 @@ function StorageListener({ tokens, onTokensChange }) {
 }
 
 test('tokens update on storage event', () => {
-  const initial = [{ id: 't1', controlledBy: 'Alice', tokenSheetId: 's1' }];
+  const initial = [{ id: 't1', controlledBy: 'Alice', tokenSheetId: 's1', syncWithPlayer: true }];
   let renderedTokens = initial;
   const Wrapper = () => {
     const [tokens, setTokens] = React.useState(initial);

--- a/src/utils/token.js
+++ b/src/utils/token.js
@@ -2,6 +2,7 @@ import { nanoid } from 'nanoid';
 
 export const createToken = (data = {}) => ({
   ...data,
+  syncWithPlayer: true,
   tokenSheetId: nanoid(),
 });
 


### PR DESCRIPTION
## Summary
- add `syncWithPlayer` default when creating tokens
- include sync flag in MapCanvas token creation
- update sync listeners to respect token.syncWithPlayer
- add checkbox in TokenSettings for player sync
- document new behaviour

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6880a41d30bc8326bd72e5167465b638