### PR TITLE
Ensure minimap sync resets loaded snapshot

### DIFF
--- a/src/components/MinimapBuilder.jsx
+++ b/src/components/MinimapBuilder.jsx
@@ -1494,6 +1494,7 @@ function MinimapBuilder({
       if (cols !== current.cols) setCols(current.cols);
       if (cellSize !== current.cellSize) setCellSize(current.cellSize);
       setGrid(() => buildGrid(current.rows, current.cols, current.grid));
+      setLoadedQuadrantData(remoteSnapshot);
       setSelectedCells([]);
     }
   }, [


### PR DESCRIPTION
## Summary
- update the minimap sync effect to store the latest remote snapshot after applying it
- this keeps the unsaved changes flag in sync with remote updates

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68e020fb7c748326941c0fb2f0cdaf16