### PR TITLE
Copying tokens preserves stats with new IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 - **Selector de ficha centrado** - Muestra el nombre personalizado de cada token
 - **Mapa de Batalla integrado** - VTT sencillo con grid y tokens arrastrables
 - **Fichas de token personalizadas** - Cada token puede tener su propia hoja de personaje
-- **Copiar tokens conserva su hoja personalizada** - Al duplicar un token se clona su ficha con los mismos ajustes
+- **Copiar tokens conserva su hoja personalizada** - Al duplicar un token se clona su ficha con todos los valores (base, total y modificados), colores y visibilidad de estadísticas manteniendo IDs independientes en los mapas del máster y del jugador
 - **Tokens almacenados individualmente** - Cada ficha se guarda como documento en `pages/{pageId}/tokens/{tokenId}`
 - **Fichas de jugador sin personaje persistentes** - Los tokens asignados a un jugador pero sin ficha asociada guardan sus cambios en `localStorage` igual que los del máster
 - **Cargar ficha del jugador bajo demanda** - Usa el selector o el botón "Restaurar ficha" para sincronizar manualmente
@@ -937,6 +937,7 @@ src/
 - **Corrección de desincronización** - Las páginas ya no se actualizan antes de
   cargarse por completo
 - **IDs de fichas** - Cada token creado ahora recibe un `tokenSheetId` único para evitar conflictos
