### PR TITLE
fix: keep text when applying style presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1401,6 +1401,10 @@ src/
 - La luz tenue aplica ahora el 80% de la intensidad configurada, evitando contrastes irreales.
 - La luz brillante emplea el 100% de la intensidad seleccionada para asegurar que nunca sea menos intensa que la tenue.
 
+**Resumen de cambios v2.4.77:**
+
+- Aplicar un estilo de texto guardado ya no reemplaza el contenido del cuadro y puede aplicarse a múltiples textos, manteniendo la opción de restablecer los cambios.
+
 **Resumen de cambios v2.4.25:**
 
 - ✅ El menú de ataque y defensa solo muestra armas o poderes al alcance

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -1197,12 +1197,13 @@ const MapCanvas = ({
   }, [selectedTextId, texts, textOptions]);
 
   const applyTextPreset = useCallback((preset) => {
-    const { text, ...opts } = preset;
+    // Ignore stored text content when applying style presets
+    const { text: _text, ...opts } = preset;
     setTextOptions(opts);
     if (selectedTextId != null || selectedTexts.length > 0) {
       const ids = selectedTexts.length > 0 ? selectedTexts : [selectedTextId];
       updateTexts(ts =>
-        ts.map(t => (ids.includes(t.id) ? { ...t, ...preset } : t))
+        ts.map(t => (ids.includes(t.id) ? { ...t, ...opts } : t))
       );
     }
   }, [selectedTextId, selectedTexts, updateTexts]);


### PR DESCRIPTION
## Summary
- avoid overriding text content when applying saved style presets to multiple map text boxes
- document the text style preset fix in the changelog

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68bec3a875b48326a7293cf0253aaae5