### PR TITLE
Display equipment traits

### DIFF
--- a/README.md
+++ b/README.md
@@ -1150,6 +1150,10 @@ src/
 - ✅ El campo de daño solo muestra valores como `1d8` o `2d6`, ocultando el tipo de daño
 - ✅ También se rellena correctamente el daño de los poderes al seleccionarlos
 
+**Resumen de cambios v2.4.30:**
+
+- ✅ Los menús de ataque y defensa muestran ahora todos los rasgos de las armas y poderes seleccionados (informativo)
+
 **Resumen de cambios v2.4.48:**
 
 - 🔧 `handleDragEnd` solo sincroniza los tokens si realmente cambian de posición

--- a/src/components/AttackModal.jsx
+++ b/src/components/AttackModal.jsx
@@ -165,6 +165,17 @@ const AttackModal = ({
     [selectedItem]
   );
 
+  const otherTraits = useMemo(
+    () =>
+      (selectedItem?.rasgos || []).filter(
+        (r) =>
+          !r
+            .toLowerCase()
+            .match(/(vigor|destreza|intelecto|voluntad)/)
+      ),
+    [selectedItem]
+  );
+
   const hasEquip = useMemo(() => {
     if (!sheet) return false;
     const w = sheet.weapons || [];
@@ -364,6 +375,11 @@ const AttackModal = ({
                             {mult > 1 ? ` x${mult}` : ''}
                           </span>
                         ))}
+                      </p>
+                    )}
+                    {otherTraits.length > 0 && (
+                      <p className="text-sm text-gray-300 mt-1">
+                        Rasgos: {otherTraits.join(', ')}
                       </p>
                     )}
                   </>

--- a/src/components/DefenseModal.jsx
+++ b/src/components/DefenseModal.jsx
@@ -154,6 +154,17 @@ const DefenseModal = ({
     [selectedItem]
   );
 
+  const otherTraits = useMemo(
+    () =>
+      (selectedItem?.rasgos || []).filter(
+        (r) =>
+          !r
+            .toLowerCase()
+            .match(/(vigor|destreza|intelecto|voluntad)/)
+      ),
+    [selectedItem]
+  );
+
   const hasEquip = useMemo(() => {
     if (!sheet) return false;
     const w = sheet.weapons || [];
@@ -378,6 +389,11 @@ const DefenseModal = ({
                             {mult > 1 ? ` x${mult}` : ''}
                           </span>
                         ))}
+                      </p>
+                    )}
+                    {otherTraits.length > 0 && (
+                      <p className="text-sm text-gray-300 mt-1">
+                        Rasgos: {otherTraits.join(', ')}
                       </p>
                     )}
                   </>


### PR DESCRIPTION
## Summary
- show non-attribute traits for selected items
- list these traits in attack and defense menus
- document new behaviour in README

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688a616dfa348326975129ad5245871c