### PR TITLE
Fix link indicator logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -1267,6 +1267,10 @@ src/
 - Debouncing reducido en el Mapa de Batalla para mover tokens y abrir puertas,
   mejorando la sincronización para máster y jugadores.
 
+**Resumen de cambios v2.4.56:**
+
+- El aviso "Vinculado a tu ficha" solo aparece tras usar "Restaurar ficha" en el token.
+
 
 **Resumen de cambios v2.4.25:**
 

--- a/src/components/TokenSettings.jsx
+++ b/src/components/TokenSettings.jsx
@@ -79,6 +79,11 @@ const TokenSettings = ({
 
   // Ref para debouncing
   const debounceRef = useRef(null);
+  const [linked, setLinked] = useState(() =>
+    token.tokenSheetId
+      ? localStorage.getItem(`link_${token.tokenSheetId}`) === controlledBy
+      : false
+  );
 
   const loadPlayerSheet = async (playerId) => {
     try {
@@ -107,6 +112,8 @@ const TokenSettings = ({
         sheet.portrait = token.url;
         sheets[token.tokenSheetId] = sheet;
         localStorage.setItem('tokenSheets', JSON.stringify(sheets));
+        localStorage.setItem(`link_${token.tokenSheetId}`, controlledBy);
+        setLinked(true);
         window.dispatchEvent(
           new CustomEvent('tokenSheetSaved', { detail: sheet })
         );
@@ -267,6 +274,13 @@ const TokenSettings = ({
     debouncedApplyChanges();
   }, [name, lightColor, lightOpacity, debouncedApplyChanges]);
 
+  useEffect(() => {
+    if (!token.tokenSheetId) return;
+    setLinked(
+      localStorage.getItem(`link_${token.tokenSheetId}`) === controlledBy
+    );
+  }, [token.tokenSheetId, controlledBy]);
+
   // Función para agregar el token al sistema de velocidad
   const addToInitiativeSystem = async () => {
     try {
@@ -362,7 +376,8 @@ const TokenSettings = ({
                 <label className="block mb-1">
                   {isPlayerView ? "Ficha de Personaje" : "Controlado por"}
                   {controlledBy !== 'master' &&
-                    controlledBy === currentPlayerName && (
+                    controlledBy === currentPlayerName &&
+                    linked && (
                       <>
                         <span
                           className="ml-2 inline-flex items-center bg-blue-600 text-white text-xs px-2 rounded-full"
@@ -470,11 +485,11 @@ const TokenSettings = ({
                       Subir cambios
                     </Boton>
                   </div>
-                  {controlledBy === currentPlayerName && (
-                    <span className="text-xs text-blue-400">🔗 Vinculado a tu ficha</span>
-                  )}
-                </div>
-              )}
+                  {controlledBy === currentPlayerName && linked && (
+                      <span className="text-xs text-blue-400">🔗 Vinculado a tu ficha</span>
+                    )}
+                  </div>
+                )}
               <Boton
                 onClick={addToInitiativeSystem}
                 size="sm"


### PR DESCRIPTION
## Summary
- link tokens to the player only after restoring
- mention this change in README

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68880f6f41b08326b38435e2099bc420