### PR TITLE
Movimiento continuo de tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -1200,6 +1200,10 @@ src/
 - ✅ La defensa se resuelve automáticamente si nadie responde
 - ✅ Si no hay armas o poderes disponibles, el defensor puede introducir un valor manual de defensa
 
+**Resumen de cambios v2.4.34:**
+
+- ✅ Los tokens se mueven de forma continua al mantener pulsadas las teclas WASD y los cambios se sincronizan con Firebase.
+
 **Resumen de cambios v2.4.35:**
 
 - ✅ El daño se calcula como `floor(daño / atributo)` y se aplica primero a la postura, luego a la armadura y finalmente a la vida


### PR DESCRIPTION
## Summary
- Controla teclas presionadas con `pressedKeys` y mueve tokens en un bucle `requestAnimationFrame`
- Sincroniza desplazamientos con Firebase mediante `saveToFirebase`
- Documenta la mejora de movimiento continuo en el README

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_688c2da092c8832687d56628ce7678cd