### PR TITLE
Ajusta contraste entre luces brillante y tenue

### DIFF
--- a/README.md
+++ b/README.md
@@ -1388,6 +1388,11 @@ src/
 
 - Ahora es posible desactivar los rasgos activos en los menús de ataque y defensa para que no afecten la tirada.
 
+**Resumen de cambios v2.4.76:**
+
+- Se reduce la intensidad mínima de la luz al 5% para transiciones más suaves entre zonas iluminadas.
+- La luz tenue aplica ahora el 100% de la intensidad configurada, evitando contrastes irreales.
+
 **Resumen de cambios v2.4.25:**
 
 - ✅ El menú de ataque y defensa solo muestra armas o poderes al alcance

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -4243,7 +4243,7 @@ const MapCanvas = ({
                 const color = token.light.color || '#ffa500';
                 const opacity = token.light.opacity ?? 0.4;
                 const brightRatio = outerRadius > 0 ? brightRadius / outerRadius : 1;
-                const dimIntensity = opacity * 0.5;
+                const dimIntensity = opacity;
                 const dimStart = Math.min(brightRatio + 0.001, 0.999);
 
                 const gradientStops =
@@ -4344,7 +4344,7 @@ const MapCanvas = ({
                       (token.light.dimRadius ?? 0) * effectiveGridSize;
                     const outerRadius = brightRadius + dimRadius;
                     const opacity = token.light.opacity ?? 0.4;
-                    const dimIntensity = opacity * 0.5;
+                    const dimIntensity = opacity;
                     const brightRatio =
                       outerRadius > 0 ? brightRadius / outerRadius : 1;
                     const dimStart = Math.min(brightRatio + 0.001, 0.999);

--- a/src/components/TokenSettings.jsx
+++ b/src/components/TokenSettings.jsx
@@ -880,7 +880,7 @@ const TokenSettings = ({
                     <label className="block mb-1">Intensidad de la luz</label>
                     <input
                       type="range"
-                      min="0.1"
+                      min="0.05"
                       max="0.8"
                       step="0.05"
                       value={lightOpacity}


### PR DESCRIPTION
## Summary
- Permite bajar la intensidad mínima de la luz al 5 %
- La luz tenue usa ahora el 100 % de la intensidad seleccionada
- Documentación actualizada con los cambios

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_688f58f6b994832683a02dcaecfedf08