### PR TITLE
Color attributes on token sheets

### DIFF
--- a/README.md
+++ b/README.md
@@ -912,6 +912,7 @@ src/
 - **Sincronización de puertas** - Abrir o cerrar puertas se guarda correctamente al mover un token
 - **Mirilla funcional para ataques** - Los jugadores pueden seleccionar objetivos enemigos con un clic y atacar con un segundo clic
 - **La mirilla apunta a tokens ajenos** - Ahora también puedes fijar como objetivo fichas controladas por otros jugadores o por el máster
+- **Atributos con color en fichas** - Destreza, Vigor, Intelecto y Voluntad muestran sus colores y los valores de dados se ven en **negrita**
 - **Doble clic seguro en mirilla** - Al usar la mirilla, el doble clic ya no abre el menú de ajustes del token
 - **Iconos de puerta siempre orientados** - Los SVG de las puertas se muestran correctamente aunque el muro se dibuje al revés
 - **Edición de estadísticas fiable** - Al borrar una estadística de la ficha se elimina también de `resourcesList`, evitando que reaparezca

--- a/src/components/EnemyViewModal.jsx
+++ b/src/components/EnemyViewModal.jsx
@@ -16,6 +16,12 @@ const recursoColor = {
   cordura: '#a78bfa',
   armadura: '#9ca3af',
 };
+const atributoColor = {
+  destreza: '#34d399',
+  vigor: '#f87171',
+  intelecto: '#60a5fa',
+  voluntad: '#a78bfa',
+};
 
 const EnemyViewModal = ({ enemy, onClose, onEdit, highlightText = (t) => t, floating = false }) => {
   const modalRef = useRef(null);
@@ -127,8 +133,18 @@ const EnemyViewModal = ({ enemy, onClose, onEdit, highlightText = (t) => t, floa
               <div className="grid grid-cols-2 gap-2 text-sm">
                 {atributos.map((attr) => (
                   <div key={attr} className="flex justify-between">
-                    <span className="font-medium">{attr}:</span>
-                    <span className="text-blue-400">{enemy.atributos?.[attr] || 'D4'}</span>
+                    <span
+                      className="font-medium capitalize"
+                      style={{ color: atributoColor[attr] }}
+                    >
+                      {attr}:
+                    </span>
+                    <span
+                      className="font-extrabold"
+                      style={{ color: atributoColor[attr] }}
+                    >
+                      {enemy.atributos?.[attr] || 'D4'}
+                    </span>
                   </div>
                 ))}
               </div>


### PR DESCRIPTION
## Summary
- add attribute color map
- show colored attribute labels and values
- show attribute dice values in bold
- document token sheet dice in bold in README

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6887f38624408326be613bf49736f964