### PR TITLE
Improve minimap sparkle effect

### DIFF
--- a/README.md
+++ b/README.md
@@ -1651,3 +1651,4 @@ Guía rápida: ver `docs/Minimapa.md`.
 - Se solucionó un error en el mapa de batalla que provocaba un fallo al inicializar `syncManager` antes de su declaración.
 - Corregido error al aplicar presets de estilo en el minimapa que provocaba "next[r] is undefined".
 - Se corrigió un error de compilación causado por un corchete faltante en `MinimapBuilder.jsx`.
+- Se mejoró el efecto de destellos del minimapa con trayectorias y tamaños aleatorios para cada partícula.

--- a/src/components/MinimapBuilder.jsx
+++ b/src/components/MinimapBuilder.jsx
@@ -125,10 +125,14 @@ QuadrantPreview.propTypes = { q: PropTypes.object.isRequired };
 const SparkleEffect = ({ color }) => {
   const particles = useMemo(
     () =>
-      Array.from({ length: 6 }).map(() => ({
+      Array.from({ length: 8 }).map(() => ({
         left: Math.random() * 100,
         top: Math.random() * 100,
-        delay: Math.random(),
+        delay: Math.random() * 1.5,
+        size: 1 + Math.random() * 2,
+        tx: (Math.random() - 0.5) * 20,
+        ty: (Math.random() - 0.5) * 20,
+        duration: 0.8 + Math.random() * 0.7,
       })),
     []
   );
@@ -141,12 +145,17 @@ const SparkleEffect = ({ color }) => {
         <span
           // eslint-disable-next-line react/no-array-index-key
           key={i}
-          className="absolute w-1 h-1 rounded-full opacity-80 animate-sparkle"
+          className="absolute rounded-full opacity-80 animate-sparkle"
           style={{
             backgroundColor: color,
             left: `${p.left}%`,
             top: `${p.top}%`,
+            width: `${p.size}px`,
+            height: `${p.size}px`,
             animationDelay: `${p.delay}s`,
+            animationDuration: `${p.duration}s`,
+            '--tx': `${p.tx}px`,
+            '--ty': `${p.ty}px`,
           }}
         />
       ))}

--- a/src/index.css
+++ b/src/index.css
@@ -127,11 +127,11 @@ html {
 
 @keyframes sparkle {
   0% {
-    transform: translateY(0) scale(1);
+    transform: translate(0, 0) scale(1);
     opacity: 1;
   }
   100% {
-    transform: translateY(-6px) scale(0.5);
+    transform: translate(var(--tx), var(--ty)) scale(0);
     opacity: 0;
   }
 }


### PR DESCRIPTION
## Summary
- Enhance minimap "sparkle" effect with randomized particle paths, size and duration
- Update CSS animation to support directional variables
- Document enhanced destello effect in README

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf616d6a108326b14ed8eb7b8a3309