### PR TITLE
Implement weapon attribute bonuses

### DIFF
--- a/README.md
+++ b/README.md
@@ -1309,6 +1309,11 @@ src/
 
 - El ajuste de la regla ahora desplaza la figura al centro o a la esquina de la cuadrcula en lugar de solo calcular la distancia.
 
+**Resumen de cambios v2.4.65:**
+
+- Los ataques ahora suman el dado del atributo si el arma tiene rasgos como `vigor`, `destreza`, `intelecto` o `voluntad`.
+- Se indica visualmente el atributo aplicado y si está duplicado con `x2`.
+
 **Resumen de cambios v2.4.25:**
 
 - ✅ El menú de ataque y defensa solo muestra armas o poderes al alcance

--- a/src/components/__tests__/AttackTool.test.js
+++ b/src/components/__tests__/AttackTool.test.js
@@ -255,3 +255,32 @@ test('damage field prefilled when selecting power', async () => {
   expect(input).toBeInTheDocument();
   expect(input.value).toBe('2d6');
 });
+
+test('shows attribute bonuses from weapon traits', async () => {
+  localStorage.setItem(
+    'tokenSheets',
+    JSON.stringify({
+      '1': {
+        id: '1',
+        atributos: { destreza: 'D6' },
+        weapons: [
+          { nombre: 'Espada', alcance: 'Toque', dano: '1d4', rasgos: ['Destreza'] },
+        ],
+        poderes: [],
+      },
+    })
+  );
+  render(
+    <AttackModal
+      isOpen
+      attacker={{ name: 'A', tokenSheetId: '1' }}
+      target={{ name: 'B', tokenSheetId: '2' }}
+      distance={1}
+      armas={[]}
+      poderesCatalog={[]}
+      onClose={() => {}}
+    />
+  );
+  await userEvent.selectOptions(screen.getByRole('combobox'), 'Espada');
+  expect(screen.getByText(/destreza d6/i)).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- add attribute bonus parsing for attack traits
- display traits applied in AttackModal
- combine item damage with attribute dice
- document the new feature
- test trait display in AttackModal

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68897cf817d48326ab98e71d6945036d