### PR TITLE
Ensure explorer origin is shared with players

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ Fichas Rol App es una aplicación web desarrollada en React para crear y gestion
 - **Buscador de iconos en caché** - El minimapa reutiliza los datos de emojis descargados para evitar peticiones repetidas al desplazarse por el listado
 - **Anotaciones emergentes** - Ahora puedes agregar notas a cada celda y se muestran en un tooltip estilizado al seleccionarla o pasar el cursor
 - **Pings temporales en el minimapa** - Haz doble clic o Alt+clic sobre una celda para resaltar su posición con una animación breve sincronizada
+- **Exploración compartida persistente** - Las casillas reveladas en el modo explorador se sincronizan al instante entre máster y jugadores y se conservan al recargar o cambiar de dispositivo
+- **Compartición instantánea de cuadrantes** - Al añadir o quitar jugadores compartidos desde el máster, los permisos se guardan automáticamente en Firebase y llegan al instante a los clientes autorizados
 - **Anotaciones por cuadrante** - Cada cuadrante guarda sus notas con un identificador persistente en Firestore y las migraciones de datos antiguos se aplican automáticamente en memoria
 - **Panel maestro de notas** - Revisa y gestiona todas las anotaciones de un cuadrante desde un resumen consolidado
 


### PR DESCRIPTION
## Summary
- derive the explorer origin from the grid or the stored exploration document so players always have a starting cell
- sync the máster's origin changes into the exploration document and clear stale origins when removed
- reset cached explorer-origin state when quadrants change to avoid stale data for new sessions

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68dd8a5fe0d0832691bf7a27e9dec153