### PR TITLE
Add pointer gesture support and move mode to minimap builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1670,6 +1670,7 @@ Este proyecto está bajo la Licencia MIT. Ver `LICENSE` para más detalles.
 - Agrega celdas individuales en huecos adyacentes a celdas activas mediante “+” interno.
 - Elimina celdas de forma intuitiva: botón “−” en la celda seleccionada o modo “Editar forma”. En móvil, mantener pulsado sobre una celda activa para eliminarla.
 - Control de escala: Auto‑ajustar (por defecto en móvil) evita romper el responsive cuando crece el número de celdas; disponible control de Zoom manual.
+- Nuevo modo “Mover mapa”: activa el toggle dedicado o mantén dos dedos sobre el minimapa para arrastrarlo sin editar celdas; desactívalo para volver al modo de edición.
 - Nuevo toggle “Modo legible”: engrosa temporalmente las líneas del grid para mejorar la lectura en móviles o a escalas bajas.
 - Buscadores de emojis y Lucide con listado completo de iconos cargados localmente.
 - Botón de eliminación de celdas sin fondo, solo la “X” roja.


### PR DESCRIPTION
## Summary
- replace touch handlers with pointer events and gate editing while panning or using multiple pointers
- add a move map toggle that leverages the existing pointer tracking to allow single-finger panning
- document the new gesture controls for the minimap builder in the README

## Testing
- CI=true npm test

------
https://chatgpt.com/codex/tasks/task_e_68c8f5a475448326a4d5f13e638baeb8