### PR TITLE
feat: add sparkle minimap effect and fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1319,7 +1319,7 @@ src/
 
 - "Subir cambios" ahora confirma antes de actualizar y avisa si la ficha no está enlazada.
 
-**Resumen de cambios v2.4.58:**
+**Resumen de cambios v2.4.59:**
 
 - Redimensionado de tokens sin snapping hasta soltar, para un ajuste más cómodo.
   **Resumen de cambios v2.4.59:**
@@ -1557,6 +1557,13 @@ src/
 - Las anotaciones del minimapa se guardan en Firebase y siempre se muestran sobre el cuadrante.
 - Se elimina el selector de capas para las anotaciones.
 - Se añaden efectos de celda (brillo o pulso) con color personalizable para destacar cuadros específicos.
+
+**Resumen de cambios v2.4.59:**
+
+- El texto de las anotaciones del minimapa se muestra centrado.
+- Nuevo efecto de celda "Destellos" con pequeñas partículas brillantes animadas.
+- La selección de celdas con efectos visuales se visualiza correctamente.
+- Los efectos de celdas no seleccionadas ya no se recortan por superposición con otras celdas.
 
 **Resumen de cambios v2.4.58:**
 

--- a/src/components/MinimapBuilder.jsx
+++ b/src/components/MinimapBuilder.jsx
@@ -53,6 +53,7 @@ const L = {
   bounce: 'Rebote',
   spin: 'Giro',
   shake: 'Temblor',
+  sparkle: 'Destellos',
   saveQuadrant: 'Guardar cuadrante',
   saveChanges: 'Guardar cambios',
   savedQuadrants: 'Cuadrantes guardados',
@@ -120,6 +121,67 @@ const QuadrantPreview = ({ q }) => {
   );
 };
 QuadrantPreview.propTypes = { q: PropTypes.object.isRequired };
+
+const SparkleEffect = ({ color }) => {
+  const particles = useMemo(
+    () =>
+      Array.from({ length: 6 }).map(() => ({
+        left: Math.random() * 100,
+        top: Math.random() * 100,
+        delay: Math.random(),
+      })),
+    []
+  );
+  return (
+    <div
+      className="absolute inset-0 pointer-events-none overflow-visible"
+      style={{ zIndex: 5 }}
+    >
+      {particles.map((p, i) => (
+        <span
+          // eslint-disable-next-line react/no-array-index-key
+          key={i}
+          className="absolute w-1 h-1 rounded-full opacity-80 animate-sparkle"
+          style={{
+            backgroundColor: color,
+            left: `${p.left}%`,
+            top: `${p.top}%`,
+            animationDelay: `${p.delay}s`,
+          }}
+        />
+      ))}
+    </div>
+  );
+};
+SparkleEffect.propTypes = {
+  color: PropTypes.string,
+};
+
+const EffectOverlay = ({ effect }) => {
+  if (!effect || effect.type === 'none') return null;
+  if (effect.type === 'glow' || effect.type === 'pulse') {
+    return (
+      <div
+        className="absolute inset-0 rounded pointer-events-none"
+        style={{
+          boxShadow: `0 0 10px 2px ${effect.color}`,
+          animation: effect.type === 'pulse' ? 'pulse 1.5s infinite' : undefined,
+          zIndex: -1,
+        }}
+      />
+    );
+  }
+  if (effect.type === 'sparkle') {
+    return <SparkleEffect color={effect.color} />;
+  }
+  return null;
+};
+EffectOverlay.propTypes = {
+  effect: PropTypes.shape({
+    type: PropTypes.string,
+    color: PropTypes.string,
+  }),
+};
 
 const defaultCell = () => ({
   fill: '#111827',
@@ -901,16 +963,15 @@ function MinimapBuilder({ onBack }) {
                                 borderColor: p.borderColor,
                                 borderWidth: p.borderWidth,
                                 borderStyle: p.borderStyle,
-                                boxShadow:
-                                  p.effect?.type === 'glow' || p.effect?.type === 'pulse'
-                                    ? `0 0 10px 2px ${p.effect.color}`
-                                    : undefined,
                                 animation:
                                   p.effect?.type === 'pulse'
                                     ? 'pulse 1.5s infinite'
                                     : undefined,
                               }}
                             >
+                              {p.effect?.type !== 'none' && (
+                                <EffectOverlay effect={p.effect} />
+                              )}
                               {p.icon && (
                                 <img
                                   src={p.icon}
@@ -999,6 +1060,7 @@ function MinimapBuilder({ onBack }) {
                         <option value="bounce">{L.bounce}</option>
                         <option value="spin">{L.spin}</option>
                         <option value="shake">{L.shake}</option>
+                        <option value="sparkle">{L.sparkle}</option>
                       </select>
                     </label>
                     {selected.effect?.type !== 'none' && (
@@ -1518,10 +1580,6 @@ function MinimapBuilder({ onBack }) {
                                   borderStyle: cell.borderStyle,
                                   width: `${cellSize}px`,
                                   height: `${cellSize}px`,
-                                  boxShadow:
-                                    cell.effect?.type === 'glow' || cell.effect?.type === 'pulse'
-                                      ? `0 0 10px 2px ${cell.effect.color}`
-                                      : undefined,
                                   animation:
                                     cell.effect?.type === 'pulse'
                                       ? 'pulse 1.5s infinite'
@@ -1532,14 +1590,16 @@ function MinimapBuilder({ onBack }) {
                                       : cell.effect?.type === 'shake'
                                       ? 'shake 0.5s infinite'
                                       : undefined,
-                                  zIndex:
-                                    isSelected
-                                      ? 20
-                                      : cell.effect?.type !== 'none'
-                                      ? 10
-                                      : undefined,
+                                  zIndex: isSelected
+                                    ? 30
+                                    : cell.effect?.type !== 'none'
+                                    ? 20
+                                    : 10,
                                 }}
                               >
+                                {cell.effect?.type !== 'none' && (
+                                  <EffectOverlay effect={cell.effect} />
+                                )}
                                 {cell.icon && (
                                   <img
                                     src={cell.icon}
@@ -1607,7 +1667,7 @@ function MinimapBuilder({ onBack }) {
                               <div className="absolute bottom-0 right-0 w-2 h-2 bg-emerald-400 rounded-full" />
                               {showTooltip && (
                                 <div className="absolute z-40 left-1/2 -translate-x-1/2 -translate-y-full mb-2 pointer-events-none">
-                                  <div className="relative px-2 py-1 bg-gray-900/90 text-white text-xs rounded-md shadow-lg whitespace-pre-line">
+                                  <div className="relative px-2 py-1 bg-gray-900/90 text-white text-xs rounded-md shadow-lg whitespace-pre-line text-center">
                                     {a.text}
                                     <div className="absolute left-1/2 top-full -translate-x-1/2 w-2 h-2 rotate-45 bg-gray-900/90" />
                                   </div>

--- a/src/index.css
+++ b/src/index.css
@@ -125,6 +125,21 @@ html {
   }
 }
 
+@keyframes sparkle {
+  0% {
+    transform: translateY(0) scale(1);
+    opacity: 1;
+  }
+  100% {
+    transform: translateY(-6px) scale(0.5);
+    opacity: 0;
+  }
+}
+
+.animate-sparkle {
+  animation: sparkle 1.2s linear infinite;
+}
+
 /* Clases de utilidad para animaciones */
 .animate-in {
   animation: fadeIn 0.5s ease-out;


### PR DESCRIPTION
## Summary
- center annotation text in minimap
- add sparkle effect with animated particles
- fix selection overlay and effect clipping for minimap cells

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf5b658b9c83268abaf29914bbd1d8