### PR TITLE
Improve token sheet sync for player tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 - **Mapa de Batalla integrado** - VTT sencillo con grid y tokens arrastrables
 - **Fichas de token personalizadas** - Cada token puede tener su propia hoja de personaje
 - **Copiar tokens conserva su hoja personalizada** - Al duplicar un token se clona su ficha con los mismos ajustes
+- **Fichas de jugador sin personaje persistentes** - Los tokens asignados a un jugador pero sin ficha asociada guardan sus cambios en `localStorage` igual que los del máster
 - **Cargar ficha del jugador bajo demanda** - Usa el selector o el botón "Restaurar ficha" para sincronizar manualmente
 - **Nombre en tokens** - El nombre del personaje aparece justo debajo del token en negrita con contorno negro (text-shadow en cuatro direcciones y leve desenfoque)
 - **Nombre escalable** - La fuente del nombre aumenta si el token ocupa varias casillas

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -1733,9 +1733,7 @@ const MapCanvas = ({
           !canSeeBars(tk)
         )
           return;
-        if (tk.controlledBy && tk.controlledBy !== 'master') {
-          return;
-        } else if (tk.enemyId) {
+        if (tk.enemyId) {
           promises.push(
             getDoc(doc(db, 'enemies', tk.enemyId))
               .then((snap) => {


### PR DESCRIPTION
## Summary
- load token sheets from Firestore for player-controlled tokens
- document that player tokens without a character sheet persist like master tokens

## Testing
- `npm install`
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68822ea69b288326b3ef14adbd526ea4