### PR TITLE
Ensure token sheets saved from combat modals

### DIFF
--- a/README.md
+++ b/README.md
@@ -1192,6 +1192,11 @@ src/
 
 - ✅ El selector de ficha activa puede arrastrarse a cualquier posición de la pantalla
 
+### 💾 **Persistencia de cambios en combate (Enero 2027) - v2.4.41**
+
+- ✅ Los modales de Ataque y Defensa guardan las estadísticas modificadas con `saveTokenSheet`
+- ✅ Al mover un token se mantienen correctos la vida y demás recursos
+
 ### 🎯 **Alcance de armas y poderes (Enero 2027) - v2.4.25**
 
 - ✅ El menú de ataque y defensa solo muestra armas o poderes al alcance

--- a/src/components/AttackModal.jsx
+++ b/src/components/AttackModal.jsx
@@ -15,6 +15,7 @@ import {
 } from 'firebase/firestore';
 import { db } from '../firebase';
 import { nanoid } from 'nanoid';
+import { saveTokenSheet } from '../utils/token';
 
 const AUTO_RESOLVE_MS = 20000;
 
@@ -171,6 +172,7 @@ const AttackModal = ({
                 window.dispatchEvent(
                   new CustomEvent('tokenSheetSaved', { detail: updated })
                 );
+                saveTokenSheet(updated);
                 updatedSheet = updated;
               }
             }

--- a/src/components/DefenseModal.jsx
+++ b/src/components/DefenseModal.jsx
@@ -7,6 +7,7 @@ import { applyDamage, parseDieValue } from '../utils/damage';
 import { doc, getDoc, setDoc } from 'firebase/firestore';
 import { db } from '../firebase';
 import { nanoid } from 'nanoid';
+import { saveTokenSheet } from '../utils/token';
 
 const DefenseModal = ({
   isOpen,
@@ -142,6 +143,7 @@ const DefenseModal = ({
         window.dispatchEvent(
           new CustomEvent('tokenSheetSaved', { detail: updated })
         );
+        saveTokenSheet(updated);
         affectedSheet = updated;
       } else if (diff > 0 && attacker?.tokenSheetId) {
         const stored = localStorage.getItem('tokenSheets');
@@ -161,6 +163,7 @@ const DefenseModal = ({
             window.dispatchEvent(
               new CustomEvent('tokenSheetSaved', { detail: atkSheet })
             );
+            saveTokenSheet(atkSheet);
             affectedSheet = atkSheet;
           }
         }


### PR DESCRIPTION
## Summary
- persist stat changes in `AttackModal` and `DefenseModal` using `saveTokenSheet`
- note persistence in combat in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6881f4bd50e48326bf5036048a05f3a8