### PR TITLE
Permitir código hex en color de objetos personalizados

### DIFF
--- a/README.md
+++ b/README.md
@@ -1484,6 +1484,10 @@ src/
 
 - "Comida" aparece entre los objetos predeterminados del gestor de objetos personalizados.
 
+**Resumen de cambios v2.4.44:**
+
+- El editor de color para objetos de inventario personalizados permite ingresar códigos hexadecimales.
+
 ## 🔄 Historial de cambios previos
 
 <details>

--- a/src/components/inventory/CustomItemForm.jsx
+++ b/src/components/inventory/CustomItemForm.jsx
@@ -150,12 +150,27 @@ const CustomItemForm = ({ onSave, onCancel, initial = null }) => {
       </div>
       <div className="flex flex-col sm:flex-row items-center gap-2">
         <label className="text-sm">Color:</label>
-        <input
-          type="color"
-          value={color}
-          onChange={(e) => setColor(e.target.value)}
-          className="w-10 h-6 rounded border-0 p-0"
-        />
+        <div className="flex items-center gap-2">
+          <input
+            type="color"
+            value={color}
+            onChange={(e) => setColor(e.target.value)}
+            className="w-10 h-6 rounded border-0 p-0"
+          />
+          <Input
+            value={color}
+            onChange={(e) => {
+              const value = e.target.value;
+              if (value === '' || /^#([0-9a-fA-F]{0,6})$/.test(value)) {
+                setColor(value);
+              }
+            }}
+            size="sm"
+            className="w-24"
+            maxLength={7}
+            placeholder="#ffffff"
+          />
+        </div>
       </div>
       <div className="flex flex-col sm:flex-row gap-2 sm:justify-end">
         <Boton type="button" onClick={onCancel} color="gray" size="sm" className="w-full sm:w-auto">

--- a/src/components/inventory/CustomItemManager.test.js
+++ b/src/components/inventory/CustomItemManager.test.js
@@ -53,10 +53,15 @@ test('edits an item', async () => {
   const nameInput = await screen.findByPlaceholderText('Nombre');
   await userEvent.clear(nameInput);
   await userEvent.type(nameInput, 'Perla');
+  const colorInput = screen.getByPlaceholderText('#ffffff');
+  await userEvent.clear(colorInput);
+  await userEvent.type(colorInput, '#123abc');
   await userEvent.click(screen.getByText('Guardar'));
   await screen.findByText('Perla');
   const call = setDoc.mock.calls[0];
-  expect(call[1]).toEqual(expect.objectContaining({ name: 'Perla' }));
+  expect(call[1]).toEqual(
+    expect.objectContaining({ name: 'Perla', color: '#123abc' })
+  );
 });
 
 test('deletes an item', async () => {


### PR DESCRIPTION
## Summary
- Añade un campo de texto para introducir códigos hex en el editor de objetos personalizados
- Actualiza las pruebas de edición para cubrir el nuevo campo
- Documenta la nueva opción de color en el README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a06a8c5fa08326a0fbabda7a3711ec