### PR TITLE
Fix token sheet persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -1272,6 +1272,7 @@ Se sigue una numeración basada en [Semantic Versioning](https://semver.org/lang
 - Enemy tokens automatically clone their template the first time they appear if the token sheet doesn't exist, preserving life and resources across browsers.
 - Tokens loaded without a `tokenSheetId` now generate one automatically and persist to Firestore. If the update fails, the original token data is kept to avoid losing sheet changes.
 - Token sheets always include basic attributes so they can be edited even if missing in stored data.
+- Saving a token sheet now replaces the Firestore document, removing deleted statistics or equipment.
 
 ## 🤝 Contribución
 

--- a/src/utils/token.js
+++ b/src/utils/token.js
@@ -1,6 +1,7 @@
 import { nanoid } from 'nanoid';
 import { doc, setDoc } from 'firebase/firestore';
 import { db } from '../firebase';
+import sanitize from './sanitize';
 
 export const createToken = (data = {}) => {
   const token = { ...data, tokenSheetId: nanoid() };
@@ -20,7 +21,8 @@ export const saveTokenSheet = async (sheet) => {
   localStorage.setItem('tokenSheets', JSON.stringify(sheets));
   window.dispatchEvent(new CustomEvent('tokenSheetSaved', { detail: sheet }));
   try {
-    await setDoc(doc(db, 'tokenSheets', sheet.id), sheet, { merge: true });
+    const data = sanitize(sheet);
+    await setDoc(doc(db, 'tokenSheets', sheet.id), data);
   } catch (err) {
     console.error('save token sheet', err);
   }


### PR DESCRIPTION
## Summary
- sanitize token sheet data before saving
- replace Firestore document instead of merging
- document token sheet overwrite behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6883b4cd4fcc8326b0f193ca6adb2354