### PR TITLE
Fix token sheet assignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1270,6 +1270,7 @@ Se sigue una numeración basada en [Semantic Versioning](https://semver.org/lang
 - Token sheets are cached client-side. Listener subscriptions depend only on the set of sheet IDs so moving a token no longer recreates them or triggers repeated Firestore requests.
 - Restoring a player sheet no longer overwrites the token sheet ID, ensuring edits persist.
 - Enemy tokens automatically clone their template the first time they appear if the token sheet doesn't exist, preserving life and resources across browsers.
+- Tokens loaded without a `tokenSheetId` now generate one automatically and persist to Firestore.
 
 ## 🤝 Contribución
 

--- a/src/App.js
+++ b/src/App.js
@@ -37,6 +37,7 @@ import ChatPanel from './components/ChatPanel';
 import sanitize from './utils/sanitize';
 import PageSelector from './components/PageSelector';
 import { nanoid } from 'nanoid';
+import { saveTokenSheet } from './utils/token';
 import useConfirm from './hooks/useConfirm';
 import useResourcesHook from './hooks/useResources';
 import useGlossary from './hooks/useGlossary';
@@ -457,6 +458,7 @@ function App() {
   const [pages, setPages] = useState([]);
   const [currentPage, setCurrentPage] = useState(0);
   const pagesLoadedRef = useRef(false);
+  const checkedPagesRef = useRef({});
   const prevTokensRef = useRef([]);
   const prevLinesRef = useRef([]);
   const prevWallsRef = useRef([]);
@@ -491,6 +493,50 @@ function App() {
   const [gridOffsetY, setGridOffsetY] = useState(0);
   const [enableDarkness, setEnableDarkness] = useState(true);
   const [showVisionRanges, setShowVisionRanges] = useState(true);
+
+  const ensureTokenSheetIds = useCallback(async (pageId, tokens) => {
+    if (!pageId || checkedPagesRef.current[pageId]) return tokens || [];
+    const updated = tokens ? [...tokens] : [];
+    let modified = false;
+    const tasks = [];
+    updated.forEach((tk) => {
+      if (!tk.tokenSheetId) {
+        const newId = nanoid();
+        tk.tokenSheetId = newId;
+        modified = true;
+        if (tk.enemyId) {
+          tasks.push(
+            getDoc(doc(db, 'enemies', tk.enemyId))
+              .then((snap) => {
+                if (snap.exists()) {
+                  return saveTokenSheet({ id: newId, ...snap.data() });
+                }
+                return setDoc(doc(db, 'tokenSheets', newId), { stats: {} });
+              })
+              .catch((err) => console.error('clone enemy sheet', err))
+          );
+        } else {
+          tasks.push(
+            setDoc(doc(db, 'tokenSheets', newId), { stats: {} }).catch((err) =>
+              console.error('create token sheet', err)
+            )
+          );
+        }
+      }
+    });
+
+    if (modified) {
+      try {
+        await Promise.all(tasks);
+        await updateDoc(doc(db, 'pages', pageId), { tokens: updated });
+      } catch (err) {
+        console.error('update tokens', err);
+      }
+    }
+
+    checkedPagesRef.current[pageId] = true;
+    return updated;
+  }, []);
 
   // Control de visibilidad de páginas para jugadores
   const [playerVisiblePageId, setPlayerVisiblePageId] = useState(null);
@@ -594,7 +640,7 @@ function App() {
     // Listener en tiempo real para la página visible
     const unsubscribe = onSnapshot(
       doc(db, 'pages', playerVisiblePageId),
-      (docSnap) => {
+      async (docSnap) => {
         if (docSnap.exists()) {
           const pageData = docSnap.data();
           setEnableDarkness(
@@ -602,6 +648,10 @@ function App() {
           );
           const opacity =
             pageData.darknessOpacity !== undefined ? pageData.darknessOpacity : 0.7;
+          const tokensWithIds = await ensureTokenSheetIds(
+            playerVisiblePageId,
+            pageData.tokens || []
+          );
           // Actualizar la página en el array de páginas con los datos completos
           setPages((prevPages) => {
             const pageIndex = prevPages.findIndex(
@@ -611,7 +661,7 @@ function App() {
               const updatedPages = [...prevPages];
               updatedPages[pageIndex] = {
                 ...updatedPages[pageIndex],
-                tokens: pageData.tokens || [],
+                tokens: tokensWithIds,
                 lines: pageData.lines || [],
                 walls: pageData.walls || [],
                 texts: pageData.texts || [],
@@ -629,7 +679,7 @@ function App() {
           });
 
           // Actualizar también los estados del canvas
-          setCanvasTokens(pageData.tokens || []);
+          setCanvasTokens(tokensWithIds);
           setCanvasLines(pageData.lines || []);
           setCanvasWalls(pageData.walls || []);
           setCanvasTexts(pageData.texts || []);
@@ -651,10 +701,14 @@ function App() {
 
     const unsubscribe = onSnapshot(
       doc(db, 'pages', pageId),
-      (docSnap) => {
+      async (docSnap) => {
         if (docSnap.exists()) {
           const pageData = docSnap.data();
-          setCanvasTokens(pageData.tokens || []);
+          const tokensWithIds = await ensureTokenSheetIds(
+            pageId,
+            pageData.tokens || []
+          );
+          setCanvasTokens(tokensWithIds);
           setCanvasLines(pageData.lines || []);
           setCanvasWalls(pageData.walls || []);
           setCanvasTexts(pageData.texts || []);


### PR DESCRIPTION
## Summary
- assign new tokenSheetId when loading tokens without one
- clone enemy sheet if available and persist to Firestore
- document auto-assign behaviour in README

## Testing
- `npm test --silent`
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68835d4f3f988326a9d1ef2fe8667249