### PR TITLE
feat(minimap): permitir volver al cuadrante predeterminado

### DIFF
--- a/README.md
+++ b/README.md
@@ -1572,6 +1572,10 @@ src/
 - Los efectos de celda se muestran completos sobre las celdas adyacentes.
 - Nuevos efectos visuales disponibles: rebote, giro y temblor.
 
+**Resumen de cambios v2.4.60:**
+
+- Tras cargar un cuadrante guardado, el constructor de minimapas ofrece un botón para volver al cuadrante predeterminado.
+
 ## 🔄 Historial de cambios previos
 
 <details>

--- a/src/components/MinimapBuilder.jsx
+++ b/src/components/MinimapBuilder.jsx
@@ -57,6 +57,7 @@ const L = {
   saveQuadrant: 'Guardar cuadrante',
   saveChanges: 'Guardar cambios',
   savedQuadrants: 'Cuadrantes guardados',
+  defaultQuadrant: 'Cuadrante predeterminado',
   title: 'T\u00EDtulo',
   addRowTop: 'A\u00F1adir fila desde arriba',
   addRowBottom: 'A\u00F1adir fila desde abajo',
@@ -701,6 +702,19 @@ function MinimapBuilder({ onBack }) {
     setCurrentQuadrantIndex(idx);
     setLoadedQuadrantData({ rows: q.rows, cols: q.cols, cellSize: q.cellSize, grid: q.grid });
   };
+  const loadDefaultQuadrant = () => {
+    const dRows = 8;
+    const dCols = 12;
+    const dSize = 48;
+    setRows(dRows);
+    setCols(dCols);
+    setCellSize(dSize);
+    setGrid(buildGrid(dRows, dCols));
+    setSelectedCells([]);
+    setCurrentQuadrantIndex(null);
+    setLoadedQuadrantData(null);
+    setAnnotations([]);
+  };
   const saveQuadrantChanges = () => {
     if (currentQuadrantIndex === null) return;
     const data = {
@@ -1313,6 +1327,13 @@ function MinimapBuilder({ onBack }) {
               <div>
                 <Boton size="sm" onClick={saveQuadrantChanges}>
                   {L.saveChanges}
+                </Boton>
+              </div>
+            )}
+            {currentQuadrantIndex !== null && (
+              <div>
+                <Boton size="sm" onClick={loadDefaultQuadrant}>
+                  {L.defaultQuadrant}
                 </Boton>
               </div>
             )}


### PR DESCRIPTION
## Summary
- add button to restore default quadrant after loading a saved one
- document minimap default quadrant reset option

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bf66b416b08326aec226b7e66041fe