### PR TITLE
Add damage tint animation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1243,6 +1243,10 @@ src/
 
 - Se cambia la frase de la animación: "¡Defensa perfecta!" por "¡Bloqueo perfecto!".
 
+**Resumen de cambios v2.4.50:**
+
+- Los tokens se tintan de rojo durante 7 segundos cada vez que reciben daño para destacar el impacto.
+
 
 **Resumen de cambios v2.4.25:**
 

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -1845,6 +1845,25 @@ const MapCanvas = ({
     []
   );
 
+  const highlightTokenDamage = useCallback(
+    (tokenId) => {
+      if (!tokenId) return;
+      const current = tokensRef.current;
+      if (!current.find((t) => t.id === tokenId)) return;
+      const highlight = current.map((t) =>
+        t.id === tokenId ? { ...t, tintOpacity: 0.5 } : t
+      );
+      handleTokensChange(highlight);
+      setTimeout(() => {
+        const revert = tokensRef.current.map((t) =>
+          t.id === tokenId ? { ...t, tintOpacity: 0 } : t
+        );
+        handleTokensChange(revert);
+      }, 7000);
+    },
+    [handleTokensChange]
+  );
+
   // Listener de Firebase para eventos de daño
   useEffect(() => {
     if (!pageId) return undefined;
@@ -1856,6 +1875,7 @@ const MapCanvas = ({
         const data = change.doc.data();
         console.log('Evento de daño recibido desde Firebase:', data);
         triggerDamagePopup(data);
+        highlightTokenDamage(data.tokenId);
         setTimeout(async () => {
           try {
             await deleteDoc(doc(db, 'damageEvents', change.doc.id));


### PR DESCRIPTION
## Summary
- highlight token in red for 7 seconds when it takes damage
- document new animation in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688724a72d6083268c9ac2db57b03426