### PR TITLE
Fix damage highlight tint conditions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1247,6 +1247,10 @@ src/
 
 - Los tokens se tintan de rojo al recibir daño y el tinte se desvanece progresivamente.
 
+**Resumen de cambios v2.4.52:**
+
+- El tinte rojo solo se aplica cuando el token pierde vida, armadura o postura.
+
 
 **Resumen de cambios v2.4.25:**
 

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -1885,7 +1885,12 @@ const MapCanvas = ({
         const data = change.doc.data();
         console.log('Evento de daño recibido desde Firebase:', data);
         triggerDamagePopup(data);
-        highlightTokenDamage(data.tokenId);
+        if (
+          data.value > 0 &&
+          ['vida', 'armadura', 'postura'].includes(data.stat)
+        ) {
+          highlightTokenDamage(data.tokenId);
+        }
         setTimeout(async () => {
           try {
             await deleteDoc(doc(db, 'damageEvents', change.doc.id));


### PR DESCRIPTION
## Summary
- only tint tokens when damage event reduces life, armor or posture
- note bug fix in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68872b660b788326ad632a3f3c1ac9a0