### PR TITLE
Evita aplicar escrituras pendientes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1430,6 +1430,7 @@ Se sigue una numeración basada en [Semantic Versioning](https://semver.org/lang
 - Token sheets always include basic attributes so they can be edited even if missing in stored data.
 - Saving a token sheet now replaces the Firestore document, removing deleted statistics or equipment.
 - Realtime listeners only update the local cache instead of rewriting Firestore, ensuring edits persist across browsers.
+- Player page listener ignores pending writes to avoid oscillations while Firestore transactions complete.
 
 ## 🤝 Contribución
 

--- a/src/App.js
+++ b/src/App.js
@@ -673,6 +673,7 @@ function App() {
     const unsubscribe = onSnapshot(
       doc(db, 'pages', playerVisiblePageId),
       async (docSnap) => {
+        if (docSnap.metadata.hasPendingWrites) return;
         if (docSnap.exists()) {
           const pageData = docSnap.data();
           setEnableDarkness(


### PR DESCRIPTION
## Summary
- Ignora las escrituras pendientes en el listener de la página visible para jugadores para evitar oscilaciones durante transacciones de Firestore.
- Documenta la nueva protección en el README.

## Testing
- `CI=true npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_688bef509b9c832690b946f15826243b