### PR TITLE
Preserve minimap grids from Firestore maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1627,6 +1627,10 @@ src/
 
 - La animación de daño utiliza ahora un `Konva.Tween` que desvanece el tinte del token de 0.5 a 0 en `DAMAGE_ANIMATION_MS`, reemplazando el `requestAnimationFrame` manual.
 
+**Resumen de cambios v2.4.86:**
+
+- La sincronización del minimapa vuelve a ser inmediata: los cuadrantes actualizan su cuadrícula, estilo y casilla de origen en todos los dispositivos sin recargar manualmente.
+
 ## 🔄 Historial de cambios previos
 
 <details>
@@ -1715,6 +1719,9 @@ Guía rápida: ver `docs/Minimapa.md`.
 
 - Se corrigió un fallo en el constructor de minimapas donde `selectedCell` no estaba definido al aplicar presets o eliminar celdas.
 - Se solucionó que el aviso de cambios sin guardar del minimapa siguiera apareciendo después de guardar cuadrantes o ajustar la flecha de origen.
+- Se restableció el estado de cambios sin guardar tras recibir actualizaciones remotas, evitando que los cuadrantes compartidos perdieran estilos u origen al recargarlos.
+- Se corrigió la carga de cuadrantes del minimapa cuando Firestore devolvía la cuadrícula como objeto en lugar de matriz, evitando que se reiniciara tras guardar y recargar.
+- Se evitó que al reconstruir cuadrículas del minimapa desde Firestore se perdieran estilos, iconos y exploración al compartir un cuadrante con jugadores.
 - Se optimizó la edición de celdas del minimapa en móvil apilando los controles de estilo y ajustando el auto-ajuste para evitar que el cuadrante se recorte.
 - Se solucionó un error en el mapa de batalla que provocaba un fallo al inicializar `syncManager` antes de su declaración.
 - Corregido error al aplicar presets de estilo en el minimapa que provocaba "next[r] is undefined".

--- a/src/components/MinimapBuilder.jsx
+++ b/src/components/MinimapBuilder.jsx
@@ -569,8 +569,40 @@ const buildAnnotationKey = (quadrantId, r, c, scope = '') => {
   return `${base}-${scope}`;
 };
 
-const getGridCell = (grid, r, c) =>
-  Array.isArray(grid) && Array.isArray(grid[r]) ? grid[r][c] : null;
+const sortNumericEntries = (value) =>
+  Object.keys(value || {})
+    .map((key) => [Number.parseInt(key, 10), key])
+    .filter(([index, key]) => !Number.isNaN(index) && /^\d+$/.test(key.trim()))
+    .sort((a, b) => a[0] - b[0]);
+
+const normalizeGridRow = (row) => {
+  if (Array.isArray(row)) {
+    return row;
+  }
+  if (row && typeof row === 'object') {
+    return sortNumericEntries(row).map(([, key]) => row[key]);
+  }
+  return [];
+};
+
+const normalizeGridMatrix = (grid) => {
+  if (Array.isArray(grid)) {
+    return grid.map((row) => normalizeGridRow(row));
+  }
+  if (grid && typeof grid === 'object') {
+    return sortNumericEntries(grid).map(([, key]) =>
+      normalizeGridRow(grid[key])
+    );
+  }
+  return [];
+};
+
+const getGridCell = (grid, r, c) => {
+  if (!Array.isArray(grid)) return null;
+  const row = Array.isArray(grid[r]) ? grid[r] : null;
+  if (!row) return null;
+  return row[c] !== undefined ? row[c] : null;
+};
 
 const cellKeyFromIndices = (r, c) => `${r}-${c}`;
 
