### PR TITLE
Fix master MapCanvas sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -807,6 +807,7 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 - Las animaciones de pérdida de varios bloques se muestran ahora una al lado de otra para mayor claridad y la vida se reduce de forma más lenta, desapareciendo tras 5 segundos.
 El Máster ahora también ve estas animaciones cuando los jugadores reciben daño.
 - Ahora las animaciones se comparten entre jugadores y el máster mediante Firestore.
+- MapCanvas pasa ahora el `pageId` a los modales de ataque y defensa para sincronizar animaciones.
 
 **Resumen de cambios v2.4.18:**
 

--- a/src/App.js
+++ b/src/App.js
@@ -4650,6 +4650,7 @@ function App() {
               enableDarkness={enableDarkness}
               darknessOpacity={pages[currentPage]?.darknessOpacity || 0.7}
               showVisionPolygons={showVisionRanges}
+              pageId={pages[currentPage]?.id}
             />
           </div>
           <AssetSidebar isMaster={authenticated} playerName={playerName} />

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -4621,6 +4621,8 @@ MapCanvas.propTypes = {
   enableDarkness: PropTypes.bool,
   darknessOpacity: PropTypes.number,
   showVisionPolygons: PropTypes.bool,
+  pageId: PropTypes.string,
+  isPlayerView: PropTypes.bool,
 };
 
 export default MapCanvas;


### PR DESCRIPTION
## Summary
- pass pageId to master MapCanvas
- document pageId sync for animations
- add pageId and isPlayerView to MapCanvas prop types

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688471cc0e748326a2ac277323690aaa