### PR TITLE
Normalize token IDs as strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1584,6 +1584,10 @@ src/
 
 - Las ventanas de ataque y defensa se cierran automáticamente tras resolver las tiradas para no bloquear la animación de daño.
 
+**Resumen de cambios v2.4.81:**
+
+- Se normalizan los identificadores de tokens como cadenas para evitar desincronizaciones y errores al eliminar.
+
 ## 🔄 Historial de cambios previos
 
 <details>

--- a/src/App.js
+++ b/src/App.js
@@ -597,19 +597,25 @@ function App() {
   const [showVisionRanges, setShowVisionRanges] = useState(true);
 
   const diffTokens = (prev, next) => {
-    const prevMap = new Map(prev.map((t) => [t.id, t]));
+    const prevMap = new Map(
+      prev.map((t) => {
+        const id = String(t.id);
+        return [id, { ...t, id }];
+      })
+    );
     const changed = [];
     next.forEach((tk) => {
-      const old = prevMap.get(tk.id);
+      const id = String(tk.id);
+      const old = prevMap.get(id);
       if (!old) {
-        changed.push(tk);
+        changed.push({ ...tk, id });
       } else if (!deepEqual(old, tk)) {
-        changed.push(tk);
+        changed.push({ ...tk, id });
       }
-      prevMap.delete(tk.id);
+      prevMap.delete(id);
     });
     prevMap.forEach((tk) => {
-      changed.push({ id: tk.id, _deleted: true });
+      changed.push({ id: String(tk.id), _deleted: true });
     });
     return changed;
   };
@@ -866,14 +872,21 @@ function App() {
         if (changes.length === 0) return;
         const toEnsure = changes.filter((tk) => !tk._deleted);
         const ensured = await ensureTokenSheetIds(playerVisiblePageId, toEnsure);
-        const ensuredMap = new Map(ensured.map((t) => [t.id, t]));
-        const tokensWithIds = changes.map((t) =>
-          t._deleted ? t : ensuredMap.get(t.id) || t
+        const ensuredMap = new Map(
+          ensured.map((t) => {
+            const id = String(t.id);
+            return [id, { ...t, id }];
+          })
         );
+        const tokensWithIds = changes.map((t) => {
+          const id = String(t.id);
+          return t._deleted ? { ...t, id } : ensuredMap.get(id) || { ...t, id };
+        });
         const filtered = tokensWithIds.filter((tk) => {
-          const pending = pendingTokenChangesRef.current.get(tk.id);
+          const pending = pendingTokenChangesRef.current.get(String(tk.id));
           if (pending) {
-            if (deepEqual(pending, tk)) pendingTokenChangesRef.current.delete(tk.id);
+            if (deepEqual(pending, tk))
+              pendingTokenChangesRef.current.delete(String(tk.id));
             return false;
           }
           return true;
@@ -950,14 +963,21 @@ function App() {
         if (changes.length === 0) return;
         const toEnsure = changes.filter((tk) => !tk._deleted);
         const ensured = await ensureTokenSheetIds(pageId, toEnsure);
-        const ensuredMap = new Map(ensured.map((t) => [t.id, t]));
-        const tokensWithIds = changes.map((t) =>
-          t._deleted ? t : ensuredMap.get(t.id) || t
+        const ensuredMap = new Map(
+          ensured.map((t) => {
+            const id = String(t.id);
+            return [id, { ...t, id }];
+          })
         );
+        const tokensWithIds = changes.map((t) => {
+          const id = String(t.id);
+          return t._deleted ? { ...t, id } : ensuredMap.get(id) || { ...t, id };
+        });
         const filtered = tokensWithIds.filter((tk) => {
-          const pending = pendingTokenChangesRef.current.get(tk.id);
+          const pending = pendingTokenChangesRef.current.get(String(tk.id));
           if (pending) {
-            if (deepEqual(pending, tk)) pendingTokenChangesRef.current.delete(tk.id);
+            if (deepEqual(pending, tk))
+              pendingTokenChangesRef.current.delete(String(tk.id));
             return false;
           }
           return true;
@@ -3415,7 +3435,7 @@ function App() {
                   typeof updater === 'function' ? updater(prev) : updater;
                 const changed = diffTokens(prev, next);
                 changed.forEach((tk) =>
-                  pendingTokenChangesRef.current.set(tk.id, tk)
+                  pendingTokenChangesRef.current.set(String(tk.id), tk)
                 );
                 updatedPages[effectivePageIndex].tokens = next;
                 setPages(updatedPages);
@@ -5345,7 +5365,7 @@ function App() {
                     typeof updater === 'function' ? updater(prev) : updater;
                   const changed = diffTokens(prev, next);
                   changed.forEach((tk) =>
-                    pendingTokenChangesRef.current.set(tk.id, tk)
+                    pendingTokenChangesRef.current.set(String(tk.id), tk)
                   );
                   return next;
                 });

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -1329,19 +1329,25 @@ const MapCanvas = ({
 
   // Función wrapper para manejar cambios de tokens con sincronización
   const diffTokens = (prev, next) => {
-    const prevMap = new Map(prev.map((t) => [t.id, t]));
+    const prevMap = new Map(
+      prev.map((t) => {
+        const id = String(t.id);
+        return [id, { ...t, id }];
+      })
+    );
     const changed = [];
     next.forEach((tk) => {
-      const old = prevMap.get(tk.id);
+      const id = String(tk.id);
+      const old = prevMap.get(id);
       if (!old) {
-        changed.push(tk);
+        changed.push({ ...tk, id });
       } else if (!deepEqual(old, tk)) {
-        changed.push(tk);
+        changed.push({ ...tk, id });
       }
-      prevMap.delete(tk.id);
+      prevMap.delete(id);
     });
     prevMap.forEach((tk) => {
-      changed.push({ id: tk.id, _deleted: true });
+      changed.push({ id: String(tk.id), _deleted: true });
     });
     return changed;
   };
@@ -3365,7 +3371,7 @@ const MapCanvas = ({
 
             const newToken = createToken({
               ...token,
-              id: Date.now() + Math.random(),
+              id: nanoid(),
               x: finalPos.x,
               y: finalPos.y,
               layer: activeLayer,
@@ -3783,7 +3789,7 @@ const MapCanvas = ({
         }
         
         const newToken = createToken({
-          id: Date.now(),
+          id: nanoid(),
           x,
           y,
           w: 1,

--- a/src/utils/__tests__/token.test.js
+++ b/src/utils/__tests__/token.test.js
@@ -1,4 +1,4 @@
-import { createToken } from '../token';
+import { createToken, mergeTokens } from '../token';
 
 jest.mock('firebase/firestore', () => ({
   doc: jest.fn(),
@@ -12,4 +12,16 @@ test('generated tokens across pages have unique tokenSheetId', () => {
   const ids = [...page1, ...page2].map(t => t.tokenSheetId);
   const unique = new Set(ids);
   expect(unique.size).toBe(ids.length);
+});
+
+test('deleting token with numeric id removes it after normalization', () => {
+  const prev = [
+    { id: 1, name: 'a' },
+    { id: 2, name: 'b' },
+  ];
+  const changed = [{ id: 1, _deleted: true }];
+  const result = mergeTokens(prev, changed);
+  expect(result).toHaveLength(1);
+  expect(result[0].id).toBe('2');
+  expect(result.find(t => t.id === '1')).toBeUndefined();
 });

--- a/src/utils/token.js
+++ b/src/utils/token.js
@@ -4,25 +4,36 @@ import { db } from '../firebase';
 import sanitize from './sanitize';
 
 export const mergeTokens = (prevTokens, changedTokens) => {
-  const map = new Map(prevTokens.map((t) => [t.id, t]));
+  const map = new Map(
+    prevTokens.map((t) => {
+      const id = String(t.id);
+      return [id, { ...t, id }];
+    })
+  );
   changedTokens.forEach((tk) => {
+    const id = String(tk.id);
     if (tk._deleted) {
-      map.delete(tk.id);
+      map.delete(id);
     } else {
-      map.set(tk.id, tk);
+      map.set(id, { ...tk, id });
     }
   });
   return Array.from(map.values());
 };
 
 export const createToken = (data = {}) => {
-  const token = { notes: '', ...data, tokenSheetId: nanoid() };
+  const token = {
+    notes: '',
+    ...data,
+    id: data.id ? String(data.id) : nanoid(),
+    tokenSheetId: nanoid(),
+  };
   try {
     setDoc(doc(db, 'tokenSheets', token.tokenSheetId), { stats: {} });
   } catch (err) {
     console.error('create token sheet', err);
   }
-  return token;
+  return { ...token, id: String(token.id) };
 };
 
 export const updateLocalTokenSheet = (sheet) => {


### PR DESCRIPTION
## Summary
- generate token ids with `nanoid` instead of timestamps in MapCanvas
- normalize token ids to strings in token utilities and app diffing logic
- add regression test for deleting numeric id tokens

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c6b2cc61848326825635275c4e70ee