### PR TITLE
Cerrar modales de ataque y defensa tras las tiradas

### DIFF
--- a/README.md
+++ b/README.md
@@ -1580,6 +1580,10 @@ src/
 
 - Se elimina la visualización del nivel y contadores de equipo superpuestos al abrir una ficha de jugador.
 
+**Resumen de cambios v2.4.80:**
+
+- Las ventanas de ataque y defensa se cierran automáticamente tras resolver las tiradas para no bloquear la animación de daño.
+
 ## 🔄 Historial de cambios previos
 
 <details>

--- a/src/components/AttackModal.jsx
+++ b/src/components/AttackModal.jsx
@@ -388,10 +388,10 @@ const AttackModal = ({
           console.error(err);
         }
       }, AUTO_RESOLVE_MS);
-      await addSpeedForToken(attacker, speedCost);
-      await consumeStatForToken(attacker, 'ingenio', ingenioCost, pageId);
       setLoading(false);
       onClose(result);
+      await addSpeedForToken(attacker, speedCost);
+      await consumeStatForToken(attacker, 'ingenio', ingenioCost, pageId);
     } catch (e) {
       setLoading(false);
       alert('Fórmula inválida');

--- a/src/components/DefenseModal.jsx
+++ b/src/components/DefenseModal.jsx
@@ -419,10 +419,10 @@ const DefenseModal = ({
       messages.push({ id: nanoid(), author: targetName, text, result });
       setDoc(doc(db, 'assetSidebar', 'chat'), { messages }).catch(() => {});
 
-      await addSpeedForToken(target, speedCost);
-      await consumeStatForToken(target, 'ingenio', ingenioCost, pageId);
       setLoading(false);
       onClose(result);
+      await addSpeedForToken(target, speedCost);
+      await consumeStatForToken(target, 'ingenio', ingenioCost, pageId);
     } catch (e) {
       setLoading(false);
       alert('Fórmula inválida');

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -4930,17 +4930,24 @@ const MapCanvas = ({
             armas={armas}
             poderesCatalog={habilidades}
             onClose={async (res) => {
-              if (!res && attackResult) {
+              const currentAttackResult = attackResult;
+              const currentTargetId = attackTargetId;
+              const currentRequestId = attackRequestId;
+              setAttackTargetId(null);
+              setAttackLine(null);
+              setAttackResult(null);
+              setAttackReady(false);
+              if (!res && currentAttackResult) {
                 try {
                   let alreadyCompleted = false;
-                  if (attackRequestId) {
+                  if (currentRequestId) {
                     try {
-                      const snap = await getDoc(doc(db, 'attacks', attackRequestId));
+                      const snap = await getDoc(doc(db, 'attacks', currentRequestId));
                       if (snap.exists() && snap.data().completed) alreadyCompleted = true;
                     } catch {}
                   }
                   if (!alreadyCompleted) {
-                    const target = tokens.find(t => t.id === attackTargetId);
+                    const target = tokens.find(t => t.id === currentTargetId);
                     if (target) {
                       let lost = { armadura: 0, postura: 0, vida: 0 };
                       let updatedSheet = null;
@@ -4951,7 +4958,7 @@ const MapCanvas = ({
                           const sheet = sheets[target.tokenSheetId];
                           if (sheet) {
                             let updated = sheet;
-                            let remaining = attackResult.total;
+                            let remaining = currentAttackResult.total;
                             ['postura', 'armadura', 'vida'].forEach((stat) => {
                               const resDam = applyDamage(updated, remaining, stat);
                               remaining = resDam.remaining;
@@ -5015,18 +5022,18 @@ const MapCanvas = ({
                       const targetName = target.customName || target.name || 'Defensor';
                       const vigor = parseDieValue(updatedSheet?.atributos?.vigor);
                       const destreza = parseDieValue(updatedSheet?.atributos?.destreza);
-                      const diff = attackResult.total;
-                      const noDamageText = `${targetName} resiste el daño. Ataque ${attackResult.total} Defensa 0 Dif ${diff} (V${vigor} D${destreza}) Bloques A-${lost.armadura} P-${lost.postura} V-${lost.vida}`;
-                      const damageText = `${targetName} no se defendió. Ataque ${attackResult.total} Defensa 0 Dif ${diff} (V${vigor} D${destreza}) Bloques A-${lost.armadura} P-${lost.postura} V-${lost.vida}`;
+                      const diff = currentAttackResult.total;
+                      const noDamageText = `${targetName} resiste el daño. Ataque ${currentAttackResult.total} Defensa 0 Dif ${diff} (V${vigor} D${destreza}) Bloques A-${lost.armadura} P-${lost.postura} V-${lost.vida}`;
+                      const damageText = `${targetName} no se defendió. Ataque ${currentAttackResult.total} Defensa 0 Dif ${diff} (V${vigor} D${destreza}) Bloques A-${lost.armadura} P-${lost.postura} V-${lost.vida}`;
                       msgs.push({
                         id: nanoid(),
                         author: targetName,
                         text: totalLost === 0 ? noDamageText : damageText,
                       });
                       await setDoc(doc(db, 'assetSidebar', 'chat'), { messages: msgs });
-                      if (attackRequestId) {
+                      if (currentRequestId) {
                         try {
-                          await updateDoc(doc(db, 'attacks', attackRequestId), { completed: true, auto: true });
+                          await updateDoc(doc(db, 'attacks', currentRequestId), { completed: true, auto: true });
                         } catch {}
                       }
                     }
@@ -5035,18 +5042,14 @@ const MapCanvas = ({
                   console.error(err);
                 }
               }
-              if (attackRequestId) {
+              if (currentRequestId) {
                 try {
-                  await deleteDoc(doc(db, 'attacks', attackRequestId));
+                  await deleteDoc(doc(db, 'attacks', currentRequestId));
                 } catch (err) {
                   console.error(err);
                 }
                 setAttackRequestId(null);
               }
-              setAttackTargetId(null);
-              setAttackLine(null);
-              setAttackResult(null);
-              setAttackReady(false);
             }}
           />
       )}


### PR DESCRIPTION
## Resumen
- Cerrar inmediatamente los modales de ataque y defensa al resolver las tiradas
- Liberar el flujo de daño cerrando el modal de defensa antes de procesar lógica pesada
- Documentar el cierre automático de los modales de combate

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c6a5c94b208326befa2a3c62127060