### PR TITLE
Fix automatic player sheet sync on token assign

### DIFF
--- a/README.md
+++ b/README.md
@@ -693,6 +693,10 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 
 - Añadido buscador de tokens en la sección de assets para localizar imágenes por nombre.
 
+**Resumen de cambios v2.3.29:**
+
+- Asignar un jugador a un token ya no descarga automáticamente su ficha; usa **Restaurar ficha** para importarla manualmente.
+
 **Resumen de cambios v2.4.0:**
 
 - Sistema de Capas implementado con organización del contenido del mapa en 3 capas independientes.

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -1686,16 +1686,8 @@ const MapCanvas = ({
       tokens.forEach(tk => {
         if (!tk.tokenSheetId || sheets[tk.tokenSheetId] || !canSeeBars(tk)) return;
         if (tk.controlledBy && tk.controlledBy !== 'master') {
-          promises.push(
-            getDoc(doc(db, 'players', tk.controlledBy))
-              .then(snap => {
-                if (snap.exists()) {
-                  const sheet = { id: tk.tokenSheetId, ...snap.data() };
-                  sheets[tk.tokenSheetId] = sheet;
-                }
-              })
-              .catch(err => console.error('load player sheet', err))
-          );
+          // No cargar automáticamente la ficha del jugador al asignar el token.
+          return;
         } else if (tk.enemyId) {
           promises.push(
             getDoc(doc(db, 'enemies', tk.enemyId))


### PR DESCRIPTION
## Summary
- prevent auto downloading player sheet when assigning token controller
- document change in README

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688130dbd9f483268cb5879f370d5f2d