### PR TITLE
Fix minimap builder return syntax error

### DIFF
--- a/src/components/MinimapBuilder.jsx
+++ b/src/components/MinimapBuilder.jsx
@@ -1952,8 +1952,7 @@ function MinimapBuilder({ onBack, backLabel, showNewBadge, mode = 'master' }) {
         }
       };
       migrateDefaultAnnotations();
-    }
-  };
+    };
   const loadQuadrant = (q, idx) => {
     if (!q) return;
     setRows(q.rows);


### PR DESCRIPTION
## Summary
- remove an extra closing brace so the saveQuadrant helper keeps the MinimapBuilder component body open
- ensure the component render return stays inside the component function

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cbf7efd098832691be624cf95475fc