### PR TITLE
Implement progressive fade for damage tint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1243,9 +1243,9 @@ src/
 
 - Se cambia la frase de la animación: "¡Defensa perfecta!" por "¡Bloqueo perfecto!".
 
-**Resumen de cambios v2.4.50:**
+**Resumen de cambios v2.4.51:**
 
-- Los tokens se tintan de rojo durante 7 segundos cada vez que reciben daño para destacar el impacto.
+- Los tokens se tintan de rojo al recibir daño y el tinte se desvanece progresivamente.
 
 
 **Resumen de cambios v2.4.25:**

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -1850,16 +1850,26 @@ const MapCanvas = ({
       if (!tokenId) return;
       const current = tokensRef.current;
       if (!current.find((t) => t.id === tokenId)) return;
+      const startOpacity = 0.5;
+      const duration = 7000;
+      const steps = 20;
+
+      // Apply initial highlight
       const highlight = current.map((t) =>
-        t.id === tokenId ? { ...t, tintOpacity: 0.5 } : t
+        t.id === tokenId ? { ...t, tintOpacity: startOpacity } : t
       );
       handleTokensChange(highlight);
-      setTimeout(() => {
-        const revert = tokensRef.current.map((t) =>
-          t.id === tokenId ? { ...t, tintOpacity: 0 } : t
-        );
-        handleTokensChange(revert);
-      }, 7000);
+
+      // Gradually reduce tint
+      for (let i = 1; i <= steps; i += 1) {
+        setTimeout(() => {
+          const opacity = startOpacity * (1 - i / steps);
+          const updated = tokensRef.current.map((t) =>
+            t.id === tokenId ? { ...t, tintOpacity: Math.max(0, opacity) } : t
+          );
+          handleTokensChange(updated);
+        }, (duration / steps) * i);
+      }
     },
     [handleTokensChange]
   );


### PR DESCRIPTION
## Summary
- gradually fade out the red tint for tokens after damage
- update changelog in README

## Testing
- `npm install`
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6887284018f08326a5e21a539ac09162