### PR TITLE
Add traits field for powers

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 - **Gestión de atributos y recursos** - Dados para atributos y recursos personalizables
 - **Equipamiento desde Google Sheets** - Catálogo dinámico de armas y armaduras
 - **Habilidades personalizadas** - Creación y gestión de poderes únicos
+- **Rasgos en habilidades** - Define rasgos de cada poder y se muestran en sus tarjetas
 - **Claves consumibles** - Acciones especiales con contador de usos
 - **Carga física y mental** - Sistema automático de penalizaciones por peso
 - **Estados del personaje** - Seguimiento de efectos activos con iconos
@@ -1313,6 +1314,10 @@ src/
 
 - Los ataques ahora suman el dado del atributo si el arma tiene rasgos como `vigor`, `destreza`, `intelecto` o `voluntad`.
 - Se indica visualmente el atributo aplicado y si está duplicado con `x2`.
+
+**Resumen de cambios v2.4.66:**
+
+- Las habilidades incluyen un campo de **rasgos** que se muestra en las tarjetas al equiparlas.
 
 **Resumen de cambios v2.4.25:**
 

--- a/src/App.js
+++ b/src/App.js
@@ -386,6 +386,7 @@ function App() {
     cuerpo: '',
     mente: '',
     poder: '',
+    rasgos: '',
     descripcion: '',
   });
   const [editingAbility, setEditingAbility] = useState(null);
@@ -1821,7 +1822,14 @@ function App() {
       if (editingAbility && editingAbility !== nombre) {
         await deleteDoc(doc(db, 'abilities', editingAbility));
       }
-      await setDoc(doc(db, 'abilities', nombre), newAbility);
+      const dataToSave = {
+        ...newAbility,
+        rasgos: (newAbility.rasgos || '')
+          .split(',')
+          .map((r) => r.trim())
+          .filter(Boolean),
+      };
+      await setDoc(doc(db, 'abilities', nombre), dataToSave);
       setEditingAbility(null);
       setNewAbility({
         nombre: '',
@@ -1830,6 +1838,7 @@ function App() {
         cuerpo: '',
         mente: '',
         poder: '',
+        rasgos: '',
         descripcion: '',
       });
       setNewAbilityError('');
@@ -1839,7 +1848,12 @@ function App() {
     }
   };
   const startEditAbility = (ability) => {
-    setNewAbility(ability);
+    setNewAbility({
+      ...ability,
+      rasgos: Array.isArray(ability.rasgos)
+        ? ability.rasgos.join(', ')
+        : ability.rasgos || '',
+    });
     setEditingAbility(ability.nombre);
   };
   const deleteAbility = async (name) => {
@@ -3826,6 +3840,11 @@ function App() {
                       <p>
                         <strong>Mente:</strong> {p.mente}
                       </p>
+                      {p.rasgos && p.rasgos.length > 0 && (
+                        <p>
+                          <strong>Rasgos:</strong> {p.rasgos.join(', ')}
+                        </p>
+                      )}
                       {p.descripcion && (
                         <p className="italic">{highlightText(p.descripcion)}</p>
                       )}
@@ -4456,6 +4475,12 @@ function App() {
                               <span className="font-medium">Consumo:</span>{' '}
                               {power.consumo}
                             </p>
+                            {power.rasgos && power.rasgos.length > 0 && (
+                              <p className="text-xs mb-1">
+                                <span className="font-medium">Rasgos:</span>{' '}
+                                {highlightText(power.rasgos.join(', '))}
+                              </p>
+                            )}
                             {power.descripcion && (
                               <p className="text-xs text-gray-300">
                                 <span className="font-medium">
@@ -4824,6 +4849,13 @@ function App() {
               }
             />
             <Input
+              placeholder="Rasgos (separados por comas)"
+              value={newAbility.rasgos}
+              onChange={(e) =>
+                setNewAbility((a) => ({ ...a, rasgos: e.target.value }))
+              }
+            />
+            <Input
               placeholder="Daño"
               value={newAbility.poder}
               onChange={(e) =>
@@ -4851,6 +4883,7 @@ function App() {
                       cuerpo: '',
                       mente: '',
                       poder: '',
+                      rasgos: '',
                       descripcion: '',
                     });
                   }}
@@ -5045,6 +5078,11 @@ function App() {
                             <p>
                               <strong>Mente:</strong> {h.mente}
                             </p>
+                            {h.rasgos && h.rasgos.length > 0 && (
+                              <p>
+                                <strong>Rasgos:</strong> {h.rasgos.join(', ')}
+                              </p>
+                            )}
                             <p>
                               <strong>Daño:</strong> {h.poder}
                             </p>

--- a/src/components/EnemyViewModal.jsx
+++ b/src/components/EnemyViewModal.jsx
@@ -256,6 +256,11 @@ const EnemyViewModal = ({ enemy, onClose, onEdit, highlightText = (t) => t, floa
                       <p className="mb-1">
                         <span className="font-medium">Consumo:</span> {power.consumo}
                       </p>
+                      {power.rasgos && power.rasgos.length > 0 && (
+                        <p className="mb-1">
+                          <span className="font-medium">Rasgos:</span> {highlightText(power.rasgos.join(', '))}
+                        </p>
+                      )}
                       {power.descripcion && (
                         <p className="text-gray-300 italic">
                           <span className="font-medium">Descripción:</span> {highlightText(power.descripcion)}

--- a/src/components/InitiativeTracker.jsx
+++ b/src/components/InitiativeTracker.jsx
@@ -1184,6 +1184,9 @@ const InitiativeTracker = ({ playerName, isMaster, enemies = [], glossary = [], 
                             <div><span className="font-medium">Consumo:</span> {power.consumo}</div>
                             <div><span className="font-medium">Cuerpo:</span> {power.cuerpo}</div>
                             <div><span className="font-medium">Mente:</span> {power.mente}</div>
+                            {power.rasgos && power.rasgos.length > 0 && (
+                              <div><span className="font-medium">Rasgos:</span> {power.rasgos.join(', ')}</div>
+                            )}
                           </div>
                           {power.descripcion && (
                             <div className="mt-2 text-gray-300 italic text-sm">


### PR DESCRIPTION
## Summary
- allow storing `rasgos` when creating or editing a power
- show rasgos in equipped power cards for players, enemies and previews
- display rasgos when listing powers in the catalog
- expose rasgos field in EnemyViewModal and InitiativeTracker
- document the new feature in README

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688992a03c1c8326aca3faa6319783ef