### PR TITLE
Fix snap ruler offset

### DIFF
--- a/README.md
+++ b/README.md
@@ -1295,6 +1295,15 @@ src/
 
 - Se corrige el desplazamiento del escenario con la mirilla activada usando la rueda del ratón.
 
+**Resumen de cambios v2.4.62:**
+
+- La regla se alinea correctamente con el cursor al usar el ajuste a la cuadrícula.
+
+**Resumen de cambios v2.4.63:**
+
+- Se restaura el ajuste de la regla al centro o a la esquina sin desfasar el cursor.
+- El conteo de casillas es correcto en todas las direcciones y el texto se muestra desplazado para que no lo tape el ratón.
+
 **Resumen de cambios v2.4.25:**
 
 - ✅ El menú de ataque y defensa solo muestra armas o poderes al alcance

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -1774,6 +1774,8 @@ const MapCanvas = ({
   const pxToCell = (px, offset) =>
     Math.round((px - offset) / effectiveGridSize);
   const cellToPx = (cell, offset) => cell * effectiveGridSize + offset;
+  const snapCell = (px, offset) =>
+    Math.floor((px - offset) / effectiveGridSize);
 
   useEffect(() => {
     gridSizeRef.current = effectiveGridSize;
@@ -2264,8 +2266,8 @@ const MapCanvas = ({
   const snapPoint = useCallback(
     (x, y) => {
       if (measureSnap === 'free') return [x, y];
-      const cellX = pxToCell(x, gridOffsetX);
-      const cellY = pxToCell(y, gridOffsetY);
+      const cellX = snapCell(x, gridOffsetX);
+      const cellY = snapCell(y, gridOffsetY);
       if (measureSnap === 'center') {
         return [
           cellToPx(cellX + 0.5, gridOffsetX),
@@ -2970,10 +2972,10 @@ const MapCanvas = ({
       const [sx1, sy1] = snapPoint(x1, y1);
       const [sx2, sy2] = snapPoint(x2, y2);
       const cellDx = Math.abs(
-        pxToCell(sx2, gridOffsetX) - pxToCell(sx1, gridOffsetX)
+        snapCell(sx2, gridOffsetX) - snapCell(sx1, gridOffsetX)
       );
       const cellDy = Math.abs(
-        pxToCell(sy2, gridOffsetY) - pxToCell(sy1, gridOffsetY)
+        snapCell(sy2, gridOffsetY) - snapCell(sy1, gridOffsetY)
       );
       let distance = Math.hypot(cellDx, cellDy);
       const dx = x2 - x1;
@@ -3057,8 +3059,8 @@ const MapCanvas = ({
         <>
           {shape}
           <Text
-            x={x2}
-            y={y2}
+            x={x2 + 10}
+            y={y2 + 10}
             text={`${Math.round(distance)} casillas`}
             fontSize={16}
             fill="#fff"


### PR DESCRIPTION
## Summary
- restore snapping to grid for the measure tool
- compute snapped cells with `Math.floor` to avoid extra distance
- offset the ruler label so the mouse cursor doesn't cover it
- document the fix

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6888d1b17e588326b9851c924e32c8e9