### PR TITLE
Ajusta modales de enemigos para vista móvil

### DIFF
--- a/README.md
+++ b/README.md
@@ -1512,6 +1512,10 @@ src/
 
 - La vista de enemigos permite buscar por nombre o descripción y ordenar las fichas alfabéticamente o por nivel.
 
+**Resumen de cambios v2.4.51:**
+
+- Las fichas de enemigos ocupan toda la pantalla en móviles y permiten desplazarse cuando el contenido supera la altura.
+
 ## 🔄 Historial de cambios previos
 
 <details>

--- a/src/components/EnemySheet.jsx
+++ b/src/components/EnemySheet.jsx
@@ -33,9 +33,9 @@ const EnemySheet = ({ enemy, onClose, onSave }) => {
   };
 
   const content = (
-    <div className="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50" onClick={onClose}>
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50" onClick={onClose}>
       <div
-        className="bg-gray-800 border border-gray-700 rounded shadow-xl max-w-[80vw] max-h-[70vh] overflow-auto p-6"
+        className="bg-gray-800 border border-gray-700 rounded shadow-xl w-full h-full sm:max-w-[80vw] sm:max-h-[70vh] overflow-y-auto p-2 sm:p-6"
         onClick={e => e.stopPropagation()}
       >
         <div className="flex items-center justify-between mb-4">

--- a/src/components/EnemyViewModal.jsx
+++ b/src/components/EnemyViewModal.jsx
@@ -76,7 +76,7 @@ const EnemyViewModal = ({ enemy, onClose, onEdit, highlightText = (t) => t, floa
   const windowBox = (
     <div
       ref={modalRef}
-      className="fixed bg-gray-800 rounded-xl p-6 max-w-6xl w-full max-h-[90vh] overflow-y-auto select-none pointer-events-auto"
+      className="fixed bg-gray-800 rounded-xl w-full h-full sm:max-w-[80vw] sm:max-h-[70vh] overflow-y-auto p-2 sm:p-6 select-none pointer-events-auto"
       style={{ top: pos.y, left: pos.x, zIndex: 1000 }}
       onClick={(e) => e.stopPropagation()}
       onPointerDownCapture={(e) => e.stopPropagation()}


### PR DESCRIPTION
## Summary
- Permite que las fichas de enemigos ocupen todo el ancho y alto en móviles con desplazamiento vertical
- Ajusta la vista de enemigo para mantener el contenido centrado en escritorio
- Documenta la mejora de responsividad en el README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a5b1b287f88326ad2712d4deb431ff