+- **Copiado de tokens completo** - Al duplicar un token se clonan también sus estadísticas y se asigna un `tokenSheetId` independiente
 - **Guardado exclusivo para el máster** - Los tokens, líneas y otros datos del mapa solo se guardan si el usuario es máster
 - **Menús de token robustos** - Se eliminan IDs obsoletos al abrir configuraciones o estados, evitando errores si la ficha fue borrada
 - **Sincronización de puertas** - Abrir o cerrar puertas se guarda correctamente al mover un token

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -3322,6 +3322,20 @@ const MapCanvas = ({
                  selectedTextId ? [texts.find(t => t.id === selectedTextId)] : []
         };
 
+        // Incluir las sheets completas de los tokens para mantener todas las estadísticas
+        const stored = localStorage.getItem('tokenSheets');
+        if (stored) {
+          const sheets = JSON.parse(stored);
+          const tokenSheets = {};
+          clipboardData.tokens.forEach(tk => {
+            const sheet = sheets[tk.tokenSheetId];
+            if (sheet) {
+              tokenSheets[tk.tokenSheetId] = JSON.parse(JSON.stringify(sheet));
+            }
+          });
+          if (Object.keys(tokenSheets).length > 0) clipboardData.tokenSheets = tokenSheets;
+        }
+
         // Solo copiar si hay elementos seleccionados
         if (clipboardData.tokens.length > 0 || clipboardData.lines.length > 0 ||
             clipboardData.walls.length > 0 || clipboardData.texts.length > 0) {
@@ -3386,26 +3400,22 @@ const MapCanvas = ({
               pasteGridPos.y + relativeY
             );
 
+            const data = JSON.parse(JSON.stringify(token));
             const newToken = createToken({
-              ...token,
+              ...data,
               id: nanoid(),
               x: finalPos.x,
               y: finalPos.y,
               layer: activeLayer,
             });
-            const stored = localStorage.getItem('tokenSheets');
-            if (stored) {
-              const sheets = JSON.parse(stored);
-              const sheet = sheets[token.tokenSheetId];
-              if (sheet) {
-                const copy = JSON.parse(JSON.stringify(sheet));
-                copy.id = newToken.tokenSheetId;
-                sheets[newToken.tokenSheetId] = copy;
-                localStorage.setItem('tokenSheets', JSON.stringify(sheets));
-                window.dispatchEvent(
-                  new CustomEvent('tokenSheetSaved', { detail: copy })
-                );
-              }
+            const sheet = clipboard.tokenSheets?.[token.tokenSheetId];
+            if (sheet) {
+              const copy = JSON.parse(JSON.stringify(sheet));
+              copy.id = newToken.tokenSheetId;
+              updateLocalTokenSheet(copy);
+              saveTokenSheet(copy);
+            } else {
+              cloneTokenSheet(token.tokenSheetId, newToken.tokenSheetId);
             }
             return newToken;
           });
@@ -3831,20 +3841,7 @@ const MapCanvas = ({
           layer: activeLayer,
         });
         if (item.tokenSheetId) {
-          const stored = localStorage.getItem('tokenSheets');
-          if (stored) {
-            const sheets = JSON.parse(stored);
-            const sheet = sheets[item.tokenSheetId];
-            if (sheet) {
-              const copy = JSON.parse(JSON.stringify(sheet));
-              copy.id = newToken.tokenSheetId;
-              sheets[newToken.tokenSheetId] = copy;
-              localStorage.setItem('tokenSheets', JSON.stringify(sheets));
-              window.dispatchEvent(
-                new CustomEvent('tokenSheetSaved', { detail: copy })
-              );
-            }
-          }
+          cloneTokenSheet(item.tokenSheetId, newToken.tokenSheetId);
         }
         handleTokensChange([...tokens, newToken]);
       },

--- a/src/utils/__tests__/tokenCopy.test.js
+++ b/src/utils/__tests__/tokenCopy.test.js
@@ -1,0 +1,51 @@
+import { createToken, cloneTokenSheet } from '../token';
+import { setDoc } from 'firebase/firestore';
+
+jest.mock('firebase/firestore', () => ({
+  doc: jest.fn(),
+  setDoc: jest.fn().mockResolvedValue(),
+}));
+jest.mock('../../firebase', () => ({ db: {} }));
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+test('copying a token duplicates full sheet data and keeps independent stats', () => {
+  const original = createToken({ id: 1, estados: ['poisoned'] });
+  const sheet = {
+    id: original.tokenSheetId,
+    resourcesList: [{ id: 'vida', color: '#ff0000', tokenRow: 0, tokenAnchor: 'top' }],
+    stats: {
+      vida: {
+        actual: 4,
+        base: 10,
+        total: 10,
+        color: '#ff0000',
+        showOnToken: true,
+        label: 'Vida',
+        tokenRow: 0,
+        tokenAnchor: 'top',
+      },
+    },
+  };
+  localStorage.setItem('tokenSheets', JSON.stringify({ [sheet.id]: sheet }));
+
+  const data = JSON.parse(JSON.stringify(original));
+  const copy = createToken({ ...data, id: 2 });
+  cloneTokenSheet(original.tokenSheetId, copy.tokenSheetId);
+
+  const sheets = JSON.parse(localStorage.getItem('tokenSheets'));
+  expect(sheets[copy.tokenSheetId]).toEqual({ ...sheet, id: copy.tokenSheetId });
+
+  expect(setDoc).toHaveBeenCalledTimes(3);
+  const saved = setDoc.mock.calls[2][1];
+  expect(saved.stats).toEqual(sheet.stats);
+  expect(saved.resourcesList).toEqual(sheet.resourcesList);
+
+  sheets[copy.tokenSheetId].stats.vida.actual = 3;
+  expect(sheets[original.tokenSheetId].stats.vida.actual).toBe(4);
+
+  copy.estados.push('burned');
+  expect(original.estados).toEqual(['poisoned']);
+});

--- a/src/utils/token.js
+++ b/src/utils/token.js
@@ -66,6 +66,7 @@ export const cloneTokenSheet = (sourceId, targetId) => {
   const copy = JSON.parse(JSON.stringify(sheet));
   copy.id = targetId;
   updateLocalTokenSheet(copy);
+  saveTokenSheet(copy);
 };
 export const ensureSheetDefaults = (sheet) => {
   if (!sheet || typeof sheet !== 'object') return sheet;


### PR DESCRIPTION
## Summary
- Save full token sheet data to Firestore when pasting so copied tokens keep base, total and modified stats with independent IDs
- Clone token sheets directly to Firestore and document complete stat cloning
- Add regression test verifying saved token sheets include all stat values

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c711c51fd0832698c016ecbb3bfca6