### PR TITLE
Close attack and defense modals once rolls resolve

### DIFF
--- a/README.md
+++ b/README.md
@@ -841,6 +841,7 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 
 - Se añade una animación "Resiste el daño" en el mapa cuando un ataque no causa pérdida de bloques, usando el mismo color azul que en el chat.
 - La animación de daño reduce su tamaño de fuente de 40 a 30 para mejorar la legibilidad.
+- Las ventanas de ataque y defensa ahora se cierran inmediatamente después de resolver las tiradas para no bloquear las animaciones.
 
 ### 🛠️ **Características Técnicas**
 


### PR DESCRIPTION
## Summary
- close attack modal immediately after resolving the roll and handle DB updates asynchronously
- close defense modal immediately after resolving the roll and process effects in background
- document auto-closing combat modals in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c5fa002d2083268a611136f7a10636