### PR TITLE
Fix token sheet persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -1272,6 +1272,8 @@ Se sigue una numeración basada en [Semantic Versioning](https://semver.org/lang
 - Enemy tokens automatically clone their template the first time they appear if the token sheet doesn't exist, preserving life and resources across browsers.
 - Tokens loaded without a `tokenSheetId` now generate one automatically and persist to Firestore. If the update fails, the original token data is kept to avoid losing sheet changes.
 - Token sheets always include basic attributes so they can be edited even if missing in stored data.
+- Saving a token sheet now replaces the Firestore document, removing deleted statistics or equipment.
+- Realtime listeners only update the local cache instead of rewriting Firestore, ensuring edits persist across browsers.
 
 ## 🤝 Contribución
 

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -37,6 +37,7 @@ import {
   cloneTokenSheet,
   saveTokenSheet,
   ensureSheetDefaults,
+  updateLocalTokenSheet,
 } from '../utils/token';
 import TokenBars from './TokenBars';
 import LoadingSpinner from './LoadingSpinner';
@@ -1785,7 +1786,7 @@ const MapCanvas = ({
         sheetListeners.current[tk.tokenSheetId] = onSnapshot(ref, (snap) => {
           if (snap.exists()) {
             const data = { id: tk.tokenSheetId, ...snap.data() };
-            saveTokenSheet(data);
+            updateLocalTokenSheet(data);
           }
         });
       }

--- a/src/utils/__tests__/updateLocalTokenSheet.test.js
+++ b/src/utils/__tests__/updateLocalTokenSheet.test.js
@@ -1,0 +1,25 @@
+import { updateLocalTokenSheet } from '../token';
+import { setDoc } from 'firebase/firestore';
+
+jest.mock('firebase/firestore', () => ({
+  doc: jest.fn(),
+  setDoc: jest.fn(),
+}));
+jest.mock('../../firebase', () => ({ db: {} }));
+
+test('stores sheet locally without touching Firestore', () => {
+  localStorage.clear();
+  const sheet = { id: 's1', stats: { vida: { base: 5 } } };
+  let detail;
+  const handler = (e) => {
+    detail = e.detail;
+  };
+  window.addEventListener('tokenSheetSaved', handler);
+  updateLocalTokenSheet(sheet);
+  window.removeEventListener('tokenSheetSaved', handler);
+
+  const stored = JSON.parse(localStorage.getItem('tokenSheets'));
+  expect(stored.s1.stats.vida.base).toBe(5);
+  expect(detail).toEqual(sheet);
+  expect(setDoc).not.toHaveBeenCalled();
+});


### PR DESCRIPTION
## Summary
- avoid Firestore write loops by adding `updateLocalTokenSheet`
- call `updateLocalTokenSheet` for realtime updates
- document local-only updates in README
- test `updateLocalTokenSheet`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6883b4cd4fcc8326b0f193ca6adb2354