### PR TITLE
Disable selection while using targeting tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -1283,6 +1283,10 @@ src/
 **Resumen de cambios v2.4.58:**
 
 - Redimensionado de tokens sin snapping hasta soltar, para un ajuste más cómodo.
+**Resumen de cambios v2.4.59:**
+
+- La herramienta de mirilla ya no selecciona el token ni muestra el transformador de tamaño al hacer clic.
+
 
 **Resumen de cambios v2.4.25:**
 

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -3789,6 +3789,8 @@ const MapCanvas = ({
                   onDragEnd={handleDragEnd}
                   onDragStart={handleDragStart}
                   onClick={(e) => {
+                    if (activeTool === 'target') return; // Evitar selección durante la mirilla
+
                     // Validar permisos de selección
                     if (!canSelectElement(token, 'token')) {
                       return; // Bloquear selección si no tiene permisos


### PR DESCRIPTION
## Summary
- prevent token transform when using the target tool
- document new behavior

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6888b744f59883269de753a31a28567f