### PR TITLE
Centralize damage animation duration constant

### DIFF
--- a/README.md
+++ b/README.md
@@ -1593,6 +1593,10 @@ src/
 
 - Corrección: al asignar un token a un jugador, se normaliza el nombre para evitar mensajes de "Acceso Denegado" en el mapa de batalla.
 
+**Resumen de cambios v2.4.83:**
+
+- Duración de las animaciones de daño centralizada en `DAMAGE_ANIMATION_MS` (8 s).
+
 ## 🔄 Historial de cambios previos
 
 <details>

--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -129,6 +129,8 @@ const DOOR_PATHS = {
   ],
 };
 
+const DAMAGE_ANIMATION_MS = 8000;
+
 const normalizeWallRotation = (x1, y1, x2, y2) => {
   let deg = (Math.atan2(y2 - y1, x2 - x1) * 180) / Math.PI;
   deg = (deg + 360) % 180;
@@ -2048,7 +2050,7 @@ const MapCanvas = ({
 
         setTimeout(() => {
           setDamagePopups((prev) => prev.filter((p) => p.id !== id));
-        }, 10000);
+        }, DAMAGE_ANIMATION_MS);
       } catch (error) {
         console.error('Error en triggerDamagePopup:', error);
       }
@@ -2064,7 +2066,7 @@ const MapCanvas = ({
       const current = tokensRef.current;
       if (!current.find((t) => t.id === tokenId)) return;
       const startOpacity = 0.5;
-      const duration = 10000;
+      const duration = DAMAGE_ANIMATION_MS;
 
       const existing = damageTimersRef.current[tokenId];
       if (existing && existing.raf) {
@@ -2131,7 +2133,7 @@ const MapCanvas = ({
           } catch (err) {
             console.error('Error eliminando evento de daño:', err);
           }
-        }, 10000);
+        }, DAMAGE_ANIMATION_MS);
       });
     });
     return () => unsub();


### PR DESCRIPTION
## Summary
- add `DAMAGE_ANIMATION_MS` constant and reuse it across damage handlers
- document centralized damage animation duration in README

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c73d2f70d48326903fe3a24a48290c