### PR TITLE
Adjust minimap mobile auto fit behavior

### DIFF
--- a/src/components/MinimapBuilder.jsx
+++ b/src/components/MinimapBuilder.jsx
@@ -480,7 +480,7 @@ function MinimapBuilder({ onBack }) {
   const pinchDistRef = useRef(0);
   useEffect(() => {
     if (isMobile) {
-      setAutoFit(true);
+      setAutoFit(false);
     }
   }, [isMobile]);
   const recomputeFit = useCallback(() => {
@@ -1398,7 +1398,7 @@ function MinimapBuilder({ onBack }) {
 
         <div className="bg-gray-800/80 border border-gray-700 rounded-xl p-3 lg:col-span-3 min-h-[60vh] md:min-h-[50vh]">
           <div
-            className="h-full w-full overflow-hidden touch-none"
+            className="h-full w-full min-h-[80vh] overflow-hidden touch-none overscroll-contain"
             ref={containerRef}
             onWheel={handleWheel}
             onPointerDown={handlePointerDown}


### PR DESCRIPTION
## Summary
- stop forcing auto-fit on mobile so the quadrant retains manual scaling
- expand the minimap container height and constrain overscroll while preserving pointer interactions

## Testing
- CI=true npm test

------
https://chatgpt.com/codex/tasks/task_e_68c89c3b3f18832699a29696df594f44