### PR TITLE
Animar daño de token con Konva.Tween

### DIFF
--- a/README.md
+++ b/README.md
@@ -1601,6 +1601,10 @@ src/
 
 - Las animaciones de daño gestionan su opacidad de forma local sin alterar los tokens, evitando desincronizaciones durante la animación.
 
+**Resumen de cambios v2.4.85:**
+
+- La animación de daño utiliza ahora un `Konva.Tween` que desvanece el tinte del token de 0.5 a 0 en `DAMAGE_ANIMATION_MS`, reemplazando el `requestAnimationFrame` manual.
+
 ## 🔄 Historial de cambios previos
 
 <details>


### PR DESCRIPTION
## Summary
- Reemplaza el requestAnimationFrame de highlightTokenDamage por un Konva.Tween que desvanece la opacidad de 0.5 a 0
- Añade referencia de versión en README sobre la nueva animación

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c74c43245c832692b2051e03a7e782