### PR TITLE
Ajusta contraste entre luces brillante y tenue

### DIFF
--- a/README.md
+++ b/README.md
@@ -724,7 +724,7 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 **Resumen de cambios v2.4.3:**
 
 - Sistema de iluminación y visibilidad con cálculo realista de áreas iluminadas usando ray casting.
-- Configuración de luz en tokens con radio brillante y un radio adicional de luz tenue (permitiendo desactivar la tenue), color e intensidad personalizables. La luz tenue atenúa la oscuridad con un 50% de la intensidad de la luz brillante.
+- Configuración de luz en tokens con radio brillante y un radio adicional de luz tenue (permitiendo desactivar la tenue), color e intensidad personalizables. La luz brillante usa el 100% de la intensidad seleccionada y la luz tenue atenúa la oscuridad con el 80%.
 - El radio tenue se dibuja a partir del borde de la luz brillante para que siempre sea visible y nunca emana directamente del token.
 
 **Resumen de cambios v2.4.6:**
@@ -1387,6 +1387,12 @@ src/
 **Resumen de cambios v2.4.75:**
 
 - Ahora es posible desactivar los rasgos activos en los menús de ataque y defensa para que no afecten la tirada.
+
+**Resumen de cambios v2.4.76:**
+
+- Se reduce la intensidad mínima de la luz al 5% para transiciones más suaves entre zonas iluminadas.
+- La luz tenue aplica ahora el 80% de la intensidad configurada, evitando contrastes irreales.
+- La luz brillante emplea el 100% de la intensidad seleccionada para asegurar que nunca sea menos intensa que la tenue.
 
 **Resumen de cambios v2.4.25:**
 

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -4242,23 +4242,24 @@ const MapCanvas = ({
                 const outerRadius = brightRadius + dimRadius;
                 const color = token.light.color || '#ffa500';
                 const opacity = token.light.opacity ?? 0.4;
+                const brightIntensity = opacity;
                 const brightRatio = outerRadius > 0 ? brightRadius / outerRadius : 1;
-                const dimIntensity = opacity * 0.5;
+                const dimIntensity = opacity * 0.8;
                 const dimStart = Math.min(brightRatio + 0.001, 0.999);
 
                 const gradientStops =
                   dimRadius > 0
                     ? [
                         0,
-                        hexToRgba(color, opacity),
+                        hexToRgba(color, brightIntensity),
                         brightRatio,
-                        hexToRgba(color, opacity),
+                        hexToRgba(color, brightIntensity),
                         dimStart,
                         hexToRgba(color, dimIntensity),
                         1,
                         hexToRgba(color, 0),
                       ]
-                    : [0, hexToRgba(color, opacity), 1, hexToRgba(color, 0)];
+                    : [0, hexToRgba(color, brightIntensity), 1, hexToRgba(color, 0)];
                 
                 // Verificar si hay polígono de visibilidad para este token
                 const lightData = lightPolygons[token.id];
@@ -4344,7 +4345,8 @@ const MapCanvas = ({
                       (token.light.dimRadius ?? 0) * effectiveGridSize;
                     const outerRadius = brightRadius + dimRadius;
                     const opacity = token.light.opacity ?? 0.4;
-                    const dimIntensity = opacity * 0.5;
+                    const brightIntensity = opacity;
+                    const dimIntensity = opacity * 0.8;
                     const brightRatio =
                       outerRadius > 0 ? brightRadius / outerRadius : 1;
                     const dimStart = Math.min(brightRatio + 0.001, 0.999);
@@ -4357,15 +4359,15 @@ const MapCanvas = ({
                       dimRadius > 0
                         ? [
                             0,
-                            'rgba(0,0,0,1)',
+                            `rgba(0,0,0,${brightIntensity})`,
                             brightRatio,
-                            'rgba(0,0,0,1)',
+                            `rgba(0,0,0,${brightIntensity})`,
                             dimStart,
                             `rgba(0,0,0,${dimIntensity})`,
                             1,
                             'rgba(0,0,0,0)'
                           ]
-                        : [0, 'rgba(0,0,0,1)', 1, 'rgba(0,0,0,0)'];
+                        : [0, `rgba(0,0,0,${brightIntensity})`, 1, 'rgba(0,0,0,0)'];
 
                     if (hasWallBlocking) {
                       const points = [];

--- a/src/components/TokenSettings.jsx
+++ b/src/components/TokenSettings.jsx
@@ -880,7 +880,7 @@ const TokenSettings = ({
                     <label className="block mb-1">Intensidad de la luz</label>
                     <input
                       type="range"
-                      min="0.1"
+                      min="0.05"
                       max="0.8"
                       step="0.05"
                       value={lightOpacity}


### PR DESCRIPTION
## Summary
- Permite bajar la intensidad mínima de la luz al 5 %
- La luz brillante usa el 100 % de la intensidad seleccionada y la luz tenue se limita al 80 %
- Documentación actualizada con los nuevos valores de intensidad

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f58f6b994832683a02dcaecfedf08