### PR TITLE
Reduce battle map debounce

### DIFF
--- a/README.md
+++ b/README.md
@@ -1261,6 +1261,11 @@ src/
 
 - La animación del tinte rojo ahora es consistente.
 
+**Resumen de cambios v2.4.55:**
+
+- Debouncing reducido en el Mapa de Batalla para mover tokens y abrir puertas,
+  mejorando la sincronización para máster y jugadores.
+
 
 **Resumen de cambios v2.4.25:**
 

--- a/src/App.js
+++ b/src/App.js
@@ -895,7 +895,7 @@ function App() {
       clearTimeout(tokenSaveTimeout.current);
     }
 
-    // Debouncing: esperar 100ms antes de guardar
+    // Debouncing: esperar 50ms antes de guardar
     tokenSaveTimeout.current = setTimeout(async () => {
       const saveId = ++saveVersionRef.current.tokens;
 
@@ -927,7 +927,7 @@ function App() {
         }
       };
       saveTokens();
-    }, 100);
+    }, 50);
   }, [canvasTokens, currentPage]);
 
   useEffect(() => {
@@ -1024,7 +1024,7 @@ function App() {
           console.log('Muros guardados exitosamente en página:', pageId);
         })
         .catch((error) => console.error('Error guardando muros:', error));
-    }, 200);
+    }, 100);
     return () => {
       if (wallSaveTimeout.current) {
         clearTimeout(wallSaveTimeout.current);

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -1096,7 +1096,7 @@ const MapCanvas = ({
         clearTimeout(saveTimeouts[type]);
       }
 
-      // Debouncing: esperar 300ms antes de guardar
+      // Debouncing: esperar 100ms antes de guardar
       saveTimeouts[type] = setTimeout(async () => {
         try {
           // Validaciones de seguridad para jugadores
@@ -1139,7 +1139,7 @@ const MapCanvas = ({
         } catch (error) {
           console.error(`Error guardando ${type} para jugador:`, error);
         }
-      }, 300);
+      }, 100);
     };
 
     return { saveToFirebase };


### PR DESCRIPTION
## Summary
- shorten the debouncing time when players sync map changes
- save tokens quicker for the master view
- save wall updates faster
- document debounce change in README

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6887ea7277708326b695987cee5487dd