### PR TITLE
feat: add dim light option to tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -724,7 +724,7 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 **Resumen de cambios v2.4.3:**
 
 - Sistema de iluminación y visibilidad con cálculo realista de áreas iluminadas usando ray casting.
-- Configuración de luz en tokens con radio, color e intensidad personalizables.
+- Configuración de luz en tokens con radio brillante y tenue (permitiendo desactivar la tenue), color e intensidad personalizables. La luz tenue atenúa la oscuridad en vez de eliminarla.
 
 **Resumen de cambios v2.4.6:**
 

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -51,7 +51,7 @@ import DoorCheckModal from './DoorCheckModal';
 import AttackModal from './AttackModal';
 import DefenseModal from './DefenseModal';
 import { applyDoorCheck } from '../utils/door';
-import { computeVisibility, combineVisibilityPolygons, isPointVisible } from '../utils/visibility';
+import { computeVisibility, combineVisibilityPolygons } from '../utils/visibility';
 import { isTokenVisible, isDoorVisible } from '../utils/playerVisibility';
 import { applyDamage, parseDieValue } from '../utils/damage';
 import {
@@ -1114,7 +1114,6 @@ const MapCanvas = ({
   
   // Estados para el sistema de iluminación
   const [lightPolygons, setLightPolygons] = useState({});
-  const [combinedLight, setCombinedLight] = useState([]);
 
   // Estados para el sistema de visión de jugadores
   const [playerVisionPolygons, setPlayerVisionPolygons] = useState({});
@@ -2024,33 +2023,34 @@ const MapCanvas = ({
     const newPolygons = {};
     
     tokens.forEach(token => {
-      if (token.light && token.light.enabled && token.light.radius > 0) {
-        const origin = {
-          x: (token.x + token.w / 2) * effectiveGridSize,
-          y: (token.y + token.h / 2) * effectiveGridSize
-        };
-        
-        // Aumentar significativamente el número de rayos para mayor precisión
-        // Especialmente importante para evitar "saltos" de luz
-        const polygon = computeVisibility(origin, walls, {
-          rays: 180, // Aumentado de 64 a 180 para mayor precisión
-          maxDistance: token.light.radius * effectiveGridSize
-        });
-        
-        newPolygons[token.id] = {
-          polygon,
-          color: token.light.color || '#ffff88',
-          opacity: token.light.opacity || 0.3
-        };
+      if (token.light && token.light.enabled) {
+        const maxRadius = Math.max(
+          token.light.radius || 0,
+          token.light.dimRadius ?? 0
+        );
+        if (maxRadius > 0) {
+          const origin = {
+            x: (token.x + token.w / 2) * effectiveGridSize,
+            y: (token.y + token.h / 2) * effectiveGridSize
+          };
+
+          // Aumentar significativamente el número de rayos para mayor precisión
+          // Especialmente importante para evitar "saltos" de luz
+          const polygon = computeVisibility(origin, walls, {
+            rays: 180, // Aumentado de 64 a 180 para mayor precisión
+            maxDistance: maxRadius * effectiveGridSize
+          });
+
+          newPolygons[token.id] = {
+            polygon,
+            color: token.light.color || '#ffff88',
+            opacity: token.light.opacity || 0.3
+          };
+        }
       }
     });
 
     setLightPolygons(newPolygons);
-
-    // Combinar todos los polígonos de luz en uno solo
-    const allPolygons = Object.values(newPolygons).map(data => data.polygon).filter(p => p && p.length >= 3);
-    const combined = combineVisibilityPolygons(allPolygons);
-    setCombinedLight(combined);
   }, [tokens, walls, effectiveGridSize]);
 
   // Recalcular polígonos cuando cambien tokens o muros
@@ -4232,17 +4232,25 @@ const MapCanvas = ({
               scaleY={groupScale}
             >
               {/* Renderizar luz básica para todos los tokens con luz */}
-              {tokens.filter(token => 
-                token.light && 
-                token.light.enabled && 
-                token.light.radius && 
-                token.light.radius > 0
+              {tokens.filter(token =>
+                token.light &&
+                token.light.enabled &&
+                (token.light.radius > 0 || (token.light.dimRadius ?? 0) > 0)
               ).map(token => {
                 const centerX = (token.x + token.w / 2) * effectiveGridSize;
                 const centerY = (token.y + token.h / 2) * effectiveGridSize;
-                const radius = token.light.radius * effectiveGridSize;
+                const brightRadius = token.light.radius * effectiveGridSize;
+                const outerRadius = (token.light.dimRadius > 0 ? token.light.dimRadius : token.light.radius) * effectiveGridSize;
                 const color = token.light.color || '#ffa500';
                 const opacity = Math.max(0.2, token.light.opacity || 0.4);
+                const brightRatio = outerRadius > 0 ? brightRadius / outerRadius : 1;
+                const gradientStops = [
+                  0, hexToRgba(color, opacity * 0.8),
+                  brightRatio * 0.3, hexToRgba(color, opacity * 0.6),
+                  brightRatio * 0.6, hexToRgba(color, opacity * 0.3),
+                  brightRatio * 0.85, hexToRgba(color, opacity * 0.1),
+                  1, hexToRgba(color, 0)
+                ];
                 
                 // Verificar si hay polígono de visibilidad para este token
                 const lightData = lightPolygons[token.id];
@@ -4254,7 +4262,7 @@ const MapCanvas = ({
                   lightData.polygon.forEach(point => {
                     points.push(point.x, point.y);
                   });
-                  
+
                   return (
                     <Group key={`wall-blocked-light-${token.id}`}>
                       {/* Luz limitada por muros usando polígono de visibilidad */}
@@ -4264,14 +4272,8 @@ const MapCanvas = ({
                         fillRadialGradientStartPoint={{ x: centerX, y: centerY }}
                         fillRadialGradientEndPoint={{ x: centerX, y: centerY }}
                         fillRadialGradientStartRadius={0}
-                        fillRadialGradientEndRadius={radius}
-                        fillRadialGradientColorStops={[
-                          0, hexToRgba(color, opacity * 0.8),
-                          0.3, hexToRgba(color, opacity * 0.6),
-                          0.6, hexToRgba(color, opacity * 0.3),
-                          0.85, hexToRgba(color, opacity * 0.1),
-                          1, hexToRgba(color, 0)
-                        ]}
+                        fillRadialGradientEndRadius={outerRadius}
+                        fillRadialGradientColorStops={gradientStops}
                         listening={false}
                         perfectDrawEnabled={false}
                       />
@@ -4284,18 +4286,12 @@ const MapCanvas = ({
                       <Circle
                         x={centerX}
                         y={centerY}
-                        radius={radius}
+                        radius={outerRadius}
                         fillRadialGradientStartPoint={{ x: 0, y: 0 }}
                         fillRadialGradientEndPoint={{ x: 0, y: 0 }}
                         fillRadialGradientStartRadius={0}
-                        fillRadialGradientEndRadius={radius}
-                        fillRadialGradientColorStops={[
-                          0, hexToRgba(color, opacity * 0.8),
-                          0.3, hexToRgba(color, opacity * 0.6),
-                          0.6, hexToRgba(color, opacity * 0.3),
-                          0.85, hexToRgba(color, opacity * 0.1),
-                          1, hexToRgba(color, 0)
-                        ]}
+                        fillRadialGradientEndRadius={outerRadius}
+                        fillRadialGradientColorStops={gradientStops}
                         listening={false}
                       />
                     </Group>
@@ -4324,17 +4320,81 @@ const MapCanvas = ({
                   listening={false}
                 />
 
-                {/* Polígono combinado que revela las áreas iluminadas - solo si hay luz */}
-                {combinedLight.length >= 3 && (
-                  <Line
-                    points={combinedLight.flatMap(point => [point.x, point.y])}
-                    closed={true}
-                    fill="rgba(0, 0, 0, 1)"
-                    globalCompositeOperation="destination-out"
-                    listening={false}
-                    perfectDrawEnabled={false}
-                  />
-                )}
+                {/* Reducir la oscuridad alrededor de cada token con luz */}
+                {tokens
+                  .filter(
+                    (token) =>
+                      token.light &&
+                      token.light.enabled &&
+                      (token.light.radius > 0 || (token.light.dimRadius ?? 0) > 0)
+                  )
+                  .map((token) => {
+                    const centerX = (token.x + token.w / 2) * effectiveGridSize;
+                    const centerY = (token.y + token.h / 2) * effectiveGridSize;
+                    const brightRadius = token.light.radius * effectiveGridSize;
+                    const outerRadius =
+                      (token.light.dimRadius > 0
+                        ? token.light.dimRadius
+                        : token.light.radius) * effectiveGridSize;
+                    const brightRatio =
+                      outerRadius > 0 ? brightRadius / outerRadius : 1;
+                    const lightData = lightPolygons[token.id];
+                    const hasWallBlocking =
+                      lightData &&
+                      lightData.polygon &&
+                      lightData.polygon.length >= 3;
+                    const stops = [
+                      0,
+                      'rgba(0,0,0,1)',
+                      brightRatio,
+                      'rgba(0,0,0,1)',
+                      1,
+                      'rgba(0,0,0,0)'
+                    ];
+
+                    if (hasWallBlocking) {
+                      const points = [];
+                      lightData.polygon.forEach((point) => {
+                        points.push(point.x, point.y);
+                      });
+                      return (
+                        <Line
+                          key={`darkness-cut-${token.id}`}
+                          points={points}
+                          closed={true}
+                          fillRadialGradientStartPoint={{
+                            x: centerX,
+                            y: centerY,
+                          }}
+                          fillRadialGradientEndPoint={{
+                            x: centerX,
+                            y: centerY,
+                          }}
+                          fillRadialGradientStartRadius={0}
+                          fillRadialGradientEndRadius={outerRadius}
+                          fillRadialGradientColorStops={stops}
+                          globalCompositeOperation="destination-out"
+                          listening={false}
+                          perfectDrawEnabled={false}
+                        />
+                      );
+                    }
+                    return (
+                      <Circle
+                        key={`darkness-cut-${token.id}`}
+                        x={centerX}
+                        y={centerY}
+                        radius={outerRadius}
+                        fillRadialGradientStartPoint={{ x: 0, y: 0 }}
+                        fillRadialGradientEndPoint={{ x: 0, y: 0 }}
+                        fillRadialGradientStartRadius={0}
+                        fillRadialGradientEndRadius={outerRadius}
+                        fillRadialGradientColorStops={stops}
+                        globalCompositeOperation="destination-out"
+                        listening={false}
+                      />
+                    );
+                  })}
               </Group>
             </Layer>
           )}

--- a/src/components/TokenSettings.jsx
+++ b/src/components/TokenSettings.jsx
@@ -144,6 +144,9 @@ const TokenSettings = ({
     token.light?.enabled || false
   );
   const [lightRadius, setLightRadius] = useState(token.light?.radius || 5);
+  const [dimLightRadius, setDimLightRadius] = useState(
+    token.light?.dimRadius ?? token.light?.radius ?? 5
+  );
   const [lightColor, setLightColor] = useState(token.light?.color || '#ffa500');
   const [lightOpacity, setLightOpacity] = useState(token.light?.opacity || 0.4);
 
@@ -288,6 +291,7 @@ const TokenSettings = ({
         light: {
           enabled: lightEnabled,
           radius: lightRadius,
+          dimRadius: dimLightRadius,
           color: lightColor,
           opacity: lightOpacity,
         },
@@ -316,6 +320,7 @@ const TokenSettings = ({
     notes,
     lightEnabled,
     lightRadius,
+    dimLightRadius,
     lightColor,
     lightOpacity,
     visionEnabled,
@@ -347,6 +352,7 @@ const TokenSettings = ({
       light: {
         enabled: lightEnabled,
         radius: lightRadius,
+        dimRadius: dimLightRadius,
         color: lightColor,
         opacity: lightOpacity,
       },
@@ -377,6 +383,7 @@ const TokenSettings = ({
     tintOpacity,
     lightEnabled,
     lightRadius,
+    dimLightRadius,
     visionEnabled, // Cambio inmediato para visión
   ]);
 
@@ -815,6 +822,22 @@ const TokenSettings = ({
                       value={lightRadius}
                       onChange={(e) =>
                         setLightRadius(parseInt(e.target.value, 10) || 1)
+                      }
+                    />
+                  </div>
+                  <div>
+                    <label className="block mb-1">
+                      Radio de luz tenue (casillas)
+                    </label>
+                    <Input
+                      type="number"
+                      min="0"
+                      max="40"
+                      value={dimLightRadius}
+                      onChange={(e) =>
+                        setDimLightRadius(
+                          Math.max(0, parseInt(e.target.value, 10) || 0)
+                        )
                       }
                     />
                   </div>


### PR DESCRIPTION
## Summary
- allow tokens to configure separate dim light radius, including zero
- render dim light by softening darkness with radial gradients
- document dim light behavior and ability to disable it

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e901368c88326a3cb2a2ea83c9193