### PR TITLE
feat: save minimap annotations and add cell effects

### DIFF
--- a/README.md
+++ b/README.md
@@ -1552,6 +1552,12 @@ src/
 
 - El constructor de minimapas permite hacer zoom y desplazarse con rueda del ratón o gestos táctiles y añade un botón "Reset" para volver a la vista inicial.
 
+**Resumen de cambios v2.4.57:**
+
+- Las anotaciones del minimapa se guardan en Firebase y siempre se muestran sobre el cuadrante.
+- Se elimina el selector de capas para las anotaciones.
+- Se añaden efectos de celda (brillo o pulso) con color personalizable para destacar cuadros específicos.
+
 ## 🔄 Historial de cambios previos
 
 <details>

--- a/docs/Minimapa.md
+++ b/docs/Minimapa.md
@@ -9,6 +9,8 @@ Características:
 - Edición de celdas: color de fondo, borde independiente (color, ancho, estilo) e icono.
 - Selector de iconos basado en Estados existentes.
 - Iconos personalizados: sube imágenes desde tu equipo; se guardan en almacenamiento y quedan disponibles en el selector.
+- Anotaciones por celda con texto o icono que se guardan en Firebase y se muestran siempre por encima del cuadrante.
+- Efectos de celda opcionales (brillo o pulso) con color personalizable para destacar áreas.
 - Móvil: mantener pulsado sobre una celda activa para eliminarla rápidamente.
 
 Ubicación del código: `src/components/MinimapBuilder.jsx`.


### PR DESCRIPTION
## Summary
- persist minimap annotations to Firebase and load on start
- remove annotation layer controls
- add glow and pulse effects for cells with customizable color

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf486d473c83268c8c65947d0409d8