### PR TITLE
Disable auto load of player sheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -883,7 +883,7 @@ src/
 #### v2.1.2 (diciembre 2024)
 
 - **Sistema de Píldoras de Equipamiento** - Nuevas píldoras interactivas en el Sistema de Velocidad que permiten usar armas y poderes equipados directamente
-- **Vincular ficha de jugador** - Al asignar un controlador se descarga su ficha desde Firestore y se almacena localmente
+- **Vincular ficha de jugador** - Al asignar un controlador ya no se descarga automáticamente su ficha; usa **Restaurar ficha** para importarla desde Firestore
 - **Fichas de jugador completas** - Las estadísticas personalizadas y el equipamiento se muestran correctamente al enlazar
 - **Carga de imágenes optimizada** - Las tarjetas ya no hacen peticiones en bucle al equipar objetos
 - **Sincronización total de fichas de jugador** - Se respetan las posiciones personalizadas de estadísticas y se cargan armas, armaduras y poderes equipados

--- a/src/components/TokenSettings.jsx
+++ b/src/components/TokenSettings.jsx
@@ -147,12 +147,14 @@ const TokenSettings = ({
     }
   };
 
-  const handleControlledByChange = async (e) => {
+  const handleControlledByChange = (e) => {
     const value = e.target.value;
     setControlledBy(value);
     if (value !== 'master') {
       setEnemyId('');
-      await loadPlayerSheet(value);
+      // La ficha del jugador ya no se carga de forma automática al
+      // asignar el token. Se mantiene la ficha actual hasta que el
+      // usuario pulse "Restaurar ficha" manualmente.
     }
   };
   


### PR DESCRIPTION
## Summary
- stop autoloading player sheet when assigning token to a player
- update docs about linking player sheets

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6880d34412948326b1b34b99e4268a26