### PR TITLE
fix: avoid blank player map without background

### DIFF
--- a/README.md
+++ b/README.md
@@ -1658,3 +1658,4 @@ Guía rápida: ver `docs/Minimapa.md`.
 - Se corrigió un error de compilación causado por un corchete faltante en `MinimapBuilder.jsx`.
 - Se mejoró el efecto de destellos del minimapa con trayectorias y tamaños aleatorios para cada partícula.
 - Se intensificó el efecto de destellos del minimapa con más partículas, rotación y resplandor para hacerlo más espectacular.
+- Se solucionó un problema en el mapa de batalla donde los jugadores veían una pantalla en blanco si la página no tenía imagen de fondo.

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -1787,9 +1787,10 @@ const MapCanvas = ({
   const redoStack = useRef([]);
   const panStart = useRef({ x: 0, y: 0 });
   const panOrigin = useRef({ x: 0, y: 0 });
-  const [bg, bgStatus] = useImage(backgroundImage, 'anonymous');
-  const isBgLoading = bgStatus === 'loading';
-  const isBgError = bgStatus === 'failed';
+  // Avoid showing a perpetual loading state when no background image is provided
+  const [bg, bgStatus] = useImage(backgroundImage || null, 'anonymous');
+  const isBgLoading = !!backgroundImage && bgStatus === 'loading';
+  const isBgError = !!backgroundImage && bgStatus === 'failed';
 
   useEffect(() => {
     setLines(propLines);


### PR DESCRIPTION
## Summary
- prevent MapCanvas from showing perpetual loading screen when background image is missing
- document battle map fix in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c2b6228b588326bfd39dc77eda0c39