### PR TITLE
Copying tokens preserves stats with new IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -937,6 +937,7 @@ src/
 - **Corrección de desincronización** - Las páginas ya no se actualizan antes de
   cargarse por completo
 - **IDs de fichas** - Cada token creado ahora recibe un `tokenSheetId` único para evitar conflictos
+- **Copiado de tokens completo** - Al duplicar un token se clonan también sus estadísticas y se asigna un `tokenSheetId` independiente
 - **Guardado exclusivo para el máster** - Los tokens, líneas y otros datos del mapa solo se guardan si el usuario es máster
 - **Menús de token robustos** - Se eliminan IDs obsoletos al abrir configuraciones o estados, evitando errores si la ficha fue borrada
 - **Sincronización de puertas** - Abrir o cerrar puertas se guarda correctamente al mover un token

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -3386,27 +3386,15 @@ const MapCanvas = ({
               pasteGridPos.y + relativeY
             );
 
+            const data = JSON.parse(JSON.stringify(token));
             const newToken = createToken({
-              ...token,
+              ...data,
               id: nanoid(),
               x: finalPos.x,
               y: finalPos.y,
               layer: activeLayer,
             });
-            const stored = localStorage.getItem('tokenSheets');
-            if (stored) {
-              const sheets = JSON.parse(stored);
-              const sheet = sheets[token.tokenSheetId];
-              if (sheet) {
-                const copy = JSON.parse(JSON.stringify(sheet));
-                copy.id = newToken.tokenSheetId;
-                sheets[newToken.tokenSheetId] = copy;
-                localStorage.setItem('tokenSheets', JSON.stringify(sheets));
-                window.dispatchEvent(
-                  new CustomEvent('tokenSheetSaved', { detail: copy })
-                );
-              }
-            }
+            cloneTokenSheet(token.tokenSheetId, newToken.tokenSheetId);
             return newToken;
           });
           handleTokensChange([...tokens, ...newTokens]);
@@ -3831,20 +3819,7 @@ const MapCanvas = ({
           layer: activeLayer,
         });
         if (item.tokenSheetId) {
-          const stored = localStorage.getItem('tokenSheets');
-          if (stored) {
-            const sheets = JSON.parse(stored);
-            const sheet = sheets[item.tokenSheetId];
-            if (sheet) {
-              const copy = JSON.parse(JSON.stringify(sheet));
-              copy.id = newToken.tokenSheetId;
-              sheets[newToken.tokenSheetId] = copy;
-              localStorage.setItem('tokenSheets', JSON.stringify(sheets));
-              window.dispatchEvent(
-                new CustomEvent('tokenSheetSaved', { detail: copy })
-              );
-            }
-          }
+          cloneTokenSheet(item.tokenSheetId, newToken.tokenSheetId);
         }
         handleTokensChange([...tokens, newToken]);
       },

--- a/src/utils/__tests__/tokenCopy.test.js
+++ b/src/utils/__tests__/tokenCopy.test.js
@@ -1,0 +1,31 @@
+import { createToken, cloneTokenSheet } from '../token';
+
+jest.mock('firebase/firestore', () => ({
+  doc: jest.fn(),
+  setDoc: jest.fn().mockResolvedValue(),
+}));
+jest.mock('../../firebase', () => ({ db: {} }));
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+test('copying a token duplicates stats and keeps independent data', () => {
+  const original = createToken({ id: 1, estados: ['poisoned'] });
+  const sheet = { id: original.tokenSheetId, stats: { vida: { actual: 8 } } };
+  localStorage.setItem('tokenSheets', JSON.stringify({ [sheet.id]: sheet }));
+
+  const data = JSON.parse(JSON.stringify(original));
+  const copy = createToken({ ...data, id: 2 });
+  cloneTokenSheet(original.tokenSheetId, copy.tokenSheetId);
+
+  const sheets = JSON.parse(localStorage.getItem('tokenSheets'));
+  expect(sheets[copy.tokenSheetId]).toEqual({ ...sheet, id: copy.tokenSheetId });
+
+  sheets[copy.tokenSheetId].stats.vida.actual = 3;
+  expect(sheets[original.tokenSheetId].stats.vida.actual).toBe(8);
+
+  copy.estados.push('burned');
+  expect(original.estados).toEqual(['poisoned']);
+});
+


### PR DESCRIPTION
## Summary
- Deep clone tokens on paste and use `cloneTokenSheet` to copy full stat sheets with new IDs
- Reuse `cloneTokenSheet` when dropping token assets onto the map
- Document token copy behavior and add regression test for token sheet cloning

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c711c51fd0832698c016ecbb3bfca6