### PR TITLE
Optimize defense roll

### DIFF
--- a/README.md
+++ b/README.md
@@ -1261,6 +1261,10 @@ src/
 
 - La animación del tinte rojo ahora es consistente.
 
+**Resumen de cambios v2.4.55:**
+
+- La defensa se resuelve más rápido reutilizando la página visible para guardar eventos de daño.
+
 
 **Resumen de cambios v2.4.25:**
 


### PR DESCRIPTION
## Summary
- make defense modal set loading before rolling
- cache the playerVisiblePageId for all damage events
- document the faster defense modal

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6887cafd3e78832684748463027c5c8c