### PR TITLE
Fix damage popup listener

### DIFF
--- a/README.md
+++ b/README.md
@@ -969,6 +969,7 @@ src/
 - ✅ **Imports optimizados** - Eliminación de useState no usado en Input.jsx
 - ✅ **Compilación perfecta** - Proyecto ahora compila sin errores ni warnings de ESLint
 - ✅ **Mantenibilidad mejorada** - Código más limpio y fácil de mantener
+- ✅ **MapCanvas optimizado** - Nuevos refs para tokens y cuadrícula evitan llamadas repetidas a `/Listen`
 
 ### 🎮 **Mejoras en Minijuego de Cerrajería **
 


### PR DESCRIPTION
## Summary
- keep stable reference for damage popup calculations
- save grid and token data in refs
- document MapCanvas ref optimization

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68866d5c4ff48326b2490a3819ee9428