### PR TITLE
feat: allow custom inventory items

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 - **Claves consumibles** - Acciones especiales con contador de usos
 - **Carga física y mental** - Sistema automático de penalizaciones por peso
 - **Estados del personaje** - Seguimiento de efectos activos con iconos
-- **Inventario tradicional** - Sistema de slots drag & drop para objetos básicos
+- **Inventario tradicional** - Sistema de slots drag & drop para objetos básicos y personalizables
 
 **Resumen de cambios v2.2.1:**
 
@@ -1449,6 +1449,10 @@ src/
 
 - Las animaciones de daño duran ahora 10 s.
 - Los números de daño duplican su tamaño para mayor legibilidad.
+
+**Resumen de cambios v2.4.37:**
+
+- El máster puede crear objetos de inventario personalizados con nombre, descripción, icono y color.
 
 ## 🔄 Historial de cambios previos
 

--- a/src/components/inventory/CustomItemForm.jsx
+++ b/src/components/inventory/CustomItemForm.jsx
@@ -1,0 +1,87 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+
+const toSlug = (str) =>
+  str
+    .toLowerCase()
+    .trim()
+    .replace(/\s+/g, '-')
+    .replace(/[^a-z0-9-]/g, '');
+
+const CustomItemForm = ({ onSave, onCancel }) => {
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [icon, setIcon] = useState('');
+  const [color, setColor] = useState('#a3a3a3');
+
+  const handleFile = (e) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onloadend = () => {
+      if (typeof reader.result === 'string') setIcon(reader.result);
+    };
+    reader.readAsDataURL(file);
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    if (!name) return;
+    const type = toSlug(name);
+    onSave({ type, icon, description, color });
+    setName('');
+    setDescription('');
+    setIcon('');
+    setColor('#a3a3a3');
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-2 p-2 border rounded bg-gray-800">
+      <input
+        className="w-full px-2 py-1 text-black"
+        placeholder="Nombre"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+      />
+      <input
+        className="w-full px-2 py-1 text-black"
+        placeholder="Descripción"
+        value={description}
+        onChange={(e) => setDescription(e.target.value)}
+      />
+      <div className="flex gap-2 items-center">
+        <input
+          className="flex-1 px-2 py-1 text-black"
+          placeholder="Icono (emoji)"
+          value={icon.startsWith('data:') ? '' : icon}
+          onChange={(e) => setIcon(e.target.value)}
+        />
+        <input type="file" accept="image/*" onChange={handleFile} />
+      </div>
+      <div className="flex items-center gap-2">
+        <label className="text-sm">Color:</label>
+        <input
+          type="color"
+          value={color}
+          onChange={(e) => setColor(e.target.value)}
+          className="w-10 h-6"
+        />
+      </div>
+      <div className="flex gap-2 justify-end">
+        <button type="button" onClick={onCancel} className="px-2 py-1 bg-gray-600 text-white rounded">
+          Cancelar
+        </button>
+        <button type="submit" className="px-2 py-1 bg-green-600 text-white rounded">
+          Guardar
+        </button>
+      </div>
+    </form>
+  );
+};
+
+CustomItemForm.propTypes = {
+  onSave: PropTypes.func.isRequired,
+  onCancel: PropTypes.func.isRequired,
+};
+
+export default CustomItemForm;

