### PR TITLE
feat: save minimap quadrants and fix grid selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1536,6 +1536,12 @@ src/
 
 - Los cuadros del minimapa pueden restablecer su estilo al predeterminado.
 
+**Resumen de cambios v2.4.54:**
+
+- Activar "Editar forma" selecciona todas las celdas para aplicar estilos globales.
+- Los botones "+" del minimapa ya no quedan flotando tras eliminar celdas adyacentes.
+- Se pueden guardar cuadrantes completos con título y cargarlos desde el constructor.
+
 ## 🔄 Historial de cambios previos
 
 <details>


### PR DESCRIPTION
## Summary
- auto-select all cells when enabling shape edit on minimap
- allow saving/loading titled quadrants and show them below icon picker
- trim empty rows/cols after removing cells to prevent floating add buttons

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68bf23ac794883268cc825ad1fab2929