### PR TITLE
feat: add zoom and pan to minimap builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1547,6 +1547,10 @@ src/
 - Guardar o cargar cuadrantes ya no requiere tener celdas seleccionadas.
 - Los cuadrantes guardados muestran una mini previsualización para su identificación.
 
+**Resumen de cambios v2.4.56:**
+
+- El constructor de minimapas permite hacer zoom y desplazarse con rueda del ratón o gestos táctiles y añade un botón "Reset" para volver a la vista inicial.
+
 ## 🔄 Historial de cambios previos
 
 <details>


### PR DESCRIPTION
## Summary
- add wheel and touch handlers with offset state for zooming and panning
- apply CSS translate and scale to minimap grid
- add Reset control and document change

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bf29b9b600832691958c26d39035ce