### PR TITLE
Fix snap ruler offset

### DIFF
--- a/README.md
+++ b/README.md
@@ -1295,6 +1295,10 @@ src/
 
 - Se corrige el desplazamiento del escenario con la mirilla activada usando la rueda del ratón.
 
+**Resumen de cambios v2.4.62:**
+
+- La regla se alinea correctamente con el cursor al usar el ajuste a la cuadrícula.
+
 **Resumen de cambios v2.4.25:**
 
 - ✅ El menú de ataque y defensa solo muestra armas o poderes al alcance

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -2789,11 +2789,8 @@ const MapCanvas = ({
     }
     if (activeTool === 'measure' && e.evt.button === 0) {
       const pointer = stageRef.current.getPointerPosition();
-      let relX = (pointer.x - groupPos.x) / (baseScale * zoom);
-      let relY = (pointer.y - groupPos.y) / (baseScale * zoom);
-      if (measureSnap !== 'free') {
-        [relX, relY] = snapPoint(relX, relY);
-      }
+      const relX = (pointer.x - groupPos.x) / (baseScale * zoom);
+      const relY = (pointer.y - groupPos.y) / (baseScale * zoom);
       setMeasureLine([relX, relY, relX, relY]);
     }
     if (activeTool === 'text' && e.evt.button === 0) {
@@ -2853,12 +2850,7 @@ const MapCanvas = ({
       return;
     }
     if (measureLine) {
-      let nx = relX;
-      let ny = relY;
-      if (measureSnap !== 'free') {
-        [nx, ny] = snapPoint(relX, relY);
-      }
-      setMeasureLine(([x1, y1]) => [x1, y1, nx, ny]);
+      setMeasureLine(([x1, y1]) => [x1, y1, relX, relY]);
       return;
     }
     if (!isPanning) return;


### PR DESCRIPTION
## Summary
- remove snapPoint from measure interactions
- measure distance using snapped coordinates but keep ruler under cursor
- note fix in README

## Testing
- `npm install`
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_6888d1b17e588326b9851c924e32c8e9