### PR TITLE
Add offline fallback when saving minimap quadrants

### DIFF
--- a/README.md
+++ b/README.md
@@ -1708,6 +1708,7 @@ Guía rápida: ver `docs/Minimapa.md`.
 - Corregido error al aplicar presets de estilo en el minimapa que provocaba "next[r] is undefined".
 - Se corrigió un error de compilación causado por un corchete faltante en `MinimapBuilder.jsx`.
 - Se mejoró el efecto de destellos del minimapa con trayectorias y tamaños aleatorios para cada partícula.
+- El constructor de minimapas vuelve a mostrar y guardar cuadrantes aunque la sincronización con Firestore falle, guardando una copia local como respaldo.
 - Se intensificó el efecto de destellos del minimapa con más partículas, rotación y resplandor para hacerlo más espectacular.
 - Se corrigió un fallo al abrir el mapa de batalla como jugador que generaba "enemy is not defined" cargando ahora los datos de enemigos.
 - Se añadió una verificación adicional en la hoja de fichas de tokens para evitar referencias a enemigos inexistentes en el mapa de batalla de jugadores.


### PR DESCRIPTION
## Summary
- add helper utilities to sync minimap quadrants with localStorage as a backup source when Firestore is empty or unreachable
- update quadrant operations (save, update, duplicate, delete) to optimistically update state/local storage so quadrants remain visible and editable offline
- document the new minimap fallback behaviour in the README

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68cbcfcba1948326ad4eac1789a67697