### PR TITLE
Fix minimap quadrant sync across devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -1719,6 +1719,7 @@ Guía rápida: ver `docs/Minimapa.md`.
 ## 🐛 Correcciones
 
 - Se corrigió un fallo en el constructor de minimapas donde `selectedCell` no estaba definido al aplicar presets o eliminar celdas.
+- Se corrigió la sincronización de cuadrantes del minimapa para que todos los dispositivos y navegadores compartan siempre la misma lista guardada a través de Firestore.
 - Se solucionó que el aviso de cambios sin guardar del minimapa siguiera apareciendo después de guardar cuadrantes o ajustar la flecha de origen.
 - Se restableció el estado de cambios sin guardar tras recibir actualizaciones remotas, evitando que los cuadrantes compartidos perdieran estilos u origen al recargarlos.
 - Se corrigió la carga de cuadrantes del minimapa cuando Firestore devolvía la cuadrícula como objeto en lugar de matriz, evitando que se reiniciara tras guardar y recargar.

--- a/src/components/MinimapBuilder.jsx
+++ b/src/components/MinimapBuilder.jsx
@@ -2043,7 +2043,7 @@ function MinimapBuilder({
         unsubscribe();
       } catch {}
     };
-  }, []);
+  }, [db, defaultOwner, filterQuadrantsForMode, updateLocalQuadrants]);
   useEffect(() => {
     if (isMobile && !readableMode) setReadableMode(true);
   }, [isMobile, readableMode]);


### PR DESCRIPTION
## Summary
- update the minimap quadrants subscription effect to react to database and player context changes
- document that minimap quadrants now stay synchronized across devices and browsers

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68e24ca1d4308326bd591e50d444ef9e