### PR TITLE
Fix stat deletion persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -903,6 +903,7 @@ src/
 - **La mirilla apunta a tokens ajenos** - Ahora también puedes fijar como objetivo fichas controladas por otros jugadores o por el máster
 - **Doble clic seguro en mirilla** - Al usar la mirilla, el doble clic ya no abre el menú de ajustes del token
 - **Iconos de puerta siempre orientados** - Los SVG de las puertas se muestran correctamente aunque el muro se dibuje al revés
+- **Edición de estadísticas fiable** - Al borrar una estadística de la ficha se elimina también de `resourcesList`, evitando que reaparezca
 
 #### v2.1.1 (junio 2024)
 

--- a/src/components/TokenSheetEditor.jsx
+++ b/src/components/TokenSheetEditor.jsx
@@ -70,7 +70,11 @@ const TokenSheetEditor = ({
     setData(prev => {
       const copy = { ...prev.stats };
       delete copy[stat];
-      return { ...prev, stats: copy };
+      let list = prev.resourcesList;
+      if (Array.isArray(list)) {
+        list = list.filter(r => r.id !== stat);
+      }
+      return { ...prev, stats: copy, resourcesList: list };
     });
   };
 


### PR DESCRIPTION
## Summary
- remove stats from `resourcesList` when deleted in `TokenSheetEditor`
- document stat deletion fix

## Testing
- `npm install`
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68812b24c5ec8326b3544fb399d4da39