### PR TITLE
fix: skip base lucide icon to prevent picker crash

### DIFF
--- a/README.md
+++ b/README.md
@@ -1472,6 +1472,10 @@ src/
 
 - El formulario de objetos personalizados permite seleccionar iconos SVG de la librería Lucide.
 
+**Resumen de cambios v2.4.41:**
+
+- Corrección del selector de iconos Lucide evitando el error `iconNode is undefined` al abrirlo.
+
 ## 🔄 Historial de cambios previos
 
 <details>

--- a/src/components/LucideIconPicker.jsx
+++ b/src/components/LucideIconPicker.jsx
@@ -2,7 +2,13 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import * as icons from 'lucide-react';
 
-const iconList = Object.keys(icons).filter((name) => /^[A-Z]/.test(name));
+// The lucide-react package also exports a base `Icon` component which expects an
+// `iconNode` prop. Rendering this component without the prop (as we do when
+// listing all icons) causes a runtime error. Filter it out from the list of
+// icon names so only valid icon components are shown in the picker.
+const iconList = Object.keys(icons).filter(
+  (name) => /^[A-Z]/.test(name) && name !== 'Icon'
+);
 
 const LucideIconPicker = ({ onSelect }) => {
   const [query, setQuery] = useState('');


### PR DESCRIPTION
## Summary
- ignore lucide-react's base `Icon` when listing SVG icons to avoid `iconNode is undefined`
- document the fix in the changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689e24d0974c8326b792f5f9d5cb958e