### PR TITLE
refactor: merge remote token updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1667,4 +1667,5 @@ Guía rápida: ver `docs/Minimapa.md`.
 - Se intensificó el efecto de destellos del minimapa con más partículas, rotación y resplandor para hacerlo más espectacular.
 - Se corrigió un fallo al abrir el mapa de batalla como jugador que generaba "enemy is not defined" cargando ahora los datos de enemigos.
 - Se añadió una verificación adicional en la hoja de fichas de tokens para evitar referencias a enemigos inexistentes en el mapa de batalla de jugadores.
+- Mejora de sincronización de tokens en el mapa de batalla: los cambios remotos se fusionan con el estado local respetando modificaciones pendientes y reflejando eliminaciones.
 


### PR DESCRIPTION
## Summary
- merge remote token snapshots into existing state with mergeTokens
- track and prioritize local token changes until saved
- document improved token sync in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c6a9b6d8708326a8189d1188044a63