### PR TITLE
Preserve player token position on snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -1406,6 +1406,10 @@ src/
 
 - Optimización del bloqueo de posiciones en el mapa usando un `Set` memoizado de celdas ocupadas por muros.
 
+**Resumen de cambios v2.4.34:**
+
+- Los tokens controlados por el jugador conservan su posición local al sincronizarse, evitando guardados innecesarios.
+
 ## 🔄 Historial de cambios previos
 
 <details>


### PR DESCRIPTION
## Summary
- merge snapshot tokens with local player positions to avoid overrides
- document preservation of player token positions in changelog

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_688ca93727008326a910b1193f67c3ed