### PR TITLE
Load enemy sheets on missing tokenSheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -1264,6 +1264,7 @@ Se sigue una numeración basada en [Semantic Versioning](https://semver.org/lang
 
 - Token sheets are cached client-side. Listener subscriptions depend only on the set of sheet IDs so moving a token no longer recreates them or triggers repeated Firestore requests.
 - Restoring a player sheet no longer overwrites the token sheet ID, ensuring edits persist.
+- Enemy tokens automatically clone their template the first time they appear if the token sheet doesn't exist, preserving life and resources across browsers.
 
 ## 🤝 Contribución
 


### PR DESCRIPTION
## Summary
- automatically clone enemy template for tokens without a sheet
- cache the cloned sheet and save it to Firestore
- document new behaviour for enemy tokens in README

## Testing
- `npm install`
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6883533e0c64832684c7a3272200fcdf