### PR TITLE
Eliminar insignias de nivel de las fichas de jugador

### DIFF
--- a/README.md
+++ b/README.md
@@ -1576,6 +1576,10 @@ src/
 
 - Tras cargar un cuadrante guardado, el constructor de minimapas ofrece un botón para volver al cuadrante predeterminado.
 
+**Resumen de cambios v2.4.79:**
+
+- Se elimina la visualización del nivel y contadores de equipo superpuestos al abrir una ficha de jugador.
+
 ## 🔄 Historial de cambios previos
 
 <details>

--- a/src/App.js
+++ b/src/App.js
@@ -3813,23 +3813,6 @@ function App() {
                       {newResError}
                     </p>
                   )}
-                  {/* Metadatos superpuestos */}
-                  <div className="absolute top-2 left-2">
-                    <span className="px-2 py-0.5 rounded-full text-xs bg-yellow-500/20 border border-yellow-600/40 text-yellow-300 font-semibold inline-flex items-center gap-1 shadow-sm">
-                      <FiStar /> Nivel {enemy.nivel || 1}
-                    </span>
-                  </div>
-                  <div className="absolute top-2 right-2 flex items-center gap-1">
-                    <span className="px-2 py-0.5 rounded-full text-[10px] bg-gray-900/60 border border-gray-700 text-gray-200 inline-flex items-center gap-1 shadow-sm">
-                      <GiCrossedSwords className="text-yellow-300" /> {enemy.weapons?.length || 0}
-                    </span>
-                    <span className="px-2 py-0.5 rounded-full text-[10px] bg-gray-900/60 border border-gray-700 text-gray-200 inline-flex items-center gap-1 shadow-sm">
-                      <GiShield className="text-blue-300" /> {enemy.armaduras?.length || 0}
-                    </span>
-                    <span className="px-2 py-0.5 rounded-full text-[10px] bg-gray-900/60 border border-gray-700 text-gray-200 inline-flex items-center gap-1 shadow-sm">
-                      <GiSpellBook className="text-purple-300" /> {enemy.poderes?.length || 0}
-                    </span>
-                  </div>
                 </div>
               )}
             </div>


### PR DESCRIPTION
## Resumen
- elimina los badges de nivel y contadores de equipamiento que aparecían sobre la ficha del jugador
- documenta el cambio en el historial de versiones

## Pruebas
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68c63b02ffe88326af6103124cce6a6c