### PR TITLE
feat: allow custom weapons and armors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1355,6 +1355,11 @@ src/
 
 - Las acciones de combate en el chat se resaltan también para los jugadores.
 
+**Resumen de cambios v2.4.72:**
+
+- Las armas y armaduras personalizadas pueden crearse, editarse y eliminarse directamente en la aplicación, guardándose en Firebase.
+- El catálogo base sigue cargándose desde Google Sheets.
+
 **Resumen de cambios v2.4.25:**
 
 - ✅ El menú de ataque y defensa solo muestra armas o poderes al alcance


### PR DESCRIPTION
## Summary
- integrate weapons and armors from Firestore with existing Google Sheets list
- allow creating, editing and deleting custom weapons and armors
- document custom equipment support

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688abcd0988c8326b110c007d9e24f2a