### PR TITLE
Fix link indicator logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -1267,6 +1267,14 @@ src/
 - Debouncing reducido en el Mapa de Batalla para mover tokens y abrir puertas,
   mejorando la sincronización para máster y jugadores.
 
+**Resumen de cambios v2.4.56:**
+
+- El aviso "Vinculado a tu ficha" solo aparece tras usar "Restaurar ficha" en el token.
+
+**Resumen de cambios v2.4.57:**
+
+- "Subir cambios" ahora confirma antes de actualizar y avisa si la ficha no está enlazada.
+
 
 **Resumen de cambios v2.4.25:**
 


### PR DESCRIPTION
## Summary
- link tokens to the player only after restoring
- mention this change in README
- confirm before uploading player data and alert if link missing

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68880f6f41b08326b38435e2099bc420