### PR TITLE
Reset pointer tracking when changing modes or closing panel

### DIFF
--- a/src/components/MinimapBuilder.jsx
+++ b/src/components/MinimapBuilder.jsx
@@ -591,6 +591,14 @@ function MinimapBuilder({ onBack }) {
   const pinchStateRef = useRef(null);
   const offsetRef = useRef({ x: 0, y: 0 });
   const zoomRef = useRef(1);
+  const resetPointerState = useCallback(() => {
+    pointersRef.current.clear();
+    isPanningRef.current = false;
+    activePanPointerRef.current = null;
+    pinchDistRef.current = 0;
+    pinchStateRef.current = null;
+    hadMultiTouchRef.current = false;
+  }, []);
   useEffect(() => {
     if (isMobile) {
       setAutoFit(false);
@@ -641,17 +649,19 @@ function MinimapBuilder({ onBack }) {
     zoomRef.current = zoom;
   }, [zoom]);
   useEffect(() => {
+    resetPointerState();
     if (isMoveMode) {
       setAutoFit(false);
       skipClickRef.current = true;
-    } else if (pointersRef.current.size === 0) {
+    } else {
       skipClickRef.current = false;
     }
-    if (!isMoveMode) {
-      isPanningRef.current = false;
-      activePanPointerRef.current = null;
+  }, [isMoveMode, resetPointerState]);
+  useEffect(() => {
+    if (!isPropertyPanelOpen) {
+      resetPointerState();
     }
-  }, [isMoveMode]);
+  }, [isPropertyPanelOpen, resetPointerState]);
 
   const handleWheel = useCallback(
     (e) => {


### PR DESCRIPTION
## Summary
- add a helper to clear the active pointer/panning state
- reset pointer tracking when toggling move mode or closing the properties panel so panning works immediately after editing

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68c9193ab51c8326acd1ba3a1bcd85f3