### PR TITLE
Prolongar animación de daño y duplicar tamaño de fuente

### DIFF
--- a/README.md
+++ b/README.md
@@ -1416,6 +1416,11 @@ src/
 
 - Los tokens controlados por el jugador conservan su posición local al sincronizarse, evitando guardados innecesarios.
 
+**Resumen de cambios v2.4.36:**
+
+- Las animaciones de daño duran ahora 10 s.
+- Los números de daño duplican su tamaño para mayor legibilidad.
+
 ## 🔄 Historial de cambios previos
 
 <details>

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -1908,7 +1908,7 @@ const MapCanvas = ({
 
         setTimeout(() => {
           setDamagePopups((prev) => prev.filter((p) => p.id !== id));
-        }, 7000);
+        }, 10000);
       } catch (error) {
         console.error('Error en triggerDamagePopup:', error);
       }
@@ -1924,7 +1924,7 @@ const MapCanvas = ({
       const current = tokensRef.current;
       if (!current.find((t) => t.id === tokenId)) return;
       const startOpacity = 0.5;
-      const duration = 7000;
+      const duration = 10000;
 
       const existing = damageTimersRef.current[tokenId];
       if (existing && existing.raf) {
@@ -1991,7 +1991,7 @@ const MapCanvas = ({
           } catch (err) {
             console.error('Error eliminando evento de daño:', err);
           }
-        }, 7000);
+        }, 10000);
       });
     });
     return () => unsub();
@@ -4568,14 +4568,14 @@ const MapCanvas = ({
                   key={p.id}
                   initial={{ opacity: 1, y: 0 }}
                   animate={{ opacity: 0, y: -20 }}
-                  transition={{ duration: 7 }}
+                  transition={{ duration: 10 }}
                   style={{
                     position: 'absolute',
                     left: x + offset,
                     top: y,
                     transform: 'translate(-50%, -100%)',
                     color,
-                    fontSize: 20,
+                    fontSize: 40,
                     fontWeight: 'bold',
                     textShadow: '0 0 2px #000',
                   }}


### PR DESCRIPTION
## Summary
- Amplía a 10 s la duración de los popups de daño y el resaltado del token
- Duplica el tamaño de los números de daño para mayor visibilidad
- Documenta el cambio en el README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688d41ecef2c8326a8742744e5724f9c