### PR TITLE
Fix token sheet defaults on map

### DIFF
--- a/README.md
+++ b/README.md
@@ -1202,6 +1202,10 @@ src/
 - ✅ Restaurar la ficha de un jugador aplica valores predeterminados para que las barras sean visibles
 - ✅ Las estadísticas pueden modificarse y guardarse sin problemas
 
+### 🛠️ **Corrección de barras tras restaurar ficha (Julio 2027) - v2.4.43**
+
+- ✅ Las fichas restauradas se normalizan en el tablero para mostrar todas las barras
+
 ### 🎯 **Alcance de armas y poderes (Enero 2027) - v2.4.25**
 
 - ✅ El menú de ataque y defensa solo muestra armas o poderes al alcance

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -32,7 +32,12 @@ import TokenSheetModal from './TokenSheetModal';
 import { ESTADOS } from './EstadoSelector';
 import { nanoid } from 'nanoid';
 import { motion } from 'framer-motion';
-import { createToken, cloneTokenSheet, saveTokenSheet } from '../utils/token';
+import {
+  createToken,
+  cloneTokenSheet,
+  saveTokenSheet,
+  ensureSheetDefaults,
+} from '../utils/token';
 import TokenBars from './TokenBars';
 import LoadingSpinner from './LoadingSpinner';
 import KonvaSpinner from './KonvaSpinner';
@@ -444,12 +449,16 @@ const Token = forwardRef(
         if (!stored) return;
         const sheets = JSON.parse(stored);
         const sheet = sheets[tokenSheetId];
-        if (sheet && sheet.stats) setStats(sheet.stats);
+        if (sheet) {
+          const normalized = ensureSheetDefaults(sheet);
+          setStats(normalized.stats || {});
+        }
       };
       load();
       const handler = (e) => {
         if (e.detail && e.detail.id === tokenSheetId) {
-          setStats(e.detail.stats || {});
+          const normalized = ensureSheetDefaults(e.detail);
+          setStats(normalized.stats || {});
         }
       };
       window.addEventListener('tokenSheetSaved', handler);


### PR DESCRIPTION
## Summary
- show token resource bars when loading player sheets
- document the fix

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688200b917408326beb87e8ea2264044