### PR TITLE
Fix damage animations sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -1224,6 +1224,10 @@ src/
 - ✅ Los modales de Ataque y Defensa cargan la ficha desde Firestore si no está en caché
 - ✅ Se actualizan automáticamente al guardarse cualquier ficha
 
+**Resumen de cambios v2.4.47:**
+
+- 🛠️ Se corrigen las animaciones de daño para que todos los jugadores las vean en tiempo real
+
 
 **Resumen de cambios v2.4.25:**
 

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -1056,7 +1056,7 @@ const MapCanvas = ({
         setDamagePopups((prev) => prev.filter((p) => p.id !== id));
       }, 5000);
     },
-    [tokens]
+    []
   );
 
   // Sincronización manual de fichas con las hojas de personaje


### PR DESCRIPTION
## Summary
- keep damage event listener stable
- document fix in the changelog

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6885ee2c7a908326b8fbe5b9d1cbaddb