### PR TITLE
Add Firestore token sheet persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,6 +385,7 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 **Resumen de cambios v2.2.56:**
 
 - Las fichas de token ahora pueden editarse de forma independiente, guardando sus cambios en localStorage.
+- Las fichas de token se guardan también en Firestore y se sincronizan en tiempo real.
 
 **Resumen de cambios v2.2.57:**
 

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -32,7 +32,7 @@ import TokenSheetModal from './TokenSheetModal';
 import { ESTADOS } from './EstadoSelector';
 import { nanoid } from 'nanoid';
 import { motion } from 'framer-motion';
-import { createToken, cloneTokenSheet } from '../utils/token';
+import { createToken, cloneTokenSheet, saveTokenSheet } from '../utils/token';
 import TokenBars from './TokenBars';
 import LoadingSpinner from './LoadingSpinner';
 import KonvaSpinner from './KonvaSpinner';
@@ -45,7 +45,7 @@ import DefenseModal from './DefenseModal';
 import { applyDoorCheck } from '../utils/door';
 import { computeVisibility, combineVisibilityPolygons, isPointVisible } from '../utils/visibility';
 import { isTokenVisible, isDoorVisible } from '../utils/playerVisibility';
-import { doc, updateDoc, getDoc, setDoc, deleteDoc } from 'firebase/firestore';
+import { doc, updateDoc, getDoc, setDoc, deleteDoc, onSnapshot } from 'firebase/firestore';
 import { db } from '../firebase';
 import { deepEqual } from '../utils/deepEqual';
 import useAttackRequests from '../hooks/useAttackRequests';
@@ -623,13 +623,7 @@ const Token = forwardRef(
             const sheet = sheets[tokenSheetId];
             if (sheet && sheet.stats) {
               sheet.stats = updated;
-              sheets[tokenSheetId] = sheet;
-              localStorage.setItem('tokenSheets', JSON.stringify(sheets));
-              window.dispatchEvent(
-                new CustomEvent('tokenSheetSaved', {
-                  detail: { id: tokenSheetId, stats: updated },
-                })
-              );
+              saveTokenSheet(sheet);
             }
           }
         }
