### PR TITLE
Synchronize minimap exploration state across sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 - **Buscador de iconos en caché** - El minimapa reutiliza los datos de emojis descargados para evitar peticiones repetidas al desplazarse por el listado
 - **Anotaciones emergentes** - Ahora puedes agregar notas a cada celda y se muestran en un tooltip estilizado al seleccionarla o pasar el cursor
 - **Pings temporales en el minimapa** - Haz doble clic o Alt+clic sobre una celda para resaltar su posición con una animación breve sincronizada
+- **Exploración compartida persistente** - Las casillas reveladas en el modo explorador se sincronizan al instante entre máster y jugadores y se conservan al recargar o cambiar de dispositivo
 - **Anotaciones por cuadrante** - Cada cuadrante guarda sus notas con un identificador persistente en Firestore y las migraciones de datos antiguos se aplican automáticamente en memoria
 - **Panel maestro de notas** - Revisa y gestiona todas las anotaciones de un cuadrante desde un resumen consolidado
 

--- a/src/components/MinimapBuilder.jsx
+++ b/src/components/MinimapBuilder.jsx
@@ -1255,11 +1255,14 @@ function MinimapBuilder({
     [isPlayerMode, isSharedMasterQuadrant, originCellKey]
   );
   const shouldTrackExploration = useMemo(() => {
+    if (!activeQuadrantId) {
+      return false;
+    }
     if (isPlayerMode) {
       return isSharedMasterQuadrant;
     }
-    return isMasterSharingQuadrant;
-  }, [isMasterSharingQuadrant, isPlayerMode, isSharedMasterQuadrant]);
+    return true;
+  }, [activeQuadrantId, isPlayerMode, isSharedMasterQuadrant]);
 
   const explorerState = useMemo(() => {
     if (!isExplorerModeActive && !isMasterSharingQuadrant) {


### PR DESCRIPTION
## Summary
- ensure the master client always subscribes to exploration updates for the active quadrant to keep shared maps in sync
- document that shared exploration persists across devices and reloads

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68dd8a5fe0d0832691bf7a27e9dec153