### PR TITLE
Improve damage tint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1255,6 +1255,10 @@ src/
 
 - El tinte rojo se desvanece siempre tras 7 segundos sin quedarse pillado.
 
+**Resumen de cambios v2.4.54:**
+
+- El resaltado de daño ahora es local y no escribe en Firebase, evitando parpadeos.
+
 
 **Resumen de cambios v2.4.25:**
 


### PR DESCRIPTION
## Summary
- manage local damage tint state on MapCanvas
- show damage overlay Rect in the Token component
- clear timers and tint state on cleanup
- document update in README

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68873cccb7b48326b8a070d4e4f822fa