### PR TITLE
fix: close annotations map in MinimapBuilder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1635,3 +1635,4 @@ Guía rápida: ver `docs/Minimapa.md`.
 - Se corrigió un fallo en el constructor de minimapas donde `selectedCell` no estaba definido al aplicar presets o eliminar celdas.
 - Se solucionó un error en el mapa de batalla que provocaba un fallo al inicializar `syncManager` antes de su declaración.
 - Corregido error al aplicar presets de estilo en el minimapa que provocaba "next[r] is undefined".
+- Se corrigió un error de compilación causado por un corchete faltante en `MinimapBuilder.jsx`.

--- a/src/components/MinimapBuilder.jsx
+++ b/src/components/MinimapBuilder.jsx
@@ -1525,7 +1525,7 @@ function MinimapBuilder({ onBack }) {
                               )}
                             </div>
                           );
-                        })
+                        })}
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
## Summary
- fix build failure by closing `annotations.map` expression in MinimapBuilder
- document compile fix in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf4b00cfc08326a4206e2eb40be452