### PR TITLE
Evita escritura del máster por cambios remotos de tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -1386,6 +1386,10 @@ src/
 - ✅ El campo de daño solo muestra valores como `1d8` o `2d6`, ocultando el tipo de daño
 - ✅ También se rellena correctamente el daño de los poderes al seleccionarlos
 
+**Resumen de cambios v2.4.30:**
+
+- Se evita que las actualizaciones de otros clientes disparen escrituras del máster.
+
 ## 🔄 Historial de cambios previos
 
 <details>

--- a/src/App.js
+++ b/src/App.js
@@ -488,6 +488,7 @@ function App() {
   const pagesLoadedRef = useRef(false);
   const checkedPagesRef = useRef({});
   const prevTokensRef = useRef([]);
+  const isLocalTokenEdit = useRef(false);
   const prevLinesRef = useRef([]);
   const prevWallsRef = useRef([]);
   const wallSaveTimeout = useRef(null);
@@ -910,13 +911,15 @@ function App() {
     if (!pageId) return;
     if (deepEqual(canvasTokens, prevTokensRef.current)) return;
 
+    prevTokensRef.current = canvasTokens;
+    if (!isLocalTokenEdit.current) return;
+
     console.log(
       'Programando guardado de tokens en página:',
       pageId,
       'currentPage:',
       currentPage
     );
-    prevTokensRef.current = canvasTokens;
 
     // Limpiar timeout anterior
     if (tokenSaveTimeout.current) {
@@ -952,6 +955,8 @@ function App() {
           console.log('Tokens guardados exitosamente en página:', pageId);
         } catch (error) {
           console.error('Error guardando tokens:', error);
+        } finally {
+          isLocalTokenEdit.current = false;
         }
       };
       saveTokens();
@@ -4842,7 +4847,10 @@ function App() {
               gridOffsetX={gridOffsetX}
               gridOffsetY={gridOffsetY}
               tokens={canvasTokens}
-              onTokensChange={setCanvasTokens}
+              onTokensChange={(newTokens) => {
+                setCanvasTokens(newTokens);
+                isLocalTokenEdit.current = true;
+              }}
               texts={canvasTexts}
               onTextsChange={setCanvasTexts}
               lines={canvasLines}


### PR DESCRIPTION
## Summary
- Evita que las actualizaciones remotas de tokens disparen guardados automáticos del máster usando `isLocalTokenEdit`
- Se restablece el indicador tras completar el guardado
- Documentado el cambio en README

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_688be7c9147c832693e5c3a19805fbb4