### PR TITLE
Normalize player name when checking map tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -1588,6 +1588,10 @@ src/
 
 - Se normalizan los identificadores de tokens como cadenas para evitar desincronizaciones y errores al eliminar.
 
+**Resumen de cambios v2.4.82:**
+
+- Corrección: al asignar un token a un jugador, se normaliza el nombre para evitar mensajes de "Acceso Denegado" en el mapa de batalla.
+
 ## 🔄 Historial de cambios previos
 
 <details>

--- a/src/App.js
+++ b/src/App.js
@@ -2734,7 +2734,11 @@ function App() {
   // HANDLERS para Login y Equipo de objetos
   // ───────────────────────────────────────────────────────────
   const enterPlayer = () => {
-    if (playerName.trim()) setNameEntered(true);
+    const trimmed = playerName.trim();
+    if (trimmed) {
+      setPlayerName(trimmed);
+      setNameEntered(true);
+    }
   };
   const handlePlayerEquip = () => {
     if (loading) return;
@@ -3230,7 +3234,8 @@ function App() {
                     size="md"
                     className="w-full rounded-lg font-semibold text-base px-4 py-2 transition-colors duration-200"
                     onClick={() => {
-                      setPlayerName(n);
+                      const trimmed = n.trim();
+                      setPlayerName(trimmed);
                       setTimeout(() => setNameEntered(true), 0);
                     }}
                   >
@@ -3337,8 +3342,9 @@ function App() {
 
         // Verificar si el jugador tiene un token asignado en esta página
         const pageTokens = effectivePage?.tokens || [];
-        playerHasToken = pageTokens.some(
-          (token) => token.controlledBy === playerName
+        const normalized = playerName.trim().toLowerCase();
+        playerHasToken = pageTokens.some((token) =>
+          (token.controlledBy || '').trim().toLowerCase() === normalized
         );
       }
     }


### PR DESCRIPTION
## Summary
- Trim and normalize player names when logging in
- Compare tokens with normalized player names to avoid false "Access Denied" on battle map
- Document fix in changelog

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c70dac6d2883268404b309e9d66aef