### PR TITLE
Fix restoreFromPlayerSheet portrait sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 - **Permisos granulares** - Jugadores pueden eliminar sus propios participantes
 - **Interfaz color-coded** - Identificación visual por jugador y tipo de equipamiento
 - **Sincronización en tiempo real** - Cambios instantáneos para todos los participantes
-- **Sincronización manual de la ficha del jugador** - Usa los botones de TokenSettings para subir o restaurar cambios
+- **Sincronización manual de la ficha del jugador** - Usa los botones de TokenSettings para subir o restaurar cambios (mantiene la imagen del token)
 - **Estados sincronizados de la ficha al token** - Al activar condiciones desde la ficha se aplican inmediatamente al token controlado
 - **Modo Master y Jugador** - Controles especializados según el rol del usuario
 - **Modo "hot seat"** - Alterna entre fichas controladas con Tab o el selector

--- a/src/components/TokenSettings.jsx
+++ b/src/components/TokenSettings.jsx
@@ -104,11 +104,8 @@ const TokenSettings = ({
       if (snap.exists()) {
         const stored = localStorage.getItem('tokenSheets');
         const sheets = stored ? JSON.parse(stored) : {};
-        const sheet = {
-          id: token.tokenSheetId,
-          portrait: token.url,
-          ...snap.data(),
-        };
+        const sheet = { id: token.tokenSheetId, ...snap.data() };
+        sheet.portrait = token.url;
         sheets[token.tokenSheetId] = sheet;
         localStorage.setItem('tokenSheets', JSON.stringify(sheets));
         window.dispatchEvent(


### PR DESCRIPTION
## Summary
- ensure `restoreFromPlayerSheet` keeps current token image
- note in docs that manual sync preserves token image

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6880c29b940c83269a8450639c562c2c