### PR TITLE
Fix enemy undefined error on player battle map

### DIFF
--- a/README.md
+++ b/README.md
@@ -1657,3 +1657,5 @@ Guía rápida: ver `docs/Minimapa.md`.
 - Se corrigió un error de compilación causado por un corchete faltante en `MinimapBuilder.jsx`.
 - Se mejoró el efecto de destellos del minimapa con trayectorias y tamaños aleatorios para cada partícula.
 - Se intensificó el efecto de destellos del minimapa con más partículas, rotación y resplandor para hacerlo más espectacular.
+- Se corrigió un fallo al abrir el mapa de batalla como jugador que generaba "enemy is not defined" cargando ahora los datos de enemigos.
+- Se añadió una verificación adicional en la hoja de fichas de tokens para evitar referencias a enemigos inexistentes en el mapa de batalla de jugadores.

--- a/src/App.js
+++ b/src/App.js
@@ -3394,7 +3394,7 @@ function App() {
             enableDarkness={effectivePage?.enableDarkness || false}
             darknessOpacity={effectivePage?.darknessOpacity || 0.8}
             activeLayer="fichas"
-            enemies={[]}
+            enemies={enemies}
             players={[playerName]}
             armas={armas}
             armaduras={armaduras}

--- a/src/components/TokenSheetModal.jsx
+++ b/src/components/TokenSheetModal.jsx
@@ -24,12 +24,13 @@ const TokenSheetModal = ({
     let sheet = sheets[sheetId];
 
     if (!sheet) {
+      let enemyData = null;
       if (token.enemyId) {
-        const enemy = enemies.find((e) => e.id === token.enemyId);
-        if (enemy) {
-          sheet = JSON.parse(JSON.stringify(enemy));
-          sheet.id = sheetId;
-        }
+        enemyData = enemies.find((e) => e.id === token.enemyId);
+      }
+      if (enemyData) {
+        sheet = JSON.parse(JSON.stringify(enemyData));
+        sheet.id = sheetId;
       }
       if (!sheet) sheet = { id: sheetId, name: '', stats: {}, atributos: {} };
     }


### PR DESCRIPTION
## Summary
- Pass enemy data to player battle map to prevent `enemy is not defined` errors
- Guard TokenSheetModal against missing enemy data when cloning sheets
- Document fix in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c2d7ca00fc832685f87e84bc6b3fc8