### PR TITLE
feat: add master minimap notes summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 - **Buscador de iconos en caché** - El minimapa reutiliza los datos de emojis descargados para evitar peticiones repetidas al desplazarse por el listado
 - **Anotaciones emergentes** - Ahora puedes agregar notas a cada celda y se muestran en un tooltip estilizado al seleccionarla o pasar el cursor
 - **Anotaciones por cuadrante** - Cada cuadrante guarda sus notas con un identificador persistente en Firestore y las migraciones de datos antiguos se aplican automáticamente en memoria
+- **Panel maestro de notas** - Revisa y gestiona todas las anotaciones de un cuadrante desde un resumen consolidado
 
 ### 🎲 **Gestión de Personajes**
 


### PR DESCRIPTION
## Summary
- add a master-facing minimap notes summary modal with search, grouping, and management controls
- expose the summary entry point from the quadrant settings panel and reset search state when closing it
- document the new minimap capability in the README

## Testing
- CI=true npm test

------
https://chatgpt.com/codex/tasks/task_e_68dd9a8e4e488326a97fe75d236a87b7