--- a/src/components/inventory/ItemGenerator.jsx
+++ b/src/components/inventory/ItemGenerator.jsx
@@ -1,21 +1,33 @@
 import React, { useState, useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import Input from '../Input';
+import CustomItemForm from './CustomItemForm';
 
-const ITEMS = ['remedio', 'chatarra', 'comida', 'polvora'];
+const DEFAULT_ITEMS = ['remedio', 'chatarra', 'comida', 'polvora'];
 
 const ItemGenerator = ({ onGenerate }) => {
+  const [items, setItems] = useState(DEFAULT_ITEMS);
   const [query, setQuery] = useState('');
   const [suggest, setSuggest] = useState('');
   const mirrorRef = useRef(null);
   const [offset, setOffset] = useState(0);
+  const [showForm, setShowForm] = useState(false);
+
+  useEffect(() => {
+    try {
+      const stored = JSON.parse(localStorage.getItem('customItems')) || [];
+      setItems([...DEFAULT_ITEMS, ...stored.map((i) => i.type)]);
+    } catch {
+      setItems(DEFAULT_ITEMS);
+    }
+  }, []);
 
   useEffect(() => {
     if (!query) {
       setSuggest('');
       return;
     }
-    const match = ITEMS.find((i) => i.startsWith(query.toLowerCase()));
+      const match = items.find((i) => i.startsWith(query.toLowerCase()));
     if (match && match !== query.toLowerCase()) {
       setSuggest(match.slice(query.length));
     } else {
@@ -31,12 +43,12 @@ const ItemGenerator = ({ onGenerate }) => {
 
   const handleGenerate = () => {
     const type = query.toLowerCase();
-    if (ITEMS.includes(type)) {
-      onGenerate(type);
-      setQuery('');
-      setSuggest('');
-    }
-  };
+      if (items.includes(type)) {
+        onGenerate(type);
+        setQuery('');
+        setSuggest('');
+      }
+    };
 
   const handleKeyDown = (e) => {
     if (e.key === 'Tab' && suggest) {
@@ -48,42 +60,59 @@ const ItemGenerator = ({ onGenerate }) => {
     }
   };
 
-  return (
-    <div className="flex flex-col sm:flex-row sm:items-center gap-2">
-      <div className="relative flex-1">
-        <Input
-          className="w-full text-black bg-transparent relative z-10"
-          placeholder="Buscar objeto"
-          value={query}
-          onChange={(e) => setQuery(e.target.value)}
-          onKeyDown={handleKeyDown}
-        />
-        {suggest && (
-          <>
-            <span
-              ref={mirrorRef}
-              className="absolute left-4 top-1/2 -translate-y-1/2 invisible whitespace-pre"
-            >
-              {query}
-            </span>
-            <span
-              className="absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 pointer-events-none"
-              style={{ marginLeft: offset }}
-            >
-              {suggest}
-            </span>
-          </>
+    return (
+      <div className="flex flex-col sm:flex-row sm:items-center gap-2">
+        <div className="relative flex-1">
+          <Input
+            className="w-full text-black bg-transparent relative z-10"
+            placeholder="Buscar objeto"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            onKeyDown={handleKeyDown}
+          />
+          {suggest && (
+            <>
+              <span
+                ref={mirrorRef}
+                className="absolute left-4 top-1/2 -translate-y-1/2 invisible whitespace-pre"
+              >
+                {query}
+              </span>
+              <span
+                className="absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 pointer-events-none"
+                style={{ marginLeft: offset }}
+              >
+                {suggest}
+              </span>
+            </>
+          )}
+        </div>
+        <button
+          onClick={handleGenerate}
+          className="bg-blue-600 text-white px-3 py-1 rounded"
+        >
+          Generar
+        </button>
+        <button
+          onClick={() => setShowForm(true)}
+          className="bg-green-600 text-white px-3 py-1 rounded"
+        >
+          Nuevo
+        </button>
+        {showForm && (
+          <CustomItemForm
+            onSave={(item) => {
+              const stored = JSON.parse(localStorage.getItem('customItems') || '[]');
+              localStorage.setItem('customItems', JSON.stringify([...stored, item]));
+              setItems((prev) => [...prev, item.type]);
+              setShowForm(false);
+            }}
+            onCancel={() => setShowForm(false)}
+          />
         )}
       </div>
-      <button
-        onClick={handleGenerate}
-        className="bg-blue-600 text-white px-3 py-1 rounded"
-      >
-        Generar
-      </button>
-    </div>
-  );
-};
+    );
+  };
 
 ItemGenerator.propTypes = {
   onGenerate: PropTypes.func.isRequired,

--- a/src/components/inventory/ItemToken.jsx
+++ b/src/components/inventory/ItemToken.jsx
@@ -7,55 +7,106 @@ export const ItemTypes = {
   TOKEN: 'token'
 };
 
-const icons = {
+const defaultIcons = {
   remedio: '💊',
   chatarra: '⚙️',
   comida: '🍖',
   polvora: '💥',
 };
 
-const colors = {
+const defaultColors = {
   remedio: 'bg-blue-300',
   chatarra: 'bg-yellow-300',
   comida: 'bg-green-300',
   polvora: 'bg-gray-400',
 };
 
-const gradients = {
+const defaultGradients = {
   remedio: 'from-blue-200 via-blue-400 to-blue-200',
   chatarra: 'from-yellow-200 via-yellow-400 to-yellow-200',
   comida: 'from-green-200 via-green-400 to-green-200',
   polvora: 'from-gray-300 via-gray-500 to-gray-300',
 };
 
-const borders = {
+const defaultBorders = {
   remedio: 'border-blue-400',
   chatarra: 'border-yellow-400',
   comida: 'border-green-400',
   polvora: 'border-gray-500',
 };
 
-const descriptions = {
+const defaultDescriptions = {
   remedio: 'Un remedio curativo',
   chatarra: 'Partes de recambio variadas',
   comida: 'Provisiones comestibles',
   polvora: 'Material explosivo en polvo',
 };
 
+const lighten = (hex, amt) => {
+  let num = parseInt(hex.slice(1), 16);
+  let r = (num >> 16) + amt;
+  let g = ((num >> 8) & 0x00ff) + amt;
+  let b = (num & 0x0000ff) + amt;
+  r = Math.max(Math.min(255, r), 0);
+  g = Math.max(Math.min(255, g), 0);
+  b = Math.max(Math.min(255, b), 0);
+  return `#${(b | (g << 8) | (r << 16)).toString(16).padStart(6, '0')}`;
+};
+
+const getCustomMap = () => {
+  try {
+    const arr = JSON.parse(localStorage.getItem('customItems')) || [];
+    return arr.reduce((acc, it) => {
+      acc[it.type] = it;
+      return acc;
+    }, {});
+  } catch {
+    return {};
+  }
+};
+
 const ItemToken = ({ id, type = 'remedio', count = 1, fromSlot = null }) => {
   const [{ isDragging }, drag] = useDrag(() => ({
-    type: ItemTypes.TOKEN,
-    item: { id, type, count, fromSlot },
-    collect: (monitor) => ({
-      isDragging: monitor.isDragging(),
-    }),
-  }), [id, type, count, fromSlot]);
+      type: ItemTypes.TOKEN,
+      item: { id, type, count, fromSlot },
+      collect: (monitor) => ({
+        isDragging: monitor.isDragging(),
+      }),
+    }), [id, type, count, fromSlot]);
 
+  const customMap = getCustomMap();
+  const custom = customMap[type];
   const opacity = isDragging ? 0.5 : 1;
-  const bg = colors[type] || 'bg-gray-300';
-  const gradient = gradients[type] || 'from-gray-300 via-gray-400 to-gray-300';
-  const border = borders[type] || 'border-gray-300';
   const dragStyle = isDragging ? 'scale-110 rotate-6' : 'hover:scale-105';
+
+  if (custom) {
+    const light = lighten(custom.color, 40);
+    return (
+      <div
+        ref={drag}
+        className={`w-16 p-2 border-2 rounded shadow text-center select-none transition-transform ${dragStyle} bg-[length:200%_200%] animate-gradient animate-glow`}
+        style={{
+          opacity,
+          borderColor: custom.color,
+          backgroundImage: `linear-gradient(135deg, ${light}, ${custom.color}, ${light})`,
+        }}
+        data-tooltip-id={`item-${id}`}
+        data-tooltip-content={custom.description}
+      >
+        {custom.icon?.startsWith('data:') ? (
+          <img src={custom.icon} alt={type} className="w-8 h-8 mx-auto" />
+        ) : (
+          <div className="text-black text-2xl">{custom.icon || '❔'}</div>
+        )}
+        <div className="mt-1 text-sm bg-white text-black rounded-full px-2 inline-block">{count}</div>
+        <Tooltip id={`item-${id}`} place="top" className="max-w-[90vw] sm:max-w-xs" />
+      </div>
+    );
+  }
+
+  const bg = defaultColors[type] || 'bg-gray-300';
+  const gradient = defaultGradients[type] || 'from-gray-300 via-gray-400 to-gray-300';
+  const border = defaultBorders[type] || 'border-gray-300';
 
   return (
     <div
@@ -63,9 +114,9 @@ const ItemToken = ({ id, type = 'remedio', count = 1, fromSlot = null }) => {
       className={`w-16 p-2 ${bg} ${border} border-2 rounded shadow text-center select-none transition-transform ${dragStyle} bg-gradient-to-r ${gradient} bg-[length:200%_200%] animate-gradient animate-glow`}
       style={{ opacity }}
       data-tooltip-id={`item-${id}`}
-      data-tooltip-content={descriptions[type]}
+      data-tooltip-content={defaultDescriptions[type]}
     >
-      <div className="text-black text-2xl">{icons[type] || '❔'}</div>
+      <div className="text-black text-2xl">{defaultIcons[type] || '❔'}</div>
       <div className="mt-1 text-sm bg-white text-black rounded-full px-2 inline-block">{count}</div>
       <Tooltip id={`item-${id}`} place="top" className="max-w-[90vw] sm:max-w-xs" />
     </div>

--- a/src/components/inventory/ItemToken.test.js
+++ b/src/components/inventory/ItemToken.test.js
@@ -3,6 +3,10 @@ import ItemToken from './ItemToken';
 
 jest.mock('react-dnd', () => ({ useDrag: () => [{}, () => {}] }));
 
+beforeEach(() => {
+  localStorage.clear();
+});
+
 test('renders icon and count', () => {
   const { getByText } = render(<ItemToken id="1" type="comida" count={2} />);
   getByText('🍖');
@@ -12,5 +16,15 @@ test('renders icon and count', () => {
 test('supports new polvora type', () => {
   const { getByText } = render(<ItemToken id="2" type="polvora" count={1} />);
   getByText('💥');
+  getByText('1');
+});
+
+test('renders custom item from localStorage', () => {
+  localStorage.setItem(
+    'customItems',
+    JSON.stringify([{ type: 'gema', icon: '💎', description: 'Una gema', color: '#00ff00' }])
+  );
+  const { getByText } = render(<ItemToken id="3" type="gema" count={1} />);
+  getByText('💎');
   getByText('1');
 });


### PR DESCRIPTION
## Summary
- add form to create custom inventory items with icon, description and color
- allow generating custom items from master tools
- render custom items with dynamic gradient and icons

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b2eb9cc6083269e933fe28846f536