### PR TITLE
Implement auto speed cost on actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 - **Línea de sucesos en tiempo real** - Seguimiento visual del orden de actuación
 - **Píldoras de Equipamiento interactivas** - Uso directo de armas y poderes desde la ficha
 - **Consumo de velocidad inteligente** - Cálculo automático basado en emojis 🟡 del equipamiento
+- **Coste automático por acciones** - Al resolver ataques y defensas se suma la velocidad consumida al participante
 - **Permisos granulares** - Jugadores pueden eliminar sus propios participantes
 - **Interfaz color-coded** - Identificación visual por jugador y tipo de equipamiento
 - **Sincronización en tiempo real** - Cambios instantáneos para todos los participantes
@@ -906,6 +907,7 @@ src/
 - **Botón de papelera mejorado** - Color rojo consistente con el sistema de velocidad en inventario y línea de sucesos
 - **Corrección de error en MapCanvas** - Paréntesis faltante causaba fallo de compilación
 - **Consumo de velocidad inteligente** - Las píldoras muestran el consumo real basado en emojis 🟡 del equipamiento
+- **Coste automático por acciones** - Al resolver ataques y defensas se suma la velocidad consumida al participante
 - **Interfaz más intuitiva** - Píldoras organizadas por color (azul para armas, morado para poderes) sin subtítulos
 - **Corrección de desincronización** - Las páginas ya no se actualizan antes de
   cargarse por completo

--- a/src/components/AttackModal.jsx
+++ b/src/components/AttackModal.jsx
@@ -16,6 +16,7 @@ import {
 import { db } from '../firebase';
 import { nanoid } from 'nanoid';
 import { saveTokenSheet } from '../utils/token';
+import { addSpeedForToken } from '../utils/initiative';
 
 const AUTO_RESOLVE_MS = 20000;
 
@@ -254,6 +255,7 @@ const AttackModal = ({
           console.error(err);
         }
       }, AUTO_RESOLVE_MS);
+      await addSpeedForToken(attacker, speedCost);
       setLoading(false);
       onClose(result);
     } catch (e) {

--- a/src/components/DefenseModal.jsx
+++ b/src/components/DefenseModal.jsx
@@ -8,6 +8,7 @@ import { doc, getDoc, setDoc, collection, addDoc, serverTimestamp } from 'fireba
 import { db } from '../firebase';
 import { nanoid } from 'nanoid';
 import { saveTokenSheet } from '../utils/token';
+import { addSpeedForToken } from '../utils/initiative';
 
 const DefenseModal = ({
   isOpen,
@@ -268,6 +269,7 @@ const DefenseModal = ({
       messages.push({ id: nanoid(), author: targetName, text, result });
       setDoc(doc(db, 'assetSidebar', 'chat'), { messages }).catch(() => {});
 
+      await addSpeedForToken(target, speedCost);
       setLoading(false);
       onClose(result);
     } catch (e) {

--- a/src/components/__tests__/AttackFlow.test.js
+++ b/src/components/__tests__/AttackFlow.test.js
@@ -23,8 +23,10 @@ jest.mock('firebase/firestore', () => ({
 jest.mock('../../firebase', () => ({ db: {} }));
 
 jest.mock('../DefenseModal', () => jest.fn(() => null));
+jest.mock('../../utils/initiative', () => ({ addSpeedForToken: jest.fn() }));
 
 const { addDoc, onSnapshot, updateDoc, getDoc } = require('firebase/firestore');
+const { addSpeedForToken } = require('../../utils/initiative');
 
 function ListenerDemo({ playerName = 'p2', userType = 'player' }) {
   const [req, setReq] = React.useState(null);
@@ -70,6 +72,7 @@ describe('Attack flow', () => {
     );
     await userEvent.click(screen.getByRole('button', { name: /lanzar/i }));
     await waitFor(() => expect(addDoc).toHaveBeenCalled());
+    expect(addSpeedForToken).toHaveBeenCalled();
   });
 
   test('opens defense modal for targeted player', () => {

--- a/src/utils/__tests__/initiative.test.js
+++ b/src/utils/__tests__/initiative.test.js
@@ -1,0 +1,32 @@
+import { addSpeedForToken } from '../initiative';
+import { doc, getDoc, updateDoc } from 'firebase/firestore';
+
+jest.mock('firebase/firestore', () => ({
+  doc: jest.fn(),
+  getDoc: jest.fn(),
+  updateDoc: jest.fn(),
+}));
+
+jest.mock('../../firebase', () => ({ db: {} }));
+
+const { getDoc: mockGetDoc, updateDoc: mockUpdateDoc } = require('firebase/firestore');
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+test('creates participant if not exists', async () => {
+  mockGetDoc.mockResolvedValue({ exists: () => true, data: () => ({ participants: [] }) });
+  const token = { id: 't1', name: 'A', controlledBy: 'p1' };
+  await addSpeedForToken(token, 2);
+  const call = updateDoc.mock.calls[0];
+  expect(call[1].participants[0]).toEqual(expect.objectContaining({ name: 'A', speed: 2, addedBy: 'p1' }));
+});
+
+test('updates existing participant', async () => {
+  mockGetDoc.mockResolvedValue({ exists: () => true, data: () => ({ participants: [{ id: 'x', name: 'A', addedBy: 'p1', speed: 1 }] }) });
+  const token = { id: 't1', name: 'A', controlledBy: 'p1' };
+  await addSpeedForToken(token, 3);
+  const call2 = updateDoc.mock.calls[0];
+  expect(call2[1].participants[0]).toEqual({ id: 'x', name: 'A', addedBy: 'p1', speed: 4 });
+});

--- a/src/utils/initiative.js
+++ b/src/utils/initiative.js
@@ -1,0 +1,38 @@
+import { doc, getDoc, updateDoc } from 'firebase/firestore';
+import { db } from '../firebase';
+
+export const addSpeedForToken = async (token, speed) => {
+  if (!token || !token.id || speed <= 0) return;
+  try {
+    const initiativeRef = doc(db, 'initiative', 'current');
+    const initiativeDoc = await getDoc(initiativeRef);
+    let participants = [];
+    if (initiativeDoc.exists()) {
+      participants = initiativeDoc.data().participants || [];
+    }
+    const name = token.customName || token.name || 'Token sin nombre';
+    const addedBy = token.controlledBy || 'unknown';
+
+    const idx = participants.findIndex(
+      (p) => p.name === name && p.addedBy === addedBy
+    );
+    if (idx >= 0) {
+      participants[idx] = {
+        ...participants[idx],
+        speed: (participants[idx].speed || 0) + speed,
+      };
+    } else {
+      const newParticipant = {
+        id: Date.now().toString(),
+        name,
+        speed,
+        type: addedBy === 'master' ? 'enemy' : 'player',
+        addedBy: addedBy === 'master' ? 'master' : addedBy,
+      };
+      participants = [...participants, newParticipant];
+    }
+    await updateDoc(initiativeRef, { participants });
+  } catch (err) {
+    console.error('Error updating initiative speed:', err);
+  }
+};


### PR DESCRIPTION
## Summary
- automatically add speed cost of used weapon/power on attack & defense
- centralize initiative speed logic in `utils/initiative.js`
- test initiative utility
- verify attack flow triggers speed addition
- document automatic speed cost in README

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68883e6da8dc83268a84768bf150d56a