### PR TITLE
Resalta palabras de combate para jugadores en el chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -1347,6 +1347,10 @@ src/
   Al usarlos se resta de la estadística del atacante y se muestra una animación
   de daño en Ingenio con el color azul correspondiente.
 
+**Resumen de cambios v2.4.71:**
+
+- Las acciones de combate en el chat se resaltan también para los jugadores.
+
 **Resumen de cambios v2.4.25:**
 
 - ✅ El menú de ataque y defensa solo muestra armas o poderes al alcance

--- a/src/components/AssetSidebar.jsx
+++ b/src/components/AssetSidebar.jsx
@@ -18,27 +18,9 @@ import { doc, getDoc, setDoc, onSnapshot } from 'firebase/firestore';
 import { db } from '../firebase';
 import Input from './Input';
 import { rollExpression } from '../utils/dice';
+import highlightBattleText from '../utils/highlightBattleText';
 
 const SPECIAL_TRAIT_COLOR = '#ef4444';
-
-const highlightBattleText = (text) =>
-  text
-    .replace(
-      /(recibe daño)/gi,
-      '<span class="text-red-400 font-semibold">$1</span>'
-    )
-    .replace(
-      /(bloquea el ataque)/gi,
-      '<span class="text-green-400 font-semibold">$1</span>'
-    )
-    .replace(
-      /(resiste el ataque|resiste el daño)/gi,
-      '<span class="text-blue-400 font-semibold">$1</span>'
-    )
-    .replace(
-      /(contraataca)/gi,
-      '<span class="text-yellow-400 font-semibold">$1</span>'
-    );
 
 const MASTER_COLOR = "#FFD700";
 

--- a/src/components/ChatPanel.jsx
+++ b/src/components/ChatPanel.jsx
@@ -6,6 +6,7 @@ import { doc, onSnapshot, setDoc } from 'firebase/firestore';
 import { db } from '../firebase';
 import Input from './Input';
 import { rollExpression } from '../utils/dice';
+import highlightBattleText from '../utils/highlightBattleText';
 
 const MASTER_COLOR = "#FFD700";
 const SPECIAL_TRAIT_COLOR = '#ef4444';
@@ -118,7 +119,10 @@ const ChatPanel = ({ playerName = '', isMaster = false }) => {
                   <span className="font-semibold mr-1" style={{ color: getPlayerColor(m.author), textShadow: m.author === 'Master' ? '0 0 4px ' + MASTER_COLOR : 'none' }}>
                     {m.author}:
                   </span>
-                  <span className="text-gray-200 break-words">{m.text}</span>
+                  <span
+                    className="text-gray-200 break-words"
+                    dangerouslySetInnerHTML={{ __html: highlightBattleText(m.text) }}
+                  />
                 </div>
               )}
               {m.result && (

--- a/src/utils/highlightBattleText.js
+++ b/src/utils/highlightBattleText.js
@@ -1,0 +1,20 @@
+const highlightBattleText = (text = '') =>
+  text
+    .replace(
+      /(recibe daño)/gi,
+      '<span class="text-red-400 font-semibold">$1</span>'
+    )
+    .replace(
+      /(bloquea el ataque)/gi,
+      '<span class="text-green-400 font-semibold">$1</span>'
+    )
+    .replace(
+      /(resiste el ataque|resiste el daño)/gi,
+      '<span class="text-blue-400 font-semibold">$1</span>'
+    )
+    .replace(
+      /(contraataca)/gi,
+      '<span class="text-yellow-400 font-semibold">$1</span>'
+    );
+
+export default highlightBattleText;


### PR DESCRIPTION
## Summary
- Extrae la lógica de resaltado de combate a `highlightBattleText`
- Muestra a los jugadores las mismas palabras de combate resaltadas que ve el máster
- Documenta la mejora en el README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a9fc0dd9483268d54bcdebffc4b6b