### PR TITLE
Fix defense modal closure delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -971,6 +971,7 @@ src/
 - ✅ **Mantenibilidad mejorada** - Código más limpio y fácil de mantener
 - ✅ **MapCanvas optimizado** - Nuevos refs para tokens y cuadrícula evitan llamadas repetidas a `/Listen`
 - ✅ **Animación de daño refinada** - El tinte rojo se desvanece suavemente usando `requestAnimationFrame`
+- ✅ **Defensa instantánea** - La ventana se cierra en cuanto se resuelve la tirada
 
 ### 🎮 **Mejoras en Minijuego de Cerrajería **
 

--- a/src/components/DefenseModal.jsx
+++ b/src/components/DefenseModal.jsx
@@ -209,11 +209,11 @@ const DefenseModal = ({
           } catch (err) {
             console.warn('No se pudo obtener playerVisiblePageId, usando pageId actual:', err);
           }
-          await addDoc(collection(db, 'damageEvents'), {
+          addDoc(collection(db, 'damageEvents'), {
             ...anim,
             pageId: effectivePageId,
             timestamp: serverTimestamp(),
-          });
+          }).catch(() => {});
         } catch {}
       } else {
         const id = diff < 0 ? target.id : attacker.id;
@@ -240,11 +240,11 @@ const DefenseModal = ({
               } catch (err) {
                 console.warn('No se pudo obtener playerVisiblePageId, usando pageId actual:', err);
               }
-              await addDoc(collection(db, 'damageEvents'), {
+              addDoc(collection(db, 'damageEvents'), {
                 ...anim,
                 pageId: effectivePageId,
                 timestamp: serverTimestamp(),
-              });
+              }).catch(() => {});
             } catch {}
           }
         }
@@ -266,7 +266,7 @@ const DefenseModal = ({
         text = `${targetName} bloquea el ataque. Ataque ${attackResult?.total || 0} Defensa ${result.total}`;
       }
       messages.push({ id: nanoid(), author: targetName, text, result });
-      await setDoc(doc(db, 'assetSidebar', 'chat'), { messages });
+      setDoc(doc(db, 'assetSidebar', 'chat'), { messages }).catch(() => {});
 
       setLoading(false);
       onClose(result);


### PR DESCRIPTION
## Summary
- close defense modal immediately by removing awaits in `DefenseModal`
- document the instant defense behaviour in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688781e8e9448326a5370bb51c2899e1