### PR TITLE
Implement ingenio consumption

### DIFF
--- a/README.md
+++ b/README.md
@@ -1341,6 +1341,12 @@ src/
 - Se implementa el rasgo **Crítico** que vuelve a tirar el dado de daño cuando
   muestra su valor máximo, acumulando cada nuevo resultado.
 
+**Resumen de cambios v2.4.70:**
+
+- Las armas y poderes ahora pueden consumir Ingenio (🔵).
+  Al usarlos se resta de la estadística del atacante y se muestra una animación
+  de daño en Ingenio.
+
 **Resumen de cambios v2.4.25:**
 
 - ✅ El menú de ataque y defensa solo muestra armas o poderes al alcance

--- a/src/utils/initiative.js
+++ b/src/utils/initiative.js
@@ -1,5 +1,13 @@
-import { doc, getDoc, updateDoc } from 'firebase/firestore';
+import {
+  doc,
+  getDoc,
+  updateDoc,
+  addDoc,
+  collection,
+  serverTimestamp,
+} from 'firebase/firestore';
 import { db } from '../firebase';
+import { saveTokenSheet } from './token';
 
 export const addSpeedForToken = async (token, speed) => {
   if (!token || !token.id || speed <= 0) return;
@@ -34,5 +42,56 @@ export const addSpeedForToken = async (token, speed) => {
     await updateDoc(initiativeRef, { participants });
   } catch (err) {
     console.error('Error updating initiative speed:', err);
+  }
+};
+
+export const consumeStatForToken = async (token, stat, amount, pageId) => {
+  if (!token?.tokenSheetId || amount <= 0) return;
+  try {
+    const stored = localStorage.getItem('tokenSheets');
+    const sheets = stored ? JSON.parse(stored) : {};
+    let sheet = sheets[token.tokenSheetId];
+    if (!sheet) {
+      const snap = await getDoc(doc(db, 'tokenSheets', token.tokenSheetId));
+      if (snap.exists()) sheet = snap.data();
+    }
+    if (!sheet?.stats?.[stat]) return;
+    sheet = {
+      ...sheet,
+      stats: {
+        ...sheet.stats,
+        [stat]: { ...sheet.stats[stat], actual: Math.max(0, (sheet.stats[stat].actual || 0) - amount) },
+      },
+    };
+    sheets[token.tokenSheetId] = sheet;
+    localStorage.setItem('tokenSheets', JSON.stringify(sheets));
+    window.dispatchEvent(new CustomEvent('tokenSheetSaved', { detail: sheet }));
+    saveTokenSheet(sheet);
+
+    if (pageId) {
+      let effectivePageId = pageId;
+      try {
+        const visibilityDoc = await getDoc(doc(db, 'gameSettings', 'playerVisibility'));
+        if (visibilityDoc.exists()) {
+          effectivePageId = visibilityDoc.data().playerVisiblePageId || pageId;
+        }
+      } catch (err) {
+        console.warn('No se pudo obtener playerVisiblePageId, usando pageId actual:', err);
+      }
+      try {
+        await addDoc(collection(db, 'damageEvents'), {
+          tokenId: token.id,
+          value: amount,
+          stat,
+          ts: Date.now(),
+          pageId: effectivePageId,
+          timestamp: serverTimestamp(),
+        });
+      } catch (err) {
+        console.error('Error registrando consumo de stat:', err);
+      }
+    }
+  } catch (err) {
+    console.error('Error consuming stat for token:', err);
   }
 };


### PR DESCRIPTION
## Summary
- implement generic `consumeStatForToken` helper
- apply ingenio (`🔵`) cost in AttackModal and DefenseModal
- show blue consumption in UI
- document new ingenio usage

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688a8d546c54832699befc8cbe07eac6