### PR TITLE
Enable draggable active token selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -1180,6 +1180,10 @@ src/
 
 - ✅ Se elimina el botón "Actualizar ficha" manteniendo "Restaurar ficha" y "Subir cambios"
 
+### 🕹️ **Ventana de cambio de ficha móvil (Enero 2027) - v2.4.40**
+
+- ✅ El selector de ficha activa puede arrastrarse a cualquier posición de la pantalla
+
 ### 🎯 **Alcance de armas y poderes (Enero 2027) - v2.4.25**
 
 - ✅ El menú de ataque y defensa solo muestra armas o poderes al alcance


### PR DESCRIPTION
## Summary
- allow the active token switcher panel to be dragged
- remember its position in localStorage
- document new feature in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688127663c308326bb708130cc388177