@@ -1683,33 +1677,69 @@ const MapCanvas = ({
       const stored = localStorage.getItem('tokenSheets');
       const sheets = stored ? JSON.parse(stored) : {};
       const promises = [];
-      tokens.forEach(tk => {
+      tokens.forEach((tk) => {
         if (!tk.tokenSheetId || sheets[tk.tokenSheetId] || !canSeeBars(tk)) return;
         if (tk.controlledBy && tk.controlledBy !== 'master') {
-          // No cargar automáticamente la ficha del jugador al asignar el token.
           return;
         } else if (tk.enemyId) {
           promises.push(
             getDoc(doc(db, 'enemies', tk.enemyId))
-              .then(snap => {
+              .then((snap) => {
                 if (snap.exists()) {
                   const sheet = { id: tk.tokenSheetId, ...snap.data() };
                   sheets[tk.tokenSheetId] = sheet;
                 }
               })
-              .catch(err => console.error('load enemy sheet', err))
+              .catch((err) => console.error('load enemy sheet', err))
+          );
+        } else {
+          promises.push(
+            getDoc(doc(db, 'tokenSheets', tk.tokenSheetId))
+              .then((snap) => {
+                if (snap.exists()) {
+                  const sheet = { id: tk.tokenSheetId, ...snap.data() };
+                  sheets[tk.tokenSheetId] = sheet;
+                }
+              })
+              .catch((err) => console.error('load token sheet', err))
           );
         }
       });
       if (promises.length > 0) {
         await Promise.all(promises);
         localStorage.setItem('tokenSheets', JSON.stringify(sheets));
-        Object.values(sheets).forEach(sh =>
+        Object.values(sheets).forEach((sh) =>
           window.dispatchEvent(new CustomEvent('tokenSheetSaved', { detail: sh }))
         );
       }
     };
     loadSheets();
+  }, [tokens, playerName, userType]);
+
+  const sheetListeners = useRef({});
+  useEffect(() => {
+    tokens.forEach((tk) => {
+      if (!tk.tokenSheetId || !canSeeBars(tk)) return;
+      if (!sheetListeners.current[tk.tokenSheetId]) {
+        const ref = doc(db, 'tokenSheets', tk.tokenSheetId);
+        sheetListeners.current[tk.tokenSheetId] = onSnapshot(ref, (snap) => {
+          if (snap.exists()) {
+            const data = { id: tk.tokenSheetId, ...snap.data() };
+            saveTokenSheet(data);
+          }
+        });
+      }
+    });
+    Object.keys(sheetListeners.current).forEach((id) => {
+      if (!tokens.find((t) => t.tokenSheetId === id)) {
+        sheetListeners.current[id]();
+        delete sheetListeners.current[id];
+      }
+    });
+    return () => {
+      Object.values(sheetListeners.current).forEach((unsub) => unsub());
+      sheetListeners.current = {};
+    };
   }, [tokens, playerName, userType]);
 
   // Si se especifica el número de casillas, calculamos el tamaño de cada celda

--- a/src/components/TokenSheetModal.jsx
+++ b/src/components/TokenSheetModal.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import EnemyViewModal from './EnemyViewModal';
 import TokenSheetEditor from './TokenSheetEditor';
+import { saveTokenSheet } from '../utils/token';
 
 const recursoColor = {
   postura: '#34d399',
@@ -103,13 +104,9 @@ const TokenSheetModal = ({
   }, [sheetId, token, enemies, armas, armaduras, habilidades, editing]);
 
   const handleSave = (updated) => {
-    const stored = localStorage.getItem('tokenSheets');
-    const sheets = stored ? JSON.parse(stored) : {};
-    sheets[sheetId] = updated;
-    localStorage.setItem('tokenSheets', JSON.stringify(sheets));
+    saveTokenSheet(updated);
     setData(updated);
     setEditing(false);
-    window.dispatchEvent(new CustomEvent('tokenSheetSaved', { detail: updated }));
   };
 
   if (!token || !data) return null;

--- a/src/utils/__tests__/cloneTokenSheet.test.js
+++ b/src/utils/__tests__/cloneTokenSheet.test.js
@@ -1,5 +1,11 @@
 import { createToken, cloneTokenSheet } from '../token';
 
+jest.mock('firebase/firestore', () => ({
+  doc: jest.fn(),
+  setDoc: jest.fn().mockResolvedValue(),
+}));
+jest.mock('../../firebase', () => ({ db: {} }));
+
 beforeEach(() => {
   localStorage.clear();
 });

--- a/src/utils/__tests__/token.test.js
+++ b/src/utils/__tests__/token.test.js
@@ -1,5 +1,11 @@
 import { createToken } from '../token';
 
+jest.mock('firebase/firestore', () => ({
+  doc: jest.fn(),
+  setDoc: jest.fn().mockResolvedValue(),
+}));
+jest.mock('../../firebase', () => ({ db: {} }));
+
 test('generated tokens across pages have unique tokenSheetId', () => {
   const page1 = [createToken({ id: 1 }), createToken({ id: 2 })];
   const page2 = [createToken({ id: 3 }), createToken({ id: 4 })];

--- a/src/utils/__tests__/tokenSheetClone.test.js
+++ b/src/utils/__tests__/tokenSheetClone.test.js
@@ -1,5 +1,11 @@
 import { createToken } from '../token';
 
+jest.mock('firebase/firestore', () => ({
+  doc: jest.fn(),
+  setDoc: jest.fn().mockResolvedValue(),
+}));
+jest.mock('../../firebase', () => ({ db: {} }));
+
 describe('token sheet cloning', () => {
   beforeEach(() => {
     localStorage.clear();

--- a/src/utils/token.js
+++ b/src/utils/token.js
@@ -1,9 +1,30 @@
 import { nanoid } from 'nanoid';
+import { doc, setDoc } from 'firebase/firestore';
+import { db } from '../firebase';
 
-export const createToken = (data = {}) => ({
-  ...data,
-  tokenSheetId: nanoid(),
-});
+export const createToken = (data = {}) => {
+  const token = { ...data, tokenSheetId: nanoid() };
+  try {
+    setDoc(doc(db, 'tokenSheets', token.tokenSheetId), { stats: {} });
+  } catch (err) {
+    console.error('create token sheet', err);
+  }
+  return token;
+};
+
+export const saveTokenSheet = async (sheet) => {
+  if (!sheet?.id) return;
+  const stored = localStorage.getItem('tokenSheets');
+  const sheets = stored ? JSON.parse(stored) : {};
+  sheets[sheet.id] = { ...(sheets[sheet.id] || {}), ...sheet };
+  localStorage.setItem('tokenSheets', JSON.stringify(sheets));
+  window.dispatchEvent(new CustomEvent('tokenSheetSaved', { detail: sheet }));
+  try {
+    await setDoc(doc(db, 'tokenSheets', sheet.id), sheet, { merge: true });
+  } catch (err) {
+    console.error('save token sheet', err);
+  }
+};
 
 export const cloneTokenSheet = (sourceId, targetId) => {
   if (!sourceId || !targetId) return;


### PR DESCRIPTION
## Summary
- store token sheets in a new Firestore collection
- createToken now creates an empty Firestore sheet
- add `saveTokenSheet` helper and use it from token sheet UI
- load sheets from Firestore when missing locally
- listen for realtime updates with `onSnapshot`
- document Firestore sync behaviour

## Testing
- `npm install --silent`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_688146a6b2508326bdc7b568de33d8a3