### PR TITLE
Fix token sheet restore editing issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -1262,6 +1262,7 @@ Se sigue una numeración basada en [Semantic Versioning](https://semver.org/lang
 ## 📗 Project Notes
 
 - Token sheets are cached client-side. Listener subscriptions depend only on the set of sheet IDs so moving a token no longer recreates them or triggers repeated Firestore requests.
+- Restoring a player sheet no longer overwrites the token sheet ID, ensuring edits persist.
 
 ## 🤝 Contribución
 

--- a/src/components/TokenSettings.jsx
+++ b/src/components/TokenSettings.jsx
@@ -85,7 +85,7 @@ const TokenSettings = ({
       if (snap.exists() && token.tokenSheetId) {
         const stored = localStorage.getItem('tokenSheets');
         const sheets = stored ? JSON.parse(stored) : {};
-        const sheet = ensureSheetDefaults({ id: token.tokenSheetId, ...snap.data() });
+        const sheet = ensureSheetDefaults({ ...snap.data(), id: token.tokenSheetId });
         sheets[token.tokenSheetId] = sheet;
         localStorage.setItem('tokenSheets', JSON.stringify(sheets));
         window.dispatchEvent(new CustomEvent('tokenSheetSaved', { detail: sheet }));
@@ -102,7 +102,7 @@ const TokenSettings = ({
       if (snap.exists()) {
         const stored = localStorage.getItem('tokenSheets');
         const sheets = stored ? JSON.parse(stored) : {};
-        const sheet = ensureSheetDefaults({ id: token.tokenSheetId, ...snap.data() });
+        const sheet = ensureSheetDefaults({ ...snap.data(), id: token.tokenSheetId });
         sheet.portrait = token.url;
         sheets[token.tokenSheetId] = sheet;
         localStorage.setItem('tokenSheets', JSON.stringify(sheets));

--- a/src/components/__tests__/PlayerSheetSync.test.js
+++ b/src/components/__tests__/PlayerSheetSync.test.js
@@ -6,7 +6,7 @@ function ManualSync({ token }) {
     const stored = localStorage.getItem(`player_${token.controlledBy}`);
     if (!stored) return;
     const sheets = JSON.parse(localStorage.getItem('tokenSheets') || '{}');
-    const sheet = { id: token.tokenSheetId, ...JSON.parse(stored), portrait: token.url };
+    const sheet = { ...JSON.parse(stored), id: token.tokenSheetId, portrait: token.url };
     sheets[token.tokenSheetId] = sheet;
     localStorage.setItem('tokenSheets', JSON.stringify(sheets));
     window.dispatchEvent(new CustomEvent('tokenSheetSaved', { detail: sheet }));
@@ -48,6 +48,18 @@ test('restore button loads player sheet into tokenSheets', () => {
   expect(stored.s1.stats.vida.base).toBe(5);
   expect(saved).toHaveBeenCalledTimes(1);
   window.removeEventListener('tokenSheetSaved', saved);
+});
+
+test('restore ignores id field from player sheet', () => {
+  const token = { id: 't1', tokenSheetId: 's2', controlledBy: 'Carol', url: 'img' };
+  localStorage.setItem('player_Carol', JSON.stringify({ id: 'Carol', stats: { vida: { base: 7 } } }));
+  const { getByText } = render(<ManualSync token={token} />);
+
+  fireEvent.click(getByText('restore'));
+
+  const stored = JSON.parse(localStorage.getItem('tokenSheets'));
+  expect(stored.s2.stats.vida.base).toBe(7);
+  expect(stored.Carol).toBeUndefined();
 });
 
 test('update button saves token sheet to player', () => {


### PR DESCRIPTION
## Summary
- keep token sheet id when restoring from player sheet
- test restore with conflicting id field
- document fix in project notes

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68820871e96483269f6a883cf02717c2