### PR TITLE
Fix panning with crosshair tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -1291,6 +1291,10 @@ src/
 
 - Con la mirilla seleccionada puedes moverte por el escenario pulsando la rueda del ratón y arrastrando, sin usar la herramienta del cursor.
 
+**Resumen de cambios v2.4.61:**
+
+- Se corrige el desplazamiento del escenario con la mirilla activada usando la rueda del ratón.
+
 **Resumen de cambios v2.4.25:**
 
 - ✅ El menú de ataque y defensa solo muestra armas o poderes al alcance

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -2726,6 +2726,13 @@ const MapCanvas = ({
       }
       return;
     }
+    if (activeTool === 'target' && e.evt.button === 1) {
+      e.evt.preventDefault();
+      setIsPanning(true);
+      panStart.current = stageRef.current.getPointerPosition();
+      panOrigin.current = { ...groupPos };
+      return;
+    }
     if (activeTool === 'select' && e.evt.button === 1) {
       e.evt.preventDefault();
       setIsPanning(true);


### PR DESCRIPTION
## Summary
- allow panning the stage with middle mouse while the crosshair (`target`) tool is active
- document bugfix in README

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6888cfed1d4c8326a5029f8fe2adeb3e