### PR TITLE
Implement critical roll highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1152,6 +1152,10 @@ src/
 
 **Resumen de cambios v2.4.30:**
 
+- ✅ Los resultados extra por "crítico" se muestran en rojo dentro de la calculadora y el chat
+
+**Resumen de cambios v2.4.30:**
+
 - ✅ Los menús de ataque y defensa muestran ahora todos los rasgos de las armas y poderes seleccionados (informativo)
 
 **Resumen de cambios v2.4.48:**

--- a/src/components/AssetSidebar.jsx
+++ b/src/components/AssetSidebar.jsx
@@ -19,6 +19,8 @@ import { db } from '../firebase';
 import Input from './Input';
 import { rollExpression } from '../utils/dice';
 
+const SPECIAL_TRAIT_COLOR = '#ef4444';
+
 const highlightBattleText = (text) =>
   text
     .replace(
@@ -744,8 +746,17 @@ const AssetSidebar = ({
                                       className="w-4 h-4"
                                     />
                                   )}
-                                  {d.formula}: [{d.rolls.join(', ')}] ={' '}
-                                  {d.subtotal}
+                                  {d.formula}: [
+                                  {d.rolls.map((r, ri) => (
+                                    <span
+                                      key={ri}
+                                      style={r.critical ? { color: SPECIAL_TRAIT_COLOR } : {}}
+                                    >
+                                      {r.value}
+                                      {ri < d.rolls.length - 1 ? ', ' : ''}
+                                    </span>
+                                  ))}
+                                  ] = {d.subtotal}
                                 </span>
                               )}
                               {d.type === 'modifier' && (

--- a/src/components/ChatPanel.jsx
+++ b/src/components/ChatPanel.jsx
@@ -8,6 +8,7 @@ import Input from './Input';
 import { rollExpression } from '../utils/dice';
 
 const MASTER_COLOR = "#FFD700";
+const SPECIAL_TRAIT_COLOR = '#ef4444';
 const ChatPanel = ({ playerName = '', isMaster = false }) => {
   const [messages, setMessages] = useState([]);
   const [message, setMessage] = useState('');
@@ -133,7 +134,17 @@ const ChatPanel = ({ playerName = '', isMaster = false }) => {
                           {d.type === 'dice' && (
                             <span className="flex items-center justify-center gap-1">
                               {img && <img src={img} alt={`d${sides}`} className="w-4 h-4" />}
-                              {d.formula}: [{d.rolls.join(', ')}] = {d.subtotal}
+                              {d.formula}: [
+                              {d.rolls.map((r, ri) => (
+                                <span
+                                  key={ri}
+                                  style={r.critical ? { color: SPECIAL_TRAIT_COLOR } : {}}
+                                >
+                                  {r.value}
+                                  {ri < d.rolls.length - 1 ? ', ' : ''}
+                                </span>
+                              ))}
+                              ] = {d.subtotal}
                             </span>
                           )}
                           {d.type === 'modifier' && <span>Modificador: {d.formula}</span>}

--- a/src/components/DiceCalculator.jsx
+++ b/src/components/DiceCalculator.jsx
@@ -3,6 +3,8 @@ import Boton from './Boton';
 import Input from './Input';
 import { rollExpression } from '../utils/dice';
 
+const SPECIAL_TRAIT_COLOR = '#ef4444';
+
 const DiceCalculator = ({ playerName, onBack }) => {
 
   const [selectedDice, setSelectedDice] = useState([]);
@@ -217,7 +219,17 @@ const DiceCalculator = ({ playerName, onBack }) => {
                       <div key={index} className="text-sm text-center bg-gray-800/50 rounded p-2">
                         {detail.type === 'dice' ? (
                           <span>
-                            {detail.formula}: [{detail.rolls.join(', ')}] = {detail.subtotal}
+                            {detail.formula}: [
+                            {detail.rolls.map((r, ri) => (
+                              <span
+                                key={ri}
+                                style={r.critical ? { color: SPECIAL_TRAIT_COLOR } : {}}
+                              >
+                                {r.value}
+                                {ri < detail.rolls.length - 1 ? ', ' : ''}
+                              </span>
+                            ))}
+                            ] = {detail.subtotal}
                           </span>
                         ) : detail.type === 'calc' ? (
                           <span>Resultado: {detail.value}</span>

--- a/src/utils/dice.js
+++ b/src/utils/dice.js
@@ -49,11 +49,11 @@ export const parseAndRollFormulaCritical = (formula) => {
     const rolls = [];
     for (let i = 0; i < count; i++) {
       let roll = Math.floor(Math.random() * sides) + 1;
-      rolls.push(roll);
+      rolls.push({ value: roll, critical: false });
       total += roll;
       while (roll === sides) {
         roll = Math.floor(Math.random() * sides) + 1;
-        rolls.push(roll);
+        rolls.push({ value: roll, critical: true });
         total += roll;
       }
     }
@@ -61,7 +61,7 @@ export const parseAndRollFormulaCritical = (formula) => {
       type: 'dice',
       formula: `${count}d${sides}`,
       rolls,
-      subtotal: rolls.reduce((sum, r) => sum + r, 0),
+      subtotal: rolls.reduce((sum, r) => sum + r.value, 0),
     });
   }
 


### PR DESCRIPTION
## Summary
- differentiate critical rolls in the dice utils
- highlight critical rolls in chat, asset sidebar and dice calculator
- document critical roll display

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688a6e29d5f08326be6acab362b2f615