### PR TITLE
fix: reorder updateTexts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1405,6 +1405,10 @@ src/
 
 - Aplicar un estilo de texto guardado ya no reemplaza el contenido del cuadro y puede aplicarse a múltiples textos, manteniendo la opción de restablecer los cambios.
 
+**Resumen de cambios v2.4.78:**
+
+- Se reordena la función `updateTexts` en **MapCanvas** para evitar errores de compilación.
+
 **Resumen de cambios v2.4.25:**
 
 - ✅ El menú de ataque y defensa solo muestra armas o poderes al alcance

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -1060,6 +1060,21 @@ const MapCanvas = ({
   const [texts, setTexts] = useState(propTexts);
   const [selectedTextId, setSelectedTextId] = useState(null);
 
+  const handleTextsChange = useCallback((newTexts) => {
+    if (isPlayerView && syncManager) {
+      syncManager.saveToFirebase('texts', newTexts);
+    }
+    onTextsChange(newTexts);
+  }, [isPlayerView, syncManager, onTextsChange]);
+
+  const updateTexts = useCallback((updater) => {
+    setTexts((prev) => {
+      const next = typeof updater === 'function' ? updater(prev) : updater;
+      handleTextsChange(next);
+      return next;
+    });
+  }, [handleTextsChange]);
+
   // Estados para sistema de ataque
   const [attackSourceId, setAttackSourceId] = useState(null);
   const attackSourceIdRef = useRef(null);
@@ -1380,13 +1395,6 @@ const MapCanvas = ({
     }
     onWallsChange(newWalls);
   }, [isPlayerView, syncManager, onWallsChange]);
-
-  const handleTextsChange = useCallback((newTexts) => {
-    if (isPlayerView && syncManager) {
-      syncManager.saveToFirebase('texts', newTexts);
-    }
-    onTextsChange(newTexts);
-  }, [isPlayerView, syncManager, onTextsChange]);
 
   const [simulatedPlayer, setSimulatedPlayer] = useState('');
   const [activeTokenId, setActiveTokenId] = useState(null);
@@ -2549,14 +2557,6 @@ const MapCanvas = ({
       return next;
     });
   }, [handleWallsChange]);
-
-  const updateTexts = useCallback((updater) => {
-    setTexts((prev) => {
-      const next = typeof updater === 'function' ? updater(prev) : updater;
-      handleTextsChange(next);
-      return next;
-    });
-  }, [handleTextsChange]);
 
   const undoLines = useCallback(() => {
     setLines((prev) => {


### PR DESCRIPTION
## Summary
- move `handleTextsChange` and `updateTexts` before text option callbacks to avoid reference before initialization
- document change in README

## Testing
- `npm test -- --watchAll=false`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bed138e4b88326b72285e3f5f7825c