### PR TITLE
Fix damage animation sync cross-browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -809,6 +809,7 @@ El Máster ahora también ve estas animaciones cuando los jugadores reciben dañ
 - Ahora las animaciones se comparten entre jugadores y el máster mediante Firestore.
 - MapCanvas pasa ahora el `pageId` a los modales de ataque y defensa para sincronizar animaciones.
 - Las fichas controladas por el Máster ahora muestran la pérdida de bloques en la vista de todos los jugadores.
+- Los eventos de daño se conservan 5 segundos en Firestore para garantizar la sincronización entre navegadores.
 
 **Resumen de cambios v2.4.18:**
 

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -1097,7 +1097,7 @@ const MapCanvas = ({
           } catch (err) {
             console.error(err);
           }
-        }, 2000);
+        }, 5000);
       });
     });
     return () => unsub();


### PR DESCRIPTION
## Summary
- extend retention of `damageEvents` documents to 5 seconds
- document the new delay for damage event cleanup in README

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68848aa14e348326ac26a10a5b8d9e3f