### PR TITLE
Sync player token deletions to master battle map

### DIFF
--- a/README.md
+++ b/README.md
@@ -1672,4 +1672,5 @@ Guía rápida: ver `docs/Minimapa.md`.
 - Se corrigió un fallo al abrir el mapa de batalla como jugador que generaba "enemy is not defined" cargando ahora los datos de enemigos.
 - Se añadió una verificación adicional en la hoja de fichas de tokens para evitar referencias a enemigos inexistentes en el mapa de batalla de jugadores.
 - Mejora de sincronización de tokens en el mapa de batalla: los cambios remotos se fusionan con el estado local respetando modificaciones pendientes y reflejando eliminaciones.
+- Se corrigió un problema donde la eliminación de tokens por jugadores no se reflejaba en el mapa del máster.
 

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -1081,6 +1081,23 @@ const MapCanvas = ({
       texts: null,
     };
     let pendingTokenChanges = [];
+    const mergeTokenChanges = (prev, next) => {
+      const map = new Map(
+        prev.map((t) => {
+          const id = String(t.id);
+          return [id, { ...t, id }];
+        })
+      );
+      next.forEach((tk) => {
+        const id = String(tk.id);
+        if (tk._deleted) {
+          map.set(id, { id, _deleted: true });
+        } else {
+          map.set(id, { ...(map.get(id) || {}), ...tk, id });
+        }
+      });
+      return Array.from(map.values());
+    };
     const prevData = {
       lines: [],
       walls: [],
@@ -1093,7 +1110,7 @@ const MapCanvas = ({
       if (type === 'tokens') {
         if (!Array.isArray(data) || data.length === 0) return;
 
-        pendingTokenChanges = mergeTokens(pendingTokenChanges, data);
+        pendingTokenChanges = mergeTokenChanges(pendingTokenChanges, data);
 
         if (saveTimeouts.tokens) {
           clearTimeout(saveTimeouts.tokens);


### PR DESCRIPTION
## Summary
- preserve token deletion changes so player removals propagate to the master map
- document the fix in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c7094865c083269c8656aaf81f4fdf