### PR TITLE
Add unsaved changes guard to minimap quadrants

### DIFF
--- a/README.md
+++ b/README.md
@@ -1683,6 +1683,7 @@ Este proyecto está bajo la Licencia MIT. Ver `LICENSE` para más detalles.
 ## Novedades: Minimapa responsive (v2.4.43)
 
 - Nuevo constructor de Minimapa en modo Máster.
+- Guardado protegido: aviso persistente de cambios sin guardar y confirmación antes de cambiar o eliminar cuadrantes activos.
 - Agrega celdas desde la periferia con botones cuadrados de borde discontinuo y “+”, ahora con mayor separación del cuadrante para evitar solapes visuales. Al pasar el ratón, se resaltan en verde.
 - Agrega celdas individuales en huecos adyacentes a celdas activas mediante “+” interno.
 - Elimina celdas de forma intuitiva: botón “−” en la celda seleccionada o modo “Editar forma”. En móvil, mantener pulsado sobre una celda activa para eliminarla.


### PR DESCRIPTION
## Summary
- add a reusable unsaved-changes guard that confirms before loading default or saved minimap quadrants
- reuse the guard for destructive shortcuts such as long-press deletion and show a persistent unsaved warning banner
- document the new minimap safeguard in the README

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cbb58f9f488326ae7d9a0fdaabd5f4