### PR TITLE
Reduce token save debounce to 20ms

### DIFF
--- a/README.md
+++ b/README.md
@@ -1394,6 +1394,10 @@ src/
 
 - Los tokens del mapa se ordenan antes de guardarse para detectar cambios reales y evitar escrituras innecesarias.
 
+**Resumen de cambios v2.4.32:**
+
+- Debounce unificado a 20 ms para el guardado de tokens tanto de jugadores como del máster.
+
 ## 🔄 Historial de cambios previos
 
 <details>

--- a/src/App.js
+++ b/src/App.js
@@ -936,7 +936,7 @@ function App() {
       clearTimeout(tokenSaveTimeout.current);
     }
 
-    // Debouncing: esperar 50ms antes de guardar
+    // Debouncing: esperar 20ms antes de guardar
     tokenSaveTimeout.current = setTimeout(async () => {
       const saveId = ++saveVersionRef.current.tokens;
 
@@ -971,7 +971,7 @@ function App() {
         }
       };
       saveTokens();
-    }, 50);
+    }, 20);
   }, [canvasTokens, currentPage]);
 
   useEffect(() => {

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -1121,7 +1121,7 @@ const MapCanvas = ({
         clearTimeout(saveTimeouts[type]);
       }
 
-      // Debouncing: esperar 100ms antes de guardar
+      // Debouncing: esperar 20ms antes de guardar
       saveTimeouts[type] = setTimeout(async () => {
         try {
           // Validaciones de seguridad para jugadores
@@ -1166,7 +1166,7 @@ const MapCanvas = ({
         } catch (error) {
           console.error(`Error guardando ${type} para jugador:`, error);
         }
-      }, 100);
+      }, 20);
     };
 
     return { saveToFirebase };


### PR DESCRIPTION
## Summary
- unify token save debounce to 20ms for master and players
- document token debounce change in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688be58d4e088326a7637d685825b84c