### PR TITLE
Update token sync behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 - **Mapa de Batalla integrado** - VTT sencillo con grid y tokens arrastrables
 - **Fichas de token personalizadas** - Cada token puede tener su propia hoja de personaje
 - **Copiar tokens conserva su hoja personalizada** - Al duplicar un token se clona su ficha con los mismos ajustes
+- **Cargar ficha del jugador bajo demanda** - Usa el selector o el botón "Actualizar ficha" para sincronizar manualmente
 - **Nombre en tokens** - El nombre del personaje aparece justo debajo del token en negrita con contorno negro (text-shadow en cuatro direcciones y leve desenfoque)
 - **Nombre escalable** - La fuente del nombre aumenta si el token ocupa varias casillas
 - **Mini-barras en tokens** - Cada stat se muestra sobre el token mediante cápsulas interactivas y puedes elegir su posición


### PR DESCRIPTION
## Summary
- add `loadPlayerSheet` helper to fetch player sheets on demand
- call `loadPlayerSheet` when the controller is changed and from a new **Actualizar ficha** button
- remove automatic Firestore fetch from `applyChanges`
- prevent unwanted sync on mount by skipping the first run for `syncWithPlayer`
- document manual player sheet refresh in README

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6880b9a1e84883269b84a92b5f7fffd0