@@ -594,15 +626,20 @@ const getOrthogonalNeighbors = (r, c) => [
 ];
 
 const sanitizeGridStructure = (grid, rows, cols) => {
-  const fallbackRows = Array.isArray(grid) && grid.length > 0 ? grid.length : 8;
-  const fallbackCols =
-    Array.isArray(grid) && Array.isArray(grid[0]) && grid[0].length > 0
-      ? grid[0].length
-      : 12;
+  const normalizedGrid = normalizeGridMatrix(grid);
+  const fallbackRows = normalizedGrid.length > 0 ? normalizedGrid.length : 8;
+  const fallbackCols = normalizedGrid.reduce((max, row) => {
+    if (!Array.isArray(row) || row.length === 0) {
+      return max;
+    }
+    return Math.max(max, row.length);
+  }, 0);
+  const safeCols = clampNumber(cols, 1, 200, fallbackCols > 0 ? fallbackCols : 12);
   const safeRows = clampNumber(rows, 1, 200, fallbackRows);
-  const safeCols = clampNumber(cols, 1, 200, fallbackCols);
   const sanitizedGrid = Array.from({ length: safeRows }, (_, r) =>
-    Array.from({ length: safeCols }, (_, c) => sanitizeCell(getGridCell(grid, r, c)))
+    Array.from({ length: safeCols }, (_, c) =>
+      sanitizeCell(getGridCell(normalizedGrid, r, c))
+    )
   );
   return { rows: safeRows, cols: safeCols, grid: sanitizedGrid };
 };
@@ -908,12 +945,14 @@ const readLocalCustomization = () => {
   } catch {}
   return result;
 };
-const buildGrid = (rows, cols, prev = []) =>
-  Array.from({ length: rows }, (_, r) =>
+const buildGrid = (rows, cols, prev = []) => {
+  const normalizedPrev = normalizeGridMatrix(prev);
+  return Array.from({ length: rows }, (_, r) =>
     Array.from({ length: cols }, (_, c) =>
-      prev[r] && prev[r][c] ? { ...prev[r][c] } : defaultCell()
+      sanitizeCell(getGridCell(normalizedPrev, r, c))
     )
   );
+};
 
 function MinimapBuilder({
   onBack,
@@ -1456,6 +1495,57 @@ function MinimapBuilder({
     rows,
     cols,
     cellSize,
+  ]);
+  useEffect(() => {
+    if (currentQuadrantIndex === null) return;
+    const current = quadrants[currentQuadrantIndex];
+    if (!current) return;
+    const sanitizedShared = sanitizeSharedWith(current.sharedWith);
+    const remoteSnapshot = createQuadrantSnapshot({
+      rows: current.rows,
+      cols: current.cols,
+      cellSize: current.cellSize,
+      grid: current.grid,
+      sharedWith: sanitizedShared,
+    });
+    const localSnapshot = createQuadrantSnapshot({
+      rows,
+      cols,
+      cellSize,
+      grid,
+      sharedWith: activeQuadrantSharedWith,
+    });
+    if (quadrantSnapshotsEqual(localSnapshot, remoteSnapshot)) {
+      return;
+    }
+    if (canEditActiveQuadrant && hasUnsavedChanges) {
+      return;
+    }
+    if (!sharedWithEquals(activeQuadrantSharedWith, sanitizedShared)) {
+      setActiveQuadrantSharedWith(sanitizedShared);
+    }
+    const localWithRemoteShared = {
+      ...localSnapshot,
+      sharedWith: remoteSnapshot.sharedWith,
+    };
+    if (!quadrantSnapshotsEqual(localWithRemoteShared, remoteSnapshot)) {
+      if (rows !== current.rows) setRows(current.rows);
+      if (cols !== current.cols) setCols(current.cols);
+      if (cellSize !== current.cellSize) setCellSize(current.cellSize);
+      setGrid(() => buildGrid(current.rows, current.cols, current.grid));
+      setSelectedCells([]);
+    }
+    setLoadedQuadrantData(remoteSnapshot);
+  }, [
+    activeQuadrantSharedWith,
+    canEditActiveQuadrant,
+    cellSize,
+    cols,
+    currentQuadrantIndex,
+    grid,
+    hasUnsavedChanges,
+    quadrants,
+    rows,
   ]);
   const runUnsavedChangesGuard = useCallback(
     (callback) => {


### PR DESCRIPTION
## Summary
- rebuild minimap grids using normalized Firestore data so shared quadrants keep their saved styles and exploration
- document the Firestore grid reconstruction fix in the minimap changelog

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68e018f74f508326b414ed0df5e781a8