### PR TITLE
Add manual sync for player sheets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1173,6 +1173,10 @@ src/
 
 - ✅ Los modales de Ataque y Defensa muestran el consumo de velocidad del arma o poder seleccionado
 
+### 🗄️ **Sincronización manual de fichas (Enero 2027) - v2.4.38**
+
+- ✅ Nuevos botones para restaurar o subir la ficha del jugador desde los ajustes del token
+
 ### 🎯 **Alcance de armas y poderes (Enero 2027) - v2.4.25**
 
 - ✅ El menú de ataque y defensa solo muestra armas o poderes al alcance


### PR DESCRIPTION
## Summary
- add functions `restoreFromPlayerSheet` and `updatePlayerSheet`
- add buttons for restoring and uploading player sheets
- document manual sync buttons in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6880bc4819c483269c65742aeca66beb