### PR TITLE
Fix damage sync and defense cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1214,6 +1214,12 @@ src/
 - ✅ Distintivo visible cuando un token pertenece al jugador actual
 - ✅ Mensaje junto a "Restaurar ficha" y "Subir cambios" recordando la vinculación
 
+### 🛠️ **Corrección de animaciones de daño (Julio 2027) - v2.4.45**
+
+- ✅ Las animaciones de daño se muestran tanto al atacante como al defensor
+- ✅ La ventana de defensa se cierra automáticamente en todas las vistas al resolverse
+- ✅ Se sincronizan las animaciones en navegadores distintos mediante Firestore
+
 ### 🎯 **Alcance de armas y poderes (Enero 2027) - v2.4.25**
 
 - ✅ El menú de ataque y defensa solo muestra armas o poderes al alcance

--- a/src/components/AttackModal.jsx
+++ b/src/components/AttackModal.jsx
@@ -177,7 +177,7 @@ const AttackModal = ({
               }
             }
           }
-          ['postura', 'armadura', 'vida'].forEach((stat) => {
+          for (const stat of ['postura', 'armadura', 'vida']) {
             if (lost[stat] > 0) {
               const anim = {
                 tokenId: target.id,
@@ -190,14 +190,14 @@ const AttackModal = ({
               );
               try {
                 localStorage.setItem('damageAnimation', JSON.stringify(anim));
-                addDoc(collection(db, 'damageEvents'), {
+                await addDoc(collection(db, 'damageEvents'), {
                   ...anim,
                   pageId,
                   timestamp: serverTimestamp(),
                 });
               } catch {}
             }
-          });
+          }
           let msgs = [];
           try {
             const chatSnap = await getDoc(doc(db, 'assetSidebar', 'chat'));

--- a/src/components/DefenseModal.jsx
+++ b/src/components/DefenseModal.jsx
@@ -176,7 +176,7 @@ const DefenseModal = ({
         );
         try {
           localStorage.setItem('damageAnimation', JSON.stringify(anim));
-          addDoc(collection(db, 'damageEvents'), {
+          await addDoc(collection(db, 'damageEvents'), {
             ...anim,
             pageId,
             timestamp: serverTimestamp(),
@@ -185,7 +185,7 @@ const DefenseModal = ({
       } else {
         const id = diff < 0 ? target.id : attacker.id;
         const type = diff > 0 ? 'counter' : undefined;
-        ['postura', 'armadura', 'vida'].forEach((stat) => {
+        for (const stat of ['postura', 'armadura', 'vida']) {
           if (lost[stat] > 0) {
             const anim = {
               tokenId: id,
@@ -199,14 +199,14 @@ const DefenseModal = ({
             );
             try {
               localStorage.setItem('damageAnimation', JSON.stringify(anim));
-              addDoc(collection(db, 'damageEvents'), {
+              await addDoc(collection(db, 'damageEvents'), {
                 ...anim,
                 pageId,
                 timestamp: serverTimestamp(),
               });
             } catch {}
           }
-        });
+        }
       }
 
       const vigor = parseDieValue(affectedSheet?.atributos?.vigor);

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -1018,7 +1018,18 @@ const MapCanvas = ({
     tokens,
     playerName,
     userType,
-    onAttack: ({ id, attackerId, targetId, result }) => {
+    onAttack: ({ id, attackerId, targetId, result, deleted }) => {
+      if (deleted) {
+        if (attackRequestId === id) {
+          setAttackRequestId(null);
+          setAttackSourceId(null);
+          setAttackTargetId(null);
+          setAttackLine(null);
+          setAttackResult(null);
+          setAttackReady(false);
+        }
+        return;
+      }
       setAttackRequestId(id);
       setAttackSourceId(attackerId);
       setAttackTargetId(targetId);
@@ -1076,15 +1087,17 @@ const MapCanvas = ({
     if (!pageId) return undefined;
     const q = query(collection(db, 'damageEvents'), where('pageId', '==', pageId));
     const unsub = onSnapshot(q, (snapshot) => {
-      snapshot.docChanges().forEach(async (change) => {
+      snapshot.docChanges().forEach((change) => {
         if (change.type !== 'added') return;
         const data = change.doc.data();
         triggerDamagePopup(data);
-        try {
-          await deleteDoc(doc(db, 'damageEvents', change.doc.id));
-        } catch (err) {
-          console.error(err);
-        }
+        setTimeout(async () => {
+          try {
+            await deleteDoc(doc(db, 'damageEvents', change.doc.id));
+          } catch (err) {
+            console.error(err);
+          }
+        }, 2000);
       });
     });
     return () => unsub();

--- a/src/hooks/useAttackRequests.js
+++ b/src/hooks/useAttackRequests.js
@@ -19,15 +19,18 @@ export default function useAttackRequests({ tokens, playerName, userType, onAtta
     const q = query(collection(db, 'attacks'), where('completed', '==', false));
     const unsub = onSnapshot(q, snapshot => {
       snapshot.docChanges().forEach(change => {
-        if (change.type !== 'added') return;
         const data = change.doc.data();
-        const currentTokens = tokensRef.current || [];
-        const target = currentTokens.find(t => t.id === data.targetId);
-        if (!target) return;
-        const isTargetPlayer = target.controlledBy === playerName;
-        const isMaster = userType === 'master';
-        if (isTargetPlayer || isMaster) {
-          callbackRef.current && callbackRef.current({ id: change.doc.id, ...data });
+        if (change.type === 'added') {
+          const currentTokens = tokensRef.current || [];
+          const target = currentTokens.find(t => t.id === data.targetId);
+          if (!target) return;
+          const isTargetPlayer = target.controlledBy === playerName;
+          const isMaster = userType === 'master';
+          if (isTargetPlayer || isMaster) {
+            callbackRef.current && callbackRef.current({ id: change.doc.id, ...data });
+          }
+        } else if (change.type === 'removed') {
+          callbackRef.current && callbackRef.current({ id: change.doc.id, deleted: true });
         }
       });
     });


### PR DESCRIPTION
## Summary
- close defense modals across all clients when resolved
- ensure damage animations sync to all players
- document the fix in the README

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688481aae6148326bc1b8a2ed4a19ecd