### PR TITLE
Update damage animation duration to 7s

### DIFF
--- a/README.md
+++ b/README.md
@@ -802,12 +802,12 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 - En el chat, las frases **recibe daño**, **bloquea el ataque** y **contraataca** ahora se resaltan con colores.
 - Al recibir daño se muestran animaciones "-X" para **cada** tipo de bloque perdido, con el color de la barra afectada. Los contraataques y defensas perfectas también tienen su propia animación.
 - Las animaciones de daño se sincronizan entre pestañas y ahora se ven durante más tiempo para apreciarlas mejor.
-- Las animaciones de pérdida de varios bloques se muestran ahora una al lado de otra para mayor claridad y la vida se reduce de forma más lenta, desapareciendo tras 5 segundos.
+ - Las animaciones de pérdida de varios bloques se muestran ahora una al lado de otra para mayor claridad y la vida se reduce de forma más lenta, desapareciendo tras 7 segundos.
 El Máster ahora también ve estas animaciones cuando los jugadores reciben daño.
 - Ahora las animaciones se comparten entre jugadores y el máster mediante Firestore.
 - MapCanvas pasa ahora el `pageId` a los modales de ataque y defensa para sincronizar animaciones.
 - Las fichas controladas por el Máster ahora muestran la pérdida de bloques en la vista de todos los jugadores.
-- Los eventos de daño se conservan 5 segundos en Firestore para garantizar la sincronización entre navegadores.
+ - Los eventos de daño se conservan 7 segundos en Firestore para garantizar la sincronización entre navegadores.
 
 **Resumen de cambios v2.4.18:**
 

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -1837,7 +1837,7 @@ const MapCanvas = ({
 
         setTimeout(() => {
           setDamagePopups((prev) => prev.filter((p) => p.id !== id));
-        }, 5000);
+        }, 7000);
       } catch (error) {
         console.error('Error en triggerDamagePopup:', error);
       }
@@ -1862,7 +1862,7 @@ const MapCanvas = ({
           } catch (err) {
             console.error('Error eliminando evento de daño:', err);
           }
-        }, 5000);
+        }, 7000);
       });
     });
     return () => unsub();
@@ -4409,7 +4409,7 @@ const MapCanvas = ({
                   key={p.id}
                   initial={{ opacity: 1, y: 0 }}
                   animate={{ opacity: 0, y: -20 }}
-                  transition={{ duration: 5 }}
+                  transition={{ duration: 7 }}
                   style={{
                     position: 'absolute',
                     left: x + offset,

--- a/src/components/Toast.jsx
+++ b/src/components/Toast.jsx
@@ -126,7 +126,7 @@ export const ToastProvider = ({ children }) => {
     const newToast = {
       id,
       type: 'info',
-      duration: 5000,
+      duration: 7000,
       dismissible: true,
       ...toast,
     };


### PR DESCRIPTION
## Summary
- extend toast auto-dismiss duration to 7 seconds
- keep damage popups on screen for 7 seconds
- remove corresponding Firestore events after 7 seconds
- update docs on longer animations

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688679f5cac883269fb85cd4527f999e