### PR TITLE
feat(minimap): mejoras en cuadrantes y efectos visuales

### DIFF
--- a/README.md
+++ b/README.md
@@ -1558,6 +1558,13 @@ src/
 - Se elimina el selector de capas para las anotaciones.
 - Se añaden efectos de celda (brillo o pulso) con color personalizable para destacar cuadros específicos.
 
+**Resumen de cambios v2.4.58:**
+
+- El minimapa identifica el cuadrante cargado y permite guardar cambios, duplicar o eliminar cuadrantes.
+- Seleccionar un color de brillo ya no deselecciona la celda activa.
+- Los efectos de celda se muestran completos sobre las celdas adyacentes.
+- Nuevos efectos visuales disponibles: rebote, giro y temblor.
+
 ## 🔄 Historial de cambios previos
 
 <details>

--- a/src/index.css
+++ b/src/index.css
@@ -107,6 +107,24 @@ html {
   }
 }
 
+@keyframes shake {
+  0% {
+    transform: translateX(0);
+  }
+  25% {
+    transform: translateX(-2px);
+  }
+  50% {
+    transform: translateX(2px);
+  }
+  75% {
+    transform: translateX(-2px);
+  }
+  100% {
+    transform: translateX(0);
+  }
+}
+
 /* Clases de utilidad para animaciones */
 .animate-in {
   animation: fadeIn 0.5s ease-out;


### PR DESCRIPTION
## Summary
- Permite identificar el cuadrante cargado y guardar, duplicar o eliminar cuadrantes
- Evita que la selección se pierda al elegir color y superpone correctamente los efectos
- Añade efectos visuales adicionales como rebote, giro y temblor

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bf581a64248326804b3d843ebfa6ea