### PR TITLE
Fix editable token sheets after restore

### DIFF
--- a/README.md
+++ b/README.md
@@ -1197,6 +1197,11 @@ src/
 - ✅ Los modales de Ataque y Defensa guardan las estadísticas modificadas con `saveTokenSheet`
 - ✅ Al mover un token se mantienen correctos la vida y demás recursos
 
+### 🛠️ **Edición tras restaurar ficha (Abril 2027) - v2.4.42**
+
+- ✅ Restaurar la ficha de un jugador aplica valores predeterminados para que las barras sean visibles
+- ✅ Las estadísticas pueden modificarse y guardarse sin problemas
+
 ### 🎯 **Alcance de armas y poderes (Enero 2027) - v2.4.25**
 
 - ✅ El menú de ataque y defensa solo muestra armas o poderes al alcance

--- a/src/components/TokenSettings.jsx
+++ b/src/components/TokenSettings.jsx
@@ -6,6 +6,7 @@ import { doc, updateDoc, getDoc, setDoc } from 'firebase/firestore';
 import { db } from '../firebase';
 import Boton from './Boton';
 import Input from './Input';
+import { ensureSheetDefaults } from '../utils/token';
 
 const TokenSettings = ({
   token,
@@ -84,7 +85,7 @@ const TokenSettings = ({
       if (snap.exists() && token.tokenSheetId) {
         const stored = localStorage.getItem('tokenSheets');
         const sheets = stored ? JSON.parse(stored) : {};
-        const sheet = { id: token.tokenSheetId, ...snap.data() };
+        const sheet = ensureSheetDefaults({ id: token.tokenSheetId, ...snap.data() });
         sheets[token.tokenSheetId] = sheet;
         localStorage.setItem('tokenSheets', JSON.stringify(sheets));
         window.dispatchEvent(new CustomEvent('tokenSheetSaved', { detail: sheet }));
@@ -101,7 +102,7 @@ const TokenSettings = ({
       if (snap.exists()) {
         const stored = localStorage.getItem('tokenSheets');
         const sheets = stored ? JSON.parse(stored) : {};
-        const sheet = { id: token.tokenSheetId, ...snap.data() };
+        const sheet = ensureSheetDefaults({ id: token.tokenSheetId, ...snap.data() });
         sheet.portrait = token.url;
         sheets[token.tokenSheetId] = sheet;
         localStorage.setItem('tokenSheets', JSON.stringify(sheets));

--- a/src/components/TokenSheetModal.jsx
+++ b/src/components/TokenSheetModal.jsx
@@ -2,15 +2,7 @@ import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import EnemyViewModal from './EnemyViewModal';
 import TokenSheetEditor from './TokenSheetEditor';
-import { saveTokenSheet } from '../utils/token';
-
-const recursoColor = {
-  postura: '#34d399',
-  vida: '#f87171',
-  ingenio: '#60a5fa',
-  cordura: '#a78bfa',
-  armadura: '#9ca3af',
-};
+import { saveTokenSheet, ensureSheetDefaults } from '../utils/token';
 
 const TokenSheetModal = ({
   token,
@@ -60,45 +52,7 @@ const TokenSheetModal = ({
     sheet.armaduras = mapItems(sheet.armaduras, armaduras);
     sheet.poderes = mapItems(sheet.poderes, habilidades);
 
-    const ensureStatDefaults = (st, index, id, name, color, row, anchor) => {
-      const stat = { ...st };
-      if (stat.base === undefined) stat.base = stat.total ?? 0;
-      if (stat.total === undefined) stat.total = stat.base;
-      if (stat.color === undefined) stat.color = color || '#ffffff';
-      if (stat.showOnToken === undefined)
-        stat.showOnToken = index < 5 ? true : !!(stat.base || stat.total || stat.actual || stat.buff);
-      if (stat.label === undefined) stat.label = name || id;
-      if (stat.tokenRow === undefined) stat.tokenRow = row ?? index;
-      if (stat.tokenAnchor === undefined) stat.tokenAnchor = anchor ?? 'top';
-      return stat;
-    };
-
-    if (sheet.resourcesList && sheet.resourcesList.length > 0) {
-      sheet.resourcesList.forEach((res, index) => {
-        const existing = sheet.stats[res.id] || {};
-        sheet.stats[res.id] = ensureStatDefaults(
-          existing,
-          index,
-          res.id,
-          res.name,
-          res.color || recursoColor[res.id],
-          res.tokenRow,
-          res.tokenAnchor
-        );
-      });
-    } else if (!sheet.stats || Object.keys(sheet.stats).length === 0) {
-      sheet.stats = {
-        postura: ensureStatDefaults({}, 0, 'postura', 'postura', recursoColor.postura),
-        vida: ensureStatDefaults({}, 1, 'vida', 'vida', recursoColor.vida),
-        ingenio: ensureStatDefaults({}, 2, 'ingenio', 'ingenio', recursoColor.ingenio),
-        cordura: ensureStatDefaults({}, 3, 'cordura', 'cordura', recursoColor.cordura),
-        armadura: ensureStatDefaults({}, 4, 'armadura', 'armadura', recursoColor.armadura),
-      };
-    } else {
-      Object.keys(sheet.stats).forEach((k, index) => {
-        sheet.stats[k] = ensureStatDefaults(sheet.stats[k], index, k, k, recursoColor[k]);
-      });
-    }
+    sheet = ensureSheetDefaults(sheet);
 
     setData(sheet);
   }, [sheetId, token, enemies, armas, armaduras, habilidades, editing]);

--- a/src/utils/token.js
+++ b/src/utils/token.js
@@ -39,3 +39,43 @@ export const cloneTokenSheet = (sourceId, targetId) => {
   localStorage.setItem('tokenSheets', JSON.stringify(sheets));
   window.dispatchEvent(new CustomEvent('tokenSheetSaved', { detail: copy }));
 };
+export const ensureSheetDefaults = (sheet) => {
+  if (!sheet || typeof sheet !== 'object') return sheet;
+  const recursoColor = {
+    postura: '#34d399',
+    vida: '#f87171',
+    ingenio: '#60a5fa',
+    cordura: '#a78bfa',
+    armadura: '#9ca3af',
+  };
+  const ensure = (st, index, id) => {
+    const stat = { ...st };
+    if (stat.base === undefined) stat.base = stat.total ?? 0;
+    if (stat.total === undefined) stat.total = stat.base;
+    if (stat.color === undefined) stat.color = recursoColor[id] || '#ffffff';
+    if (stat.showOnToken === undefined)
+      stat.showOnToken = index < 5 ? true : !!(stat.base || stat.total || stat.actual || stat.buff);
+    if (stat.label === undefined) stat.label = id;
+    if (stat.tokenRow === undefined) stat.tokenRow = index;
+    if (stat.tokenAnchor === undefined) stat.tokenAnchor = 'top';
+    return stat;
+  };
+  if (!sheet.stats) sheet.stats = {};
+  if (sheet.resourcesList && sheet.resourcesList.length > 0) {
+    sheet.resourcesList.forEach((res, idx) => {
+      sheet.stats[res.id] = ensure(sheet.stats[res.id] || {}, idx, res.id);
+      if (res.color && !sheet.stats[res.id].color) sheet.stats[res.id].color = res.color;
+      if (res.tokenRow !== undefined) sheet.stats[res.id].tokenRow = res.tokenRow;
+      if (res.tokenAnchor) sheet.stats[res.id].tokenAnchor = res.tokenAnchor;
+    });
+  } else if (Object.keys(sheet.stats).length === 0) {
+    ['postura','vida','ingenio','cordura','armadura'].forEach((id, idx) => {
+      sheet.stats[id] = ensure({}, idx, id);
+    });
+  } else {
+    Object.keys(sheet.stats).forEach((id, idx) => {
+      sheet.stats[id] = ensure(sheet.stats[id], idx, id);
+    });
+  }
+  return sheet;
+};


### PR DESCRIPTION
## Summary
- ensure sheet defaults in utils
- apply defaults when restoring a player sheet
- apply defaults when opening a token sheet
- document the fix in README

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6881fe1083708326bf2e2a09d07adc11