### PR TITLE
feat(minimap): add hex color input

### DIFF
--- a/README.md
+++ b/README.md
@@ -1627,6 +1627,7 @@ Este proyecto está bajo la Licencia MIT. Ver `LICENSE` para más detalles.
 - Buscadores de emojis y Lucide con listado completo de iconos cargados localmente.
 - Botón de eliminación de celdas sin fondo, solo la “X” roja.
 - Selección múltiple de celdas para editar o eliminar varias a la vez.
+- Selectores de color con opción de introducir valores HEX personalizados.
 
 Guía rápida: ver `docs/Minimapa.md`.
 

--- a/src/components/HexColorInput.jsx
+++ b/src/components/HexColorInput.jsx
@@ -1,0 +1,40 @@
+import { useState } from 'react';
+import PropTypes from 'prop-types';
+
+function HexColorInput({ value, onChange }) {
+  const [color, setColor] = useState(value || '#ffffff');
+
+  const handleColorChange = (e) => {
+    const v = e.target.value;
+    setColor(v);
+    onChange(v);
+  };
+
+  const handleHexChange = (e) => {
+    const v = e.target.value;
+    setColor(v);
+    if (/^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/.test(v)) {
+      onChange(v);
+    }
+  };
+
+  return (
+    <div className="flex items-center gap-1">
+      <input type="color" value={color} onChange={handleColorChange} />
+      <input
+        type="text"
+        value={color}
+        onChange={handleHexChange}
+        className="w-20 bg-gray-700 border border-gray-600 rounded px-1 py-0.5 text-xs text-white"
+      />
+    </div>
+  );
+}
+
+HexColorInput.propTypes = {
+  value: PropTypes.string.isRequired,
+  onChange: PropTypes.func.isRequired,
+};
+
+export default HexColorInput;
+

--- a/src/components/MinimapBuilder.jsx
+++ b/src/components/MinimapBuilder.jsx
@@ -8,6 +8,7 @@
 import PropTypes from 'prop-types';
 import Boton from './Boton';
 import { ESTADOS } from './EstadoSelector';
+import HexColorInput from './HexColorInput';
 import { getOrUploadFile } from '../utils/storage';
 import * as LucideIcons from 'lucide-react';
 import { renderToStaticMarkup } from 'react-dom/server';
@@ -885,24 +886,22 @@ function MinimapBuilder({ onBack }) {
                   <div className="grid grid-cols-2 gap-3 text-sm">
                     <label className="flex items-center gap-2">
                       <span>{L.color}</span>
-                      <input
-                        type="color"
+                      <HexColorInput
                         value={selected.fill}
-                        onChange={(e) =>
+                        onChange={(v) =>
                           updateCell(selectedCells, {
-                            fill: e.target.value,
+                            fill: v,
                           })
                         }
                       />
                     </label>
                     <label className="flex items-center gap-2">
                       <span>{L.border}</span>
-                      <input
-                        type="color"
+                      <HexColorInput
                         value={selected.borderColor}
-                        onChange={(e) =>
+                        onChange={(v) =>
                           updateCell(selectedCells, {
-                            borderColor: e.target.value,
+                            borderColor: v,
                           })
                         }
                       />
@@ -961,14 +960,13 @@ function MinimapBuilder({ onBack }) {
                     {selected.effect?.type !== 'none' && (
                       <label className="flex items-center gap-2 col-span-2">
                         <span>{L.effectColor}</span>
-                        <input
-                          type="color"
+                        <HexColorInput
                           value={selected.effect?.color || '#ffff00'}
-                          onChange={(e) =>
+                          onChange={(v) =>
                             updateCell(selectedCells, {
                               effect: {
                                 ...selected.effect,
-                                color: e.target.value,
+                                color: v,
                               },
                             })
                           }

--- a/src/components/WallDoorMenu.jsx
+++ b/src/components/WallDoorMenu.jsx
@@ -4,6 +4,7 @@ import { createPortal } from 'react-dom';
 import { FiX } from 'react-icons/fi';
 import { RiDoorOpenLine, RiDoorClosedLine, RiEyeOffLine } from 'react-icons/ri';
 import Boton from './Boton';
+import HexColorInput from './HexColorInput';
 
 const WallDoorMenu = ({ wall, onClose, onUpdate, isMaster = false }) => {
   const [door, setDoor] = useState(wall.door || 'closed');
@@ -75,12 +76,7 @@ const WallDoorMenu = ({ wall, onClose, onUpdate, isMaster = false }) => {
         </div>
         <div>
           <label className="block mb-1">Color del muro</label>
-          <input
-            type="color"
-            value={color}
-            onChange={(e) => handleColor(e.target.value)}
-            className="w-full h-8 p-0 border-0"
-          />
+          <HexColorInput value={color} onChange={handleColor} />
         </div>
         {isMaster && (
           <div className="space-y-2">


### PR DESCRIPTION
## Summary
- add `HexColorInput` component to allow manual hex codes
- use `HexColorInput` in minimap cell styling and wall menu
- document custom hex color option for minimap

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68bf547661a883269bbb1b46a5193086