### PR TITLE
feat: text style presets and bulk edits

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 - **Muros dibujables** - Herramienta para crear y alargar segmentos arrastrando antes de guardarlos. Se corrige un error que impedía dibujarlos correctamente.
 - **Cuadros de texto personalizables** - Se crean al instante con fondo opcional; muévelos, redimensiónalos y edítalos con doble clic usando diversas fuentes
 - **Edición directa de textos** - Tras crearlos o seleccionarlos puedes escribir directamente y el cuadro se adapta al contenido
+- **Gestión de estilos de texto** - Guarda estilos, aplícalos a múltiples cuadros y restablece cambios fácilmente
 - **Notas en Ajustes de ficha** - Editor enriquecido para que jugadores y máster anoten información sobre el token con opciones de alineado de texto
 - **Selector de iconos optimizado** - Los iconos de Lucide y los emojis se generan localmente y se cargan más rápido; además, el botón «+» para crear celdas queda centrado
 - **Buscador de emojis bilingüe** - El minimapa permite buscar emojis tanto en inglés como en español

--- a/src/components/Toolbar.jsx
+++ b/src/components/Toolbar.jsx
@@ -61,6 +61,10 @@ const Toolbar = ({
   onMeasureVisibleChange,
   textOptions,
   onTextOptionsChange,
+  onResetTextOptions,
+  stylePresets = [],
+  onSaveStylePreset,
+  onApplyStylePreset,
   activeLayer = 'fichas',
   onLayerChange,
   isPlayerView = false,
@@ -318,6 +322,41 @@ const Toolbar = ({
               S
             </button>
           </div>
+          <div className="flex space-x-1 mt-2">
+            <button
+              onClick={onResetTextOptions}
+              className="px-2 py-1 rounded text-xs bg-gray-600"
+            >
+              Reset
+            </button>
+            <button
+              onClick={onSaveStylePreset}
+              className="px-2 py-1 rounded text-xs bg-gray-600"
+            >
+              Guardar
+            </button>
+          </div>
+          {stylePresets.length > 0 && (
+            <div className="mt-2">
+              <div className="text-xs mb-1">Guardados</div>
+              <div className="flex space-x-2 overflow-x-auto pb-1">
+                {stylePresets.map((preset, idx) => (
+                  <button
+                    key={idx}
+                    onClick={() => onApplyStylePreset && onApplyStylePreset(preset)}
+                    className="w-8 h-8 flex-shrink-0 rounded border flex items-center justify-center"
+                    style={{
+                      backgroundColor: preset.bgColor,
+                      color: preset.fill,
+                      fontFamily: preset.fontFamily,
+                    }}
+                  >
+                    A
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
         </motion.div>
       )}
     </AnimatePresence>
@@ -348,6 +387,21 @@ Toolbar.propTypes = {
     underline: PropTypes.bool,
   }),
   onTextOptionsChange: PropTypes.func,
+  onResetTextOptions: PropTypes.func,
+  stylePresets: PropTypes.arrayOf(
+    PropTypes.shape({
+      text: PropTypes.string,
+      fill: PropTypes.string,
+      bgColor: PropTypes.string,
+      fontFamily: PropTypes.string,
+      fontSize: PropTypes.number,
+      bold: PropTypes.bool,
+      italic: PropTypes.bool,
+      underline: PropTypes.bool,
+    })
+  ),
+  onSaveStylePreset: PropTypes.func,
+  onApplyStylePreset: PropTypes.func,
   activeLayer: PropTypes.string,
   onLayerChange: PropTypes.func,
   isPlayerView: PropTypes.bool,


### PR DESCRIPTION
## Summary
- allow resetting text style to defaults
- update multiple text boxes at once with saved presets
- list saved styles for quick apply on mobile

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bebd3a3a708326b0b69d23e890d6d6