### PR TITLE
Fix minimap icon pickers and cell delete style

### DIFF
--- a/README.md
+++ b/README.md
@@ -1583,5 +1583,7 @@ Este proyecto está bajo la Licencia MIT. Ver `LICENSE` para más detalles.
 - Elimina celdas de forma intuitiva: botón “−” en la celda seleccionada o modo “Editar forma”. En móvil, mantener pulsado sobre una celda activa para eliminarla.
 - Control de escala: Auto‑ajustar (por defecto en móvil) evita romper el responsive cuando crece el número de celdas; disponible control de Zoom manual.
 - Nuevo toggle “Modo legible”: engrosa temporalmente las líneas del grid para mejorar la lectura en móviles o a escalas bajas.
+- Buscadores de emojis y Lucide con listado completo de iconos cargados localmente.
+- Botón de eliminación de celdas sin fondo, solo la “X” roja.
 
 Guía rápida: ver `docs/Minimapa.md`.

--- a/src/App.js
+++ b/src/App.js
@@ -438,7 +438,6 @@ function App() {
   const [estados, setEstados] = useState([]);
   // Estados para fichas de enemigos
   const [enemies, setEnemies] = useState([]);
-  const [enemySearch, setEnemySearch] = useState({ term: '', sort: '' });
   const [selectedEnemy, setSelectedEnemy] = useState(null);
   const [showEnemyForm, setShowEnemyForm] = useState(false);
   const [editingEnemy, setEditingEnemy] = useState(null);
@@ -4332,17 +4331,13 @@ function App() {
   }
   if (userType === 'master' && authenticated && chosenView === 'enemies') {
     const filteredEnemies = enemies.filter((enemy) =>
-      enemy.name.toLowerCase().includes(enemySearch.term.toLowerCase()) ||
-      (enemy.description || '')
-        .toLowerCase()
-        .includes(enemySearch.term.toLowerCase())
+      enemy.name.toLowerCase().includes(enemySearch.toLowerCase()) ||
+      (enemy.description || '').toLowerCase().includes(enemySearch.toLowerCase())
     );
     const sortedEnemies =
-      enemySearch.sort === 'alpha'
-        ? [...filteredEnemies].sort((a, b) =>
-            a.name.localeCompare(b.name)
-          )
-        : enemySearch.sort === 'level'
+      enemySort === 'alpha'
+        ? [...filteredEnemies].sort((a, b) => a.name.localeCompare(b.name))
+        : enemySort === 'level'
         ? [...filteredEnemies].sort((a, b) => (a.nivel || 0) - (b.nivel || 0))
         : filteredEnemies;
     return (


### PR DESCRIPTION
## Summary
- Load Lucide icons locally and add search boxes for emoji and Lucide pickers in minimap builder
- Remove red background from cell delete button, leaving only red X
- Clean up duplicate enemy search state to fix tests
- Document minimap icon picker improvements in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bde08df73c8326b8b2b336802586ba