### PR TITLE
feat: text style presets and bulk edits

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 - **Muros dibujables** - Herramienta para crear y alargar segmentos arrastrando antes de guardarlos. Se corrige un error que impedía dibujarlos correctamente.
 - **Cuadros de texto personalizables** - Se crean al instante con fondo opcional; muévelos, redimensiónalos y edítalos con doble clic usando diversas fuentes
 - **Edición directa de textos** - Tras crearlos o seleccionarlos puedes escribir directamente y el cuadro se adapta al contenido
+- **Gestión de estilos de texto** - Al seleccionar un texto se despliega un panel para guardar estilos, aplicarlos en varios cuadros y restablecer cambios rápidamente
 - **Notas en Ajustes de ficha** - Editor enriquecido para que jugadores y máster anoten información sobre el token con opciones de alineado de texto
 - **Selector de iconos optimizado** - Los iconos de Lucide y los emojis se generan localmente y se cargan más rápido; además, el botón «+» para crear celdas queda centrado
 - **Buscador de emojis bilingüe** - El minimapa permite buscar emojis tanto en inglés como en español

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -1150,7 +1150,7 @@ const MapCanvas = ({
   // Estado para vista previa de pegado
   const [showPastePreview, setShowPastePreview] = useState(false);
 
-  const [textOptions, setTextOptions] = useState({
+  const DEFAULT_TEXT_OPTIONS = {
     fill: '#ffffff',
     bgColor: 'rgba(0,0,0,0.5)',
     fontFamily: 'Arial',
@@ -1158,7 +1158,58 @@ const MapCanvas = ({
     bold: false,
     italic: false,
     underline: false,
+  };
+  const [textOptions, setTextOptions] = useState(DEFAULT_TEXT_OPTIONS);
+  const [savedTextPresets, setSavedTextPresets] = useState(() => {
+    if (typeof window !== 'undefined') {
+      const stored = localStorage.getItem('text-presets');
+      return stored ? JSON.parse(stored) : [];
+    }
+    return [];
   });
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('text-presets', JSON.stringify(savedTextPresets));
+    }
+  }, [savedTextPresets]);
+
+  const applyTextOptions = useCallback((opts) => {
+    setTextOptions(opts);
+    if (selectedTextId != null || selectedTexts.length > 0) {
+      const ids = selectedTexts.length > 0 ? selectedTexts : [selectedTextId];
+      updateTexts(ts =>
+        ts.map(t => (ids.includes(t.id) ? { ...t, ...opts } : t))
+      );
+    }
+  }, [selectedTextId, selectedTexts, updateTexts]);
+
+  const resetTextOptions = useCallback(() => {
+    applyTextOptions(DEFAULT_TEXT_OPTIONS);
+  }, [applyTextOptions]);
+
+  const saveCurrentTextPreset = useCallback(() => {
+    if (selectedTextId != null) {
+      const t = texts.find(t => t.id === selectedTextId);
+      if (t) setSavedTextPresets(prev => [...prev, t]);
+    } else {
+      setSavedTextPresets(prev => [...prev, { text: '', ...textOptions }]);
+    }
+  }, [selectedTextId, texts, textOptions]);
+
+  const applyTextPreset = useCallback((preset) => {
+    const { text, ...opts } = preset;
+    setTextOptions(opts);
+    if (selectedTextId != null || selectedTexts.length > 0) {
+      const ids = selectedTexts.length > 0 ? selectedTexts : [selectedTextId];
+      updateTexts(ts =>
+        ts.map(t => (ids.includes(t.id) ? { ...t, ...preset } : t))
+      );
+    }
+  }, [selectedTextId, selectedTexts, updateTexts]);
+
+  const textMenuVisible =
+    activeTool === 'text' || selectedTextId != null || selectedTexts.length > 0;
+
   const [drawColor, setDrawColor] = useState('#ffffff');
   const [brushSize, setBrushSize] = useState('medium');
   const [activeLayer, setActiveLayer] = useState(propActiveLayer);
@@ -4747,7 +4798,12 @@ const MapCanvas = ({
         measureVisible={measureVisible}
         onMeasureVisibleChange={setMeasureVisible}
         textOptions={textOptions}
-        onTextOptionsChange={setTextOptions}
+        onTextOptionsChange={applyTextOptions}
+        onResetTextOptions={resetTextOptions}
+        stylePresets={savedTextPresets}
+        onSaveStylePreset={saveCurrentTextPreset}
+        onApplyStylePreset={applyTextPreset}
+        showTextMenu={textMenuVisible}
         activeLayer={activeLayer}
         onLayerChange={handleLayerChange}
         isPlayerView={isPlayerView}

--- a/src/components/Toolbar.jsx
+++ b/src/components/Toolbar.jsx
@@ -61,6 +61,11 @@ const Toolbar = ({
   onMeasureVisibleChange,
   textOptions,
   onTextOptionsChange,
+  onResetTextOptions,
+  stylePresets = [],
+  onSaveStylePreset,
+  onApplyStylePreset,
+  showTextMenu = false,
   activeLayer = 'fichas',
   onLayerChange,
   isPlayerView = false,
@@ -211,7 +216,7 @@ const Toolbar = ({
           </div>
         </motion.div>
       )}
-      {activeTool === 'text' && (
+      {showTextMenu && (
         <motion.div
           key="text-menu"
           initial={{ opacity: 0, x: -10 }}
@@ -318,6 +323,41 @@ const Toolbar = ({
               S
             </button>
           </div>
+          <div className="flex space-x-1 mt-2">
+            <button
+              onClick={onResetTextOptions}
+              className="px-2 py-1 rounded text-xs bg-gray-600"
+            >
+              Reset
+            </button>
+            <button
+              onClick={onSaveStylePreset}
+              className="px-2 py-1 rounded text-xs bg-gray-600"
+            >
+              Guardar
+            </button>
+          </div>
+          {stylePresets.length > 0 && (
+            <div className="mt-2">
+              <div className="text-xs mb-1">Guardados</div>
+              <div className="flex space-x-2 overflow-x-auto pb-1">
+                {stylePresets.map((preset, idx) => (
+                  <button
+                    key={idx}
+                    onClick={() => onApplyStylePreset && onApplyStylePreset(preset)}
+                    className="w-8 h-8 flex-shrink-0 rounded border flex items-center justify-center"
+                    style={{
+                      backgroundColor: preset.bgColor,
+                      color: preset.fill,
+                      fontFamily: preset.fontFamily,
+                    }}
+                  >
+                    A
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
         </motion.div>
       )}
     </AnimatePresence>
@@ -348,6 +388,22 @@ Toolbar.propTypes = {
     underline: PropTypes.bool,
   }),
   onTextOptionsChange: PropTypes.func,
+  onResetTextOptions: PropTypes.func,
+  stylePresets: PropTypes.arrayOf(
+    PropTypes.shape({
+      text: PropTypes.string,
+      fill: PropTypes.string,
+      bgColor: PropTypes.string,
+      fontFamily: PropTypes.string,
+      fontSize: PropTypes.number,
+      bold: PropTypes.bool,
+      italic: PropTypes.bool,
+      underline: PropTypes.bool,
+    })
+  ),
+  onSaveStylePreset: PropTypes.func,
+  onApplyStylePreset: PropTypes.func,
+  showTextMenu: PropTypes.bool,
   activeLayer: PropTypes.string,
   onLayerChange: PropTypes.func,
   isPlayerView: PropTypes.bool,


### PR DESCRIPTION
## Summary
- show text style panel whenever a text element is selected
- manage style presets directly from panel for multiple text boxes
- document automatic panel display in README

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bebd3a3a708326b0b69d23e890d6d6