### PR TITLE
Fix red tint animation trigger

### DIFF
--- a/README.md
+++ b/README.md
@@ -1247,6 +1247,10 @@ src/
 
 - Los tokens se tintan de rojo al recibir daño y el tinte se desvanece progresivamente.
 
+**Resumen de cambios v2.4.52:**
+
+- El tinte rojo solo se aplica cuando el token pierde vida, armadura o postura.
+
 
 **Resumen de cambios v2.4.25:**
 

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -1885,7 +1885,12 @@ const MapCanvas = ({
         const data = change.doc.data();
         console.log('Evento de daño recibido desde Firebase:', data);
         triggerDamagePopup(data);
-        highlightTokenDamage(data.tokenId);
+        if (
+          ['vida', 'armadura', 'postura'].includes(data.stat) &&
+          data.value > 0
+        ) {
+          highlightTokenDamage(data.tokenId);
+        }
         setTimeout(async () => {
           try {
             await deleteDoc(doc(db, 'damageEvents', change.doc.id));


### PR DESCRIPTION
## Summary
- limit red tint to actual damage events
- update README with new changelog entry

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_68872f86e1f48326abaa9eb0ef09e4bc