### PR TITLE
Improve token resize flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 
 ### 🎲 **Gestión de Personajes**
 
-> **Versión actual: 2.3.21**
+> **Versión actual: 2.4.58**
 
 **Resumen de cambios v2.1.1:**
 
@@ -1279,6 +1279,10 @@ src/
 **Resumen de cambios v2.4.57:**
 
 - "Subir cambios" ahora confirma antes de actualizar y avisa si la ficha no está enlazada.
+
+**Resumen de cambios v2.4.58:**
+
+- Redimensionado de tokens sin snapping hasta soltar, para un ajuste más cómodo.
 
 **Resumen de cambios v2.4.25:**
 

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -769,7 +769,8 @@ const Token = forwardRef(
                 'bottom-right',
               ]}
               rotateEnabled={false}
-              boundBoxFunc={(oldBox, newBox) => snapBox(newBox)}
+              // No snap mientras se redimensiona para evitar saltos abruptos
+              boundBoxFunc={(oldBox, newBox) => newBox}
               onTransformStart={handleTransformStart}
               onTransform={updateHandle}
               onTransformEnd={handleTransformEnd}


### PR DESCRIPTION
## Summary
- allow resizing tokens without snap during drag
- document smoother token resizing in README
- bump version to v2.4.58

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6888b179a3588326a54a60ea9e25a7bd