### PR TITLE
Fix minimap quadrant syncing across devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -1627,6 +1627,10 @@ src/
 
 - La animación de daño utiliza ahora un `Konva.Tween` que desvanece el tinte del token de 0.5 a 0 en `DAMAGE_ANIMATION_MS`, reemplazando el `requestAnimationFrame` manual.
 
+**Resumen de cambios v2.4.86:**
+
+- La sincronización del minimapa vuelve a ser inmediata: los cuadrantes actualizan su cuadrícula, estilo y casilla de origen en todos los dispositivos sin recargar manualmente.
+
 ## 🔄 Historial de cambios previos
 
 <details>

--- a/src/components/MinimapBuilder.jsx
+++ b/src/components/MinimapBuilder.jsx
@@ -1457,6 +1457,56 @@ function MinimapBuilder({
     cols,
     cellSize,
   ]);
+  useEffect(() => {
+    if (currentQuadrantIndex === null) return;
+    const current = quadrants[currentQuadrantIndex];
+    if (!current) return;
+    const sanitizedShared = sanitizeSharedWith(current.sharedWith);
+    const remoteSnapshot = createQuadrantSnapshot({
+      rows: current.rows,
+      cols: current.cols,
+      cellSize: current.cellSize,
+      grid: current.grid,
+      sharedWith: sanitizedShared,
+    });
+    const localSnapshot = createQuadrantSnapshot({
+      rows,
+      cols,
+      cellSize,
+      grid,
+      sharedWith: activeQuadrantSharedWith,
+    });
+    if (quadrantSnapshotsEqual(localSnapshot, remoteSnapshot)) {
+      return;
+    }
+    if (canEditActiveQuadrant && hasUnsavedChanges) {
+      return;
+    }
+    if (!sharedWithEquals(activeQuadrantSharedWith, sanitizedShared)) {
+      setActiveQuadrantSharedWith(sanitizedShared);
+    }
+    const localWithRemoteShared = {
+      ...localSnapshot,
+      sharedWith: remoteSnapshot.sharedWith,
+    };
+    if (!quadrantSnapshotsEqual(localWithRemoteShared, remoteSnapshot)) {
+      if (rows !== current.rows) setRows(current.rows);
+      if (cols !== current.cols) setCols(current.cols);
+      if (cellSize !== current.cellSize) setCellSize(current.cellSize);
+      setGrid(() => buildGrid(current.rows, current.cols, current.grid));
+      setSelectedCells([]);
+    }
+  }, [
+    activeQuadrantSharedWith,
+    canEditActiveQuadrant,
+    cellSize,
+    cols,
+    currentQuadrantIndex,
+    grid,
+    hasUnsavedChanges,
+    quadrants,
+    rows,
+  ]);
   const runUnsavedChangesGuard = useCallback(
     (callback) => {
       if (typeof callback !== 'function') return false;


### PR DESCRIPTION
## Summary
- resynchronize the active minimap quadrant with remote updates when no local edits are pending so masters and players see changes instantly
- document the regression fix in the changelog

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68e018f74f508326b414ed0df5e781a8