### PR TITLE
Fix read-only toast initialization order

### DIFF
--- a/README.md
+++ b/README.md
@@ -1705,6 +1705,7 @@ Este proyecto está bajo la Licencia MIT. Ver `LICENSE` para más detalles.
 - Buscadores de emojis y Lucide con listado completo de iconos cargados localmente.
 - Nueva categoría «Recursos» que añade al selector los iconos de objetos personalizados del inventario creados desde las herramientas de máster.
 - Permisos de cuadrantes: el máster puede asignar cuadrantes a jugadores desde la sección «Permisos» y estos aparecen destacados como compartidos y de solo lectura en sus listas.
+- Aviso contextual para jugadores al abrir cuadrantes de otros jugadores: destaca con su color quién es el autor y que no podrán editarlo ni eliminarlo hasta recibir permisos, además de mostrar una alerta fija sobre el lienzo con esa información en modo solo lectura.
 - Los jugadores pueden añadir anotaciones en cuadrantes compartidos; el máster las ve con un distintivo y sus propias notas permanecen ocultas para los jugadores.
 - Nuevo modo explorador para jugadores en cuadrantes compartidos: empiezan en la casilla de origen, ven las adyacentes como incógnitas y pueden descubrir el cuadrante de forma progresiva.
 - Estilo rápido «Origen» exclusivo del máster para marcar la casilla de inicio con una flecha orientable (arriba, abajo, izquierda o derecha).

--- a/src/components/ChatPanel.jsx
+++ b/src/components/ChatPanel.jsx
@@ -7,8 +7,8 @@ import { db } from '../firebase';
 import Input from './Input';
 import { rollExpression } from '../utils/dice';
 import highlightBattleText from '../utils/highlightBattleText';
+import { getPlayerColor, MASTER_COLOR } from '../utils/playerColors';
 
-const MASTER_COLOR = "#FFD700";
 const SPECIAL_TRAIT_COLOR = '#ef4444';
 const ChatPanel = ({ playerName = '', isMaster = false }) => {
   const [messages, setMessages] = useState([]);
@@ -66,18 +66,6 @@ const ChatPanel = ({ playerName = '', isMaster = false }) => {
     setDoc(doc(db, 'assetSidebar', 'chat'), { messages }).catch(console.error);
     prevMessagesRef.current = messages;
   }, [messages, chatLoaded]);
-
-  const getPlayerColor = (name) => {
-    if (!name || name === 'Master') return MASTER_COLOR;
-    let hash = 0;
-    for (let i = 0; i < name.length; i++) {
-      hash = name.charCodeAt(i) + ((hash << 5) - hash);
-    }
-    const hue = Math.abs(hash) % 360;
-    const saturation = 65 + (Math.abs(hash) % 20);
-    const lightness = 55 + (Math.abs(hash) % 15);
-    return `hsl(${hue}, ${saturation}%, ${lightness}%)`;
-  };
 
   const sendMessage = () => {
     const text = message.trim();

--- a/src/components/MinimapBuilder.jsx
+++ b/src/components/MinimapBuilder.jsx
@@ -13,6 +13,7 @@ import { ESTADOS } from './EstadoSelector';
 import HexColorInput from './HexColorInput';
 import { getOrUploadFile } from '../utils/storage';
 import { updateMinimapExplorationCells } from '../utils/minimapExploration';
+import { getPlayerColor, MASTER_COLOR } from '../utils/playerColors';
 import useConfirm from '../hooks/useConfirm';
 import { useToast } from './Toast';
 import * as LucideIcons from 'lucide-react';
@@ -99,6 +100,8 @@ const L = {
   noPlayers: 'Sin jugadores disponibles',
   sharedQuadrantTag: 'Compartido',
   sharedQuadrantHint: 'Asignado por el M\u00E1ster',
+  editingQuadrantLabel: 'Editando',
+  viewingQuadrantLabel: 'Solo lectura',
   explorerMasterHint:
     'Controla qu\u00E9 zonas descubre el modo explorador compartido.',
   explorerMasterToggle: 'Herramientas del m\u00E1ster',
@@ -108,6 +111,11 @@ const L = {
   explorerHideSelection: 'Ocultar selecci\u00F3n',
   masterQuadrantLocked:
     'Este cuadrante fue compartido por el M\u00E1ster y es de solo lectura.',
+  playerQuadrantLockedTitle: 'Cuadrante de otro jugador',
+  playerQuadrantLockedIntro: 'Este cuadrante pertenece a',
+  playerQuadrantLockedOutro:
+    'No puedes modificarlo ni eliminarlo a menos que esa persona te otorgue permisos.',
+  playerQuadrantLockedUnknown: 'otro jugador',
   unsavedChangesConfirm:
     'Tienes cambios sin guardar en el cuadrante actual. ¿Quieres continuar?',
   unsavedChangesIndicator: 'Cambios sin guardar en el cuadrante actual',
@@ -1142,7 +1150,7 @@ function MinimapBuilder({
   const [currentQuadrantIndex, setCurrentQuadrantIndex] = useState(null);
   const localQuadrantsRef = useRef(null);
   const pendingSharedWithRef = useRef(null);
-  const { error: showErrorToast } = useToast();
+  const { error: showErrorToast, info: showInfoToast } = useToast();
   if (localQuadrantsRef.current === null) {
     localQuadrantsRef.current = quadrants;
   }
@@ -1239,6 +1247,35 @@ function MinimapBuilder({
     () => normalizePlayerName(activeQuadrantOwner),
     [activeQuadrantOwner]
   );
+  const activeOwnerDisplayName = useMemo(() => {
+    if (typeof activeQuadrantOwner !== 'string') return '';
+    const trimmed = activeQuadrantOwner.trim();
+    if (!trimmed) return '';
+    if (normalizePlayerName(trimmed) === 'master') {
+      return 'Máster';
+    }
+    return trimmed;
+  }, [activeQuadrantOwner]);
+  const activeOwnerNameForDisplay = useMemo(() => {
+    if (activeOwnerDisplayName) return activeOwnerDisplayName;
+    if (typeof activeQuadrantOwner === 'string' && activeQuadrantOwner.trim()) {
+      return activeQuadrantOwner.trim();
+    }
+    return L.playerQuadrantLockedUnknown;
+  }, [activeQuadrantOwner, activeOwnerDisplayName]);
+  const activeOwnerDisplayColor = useMemo(
+    () => getPlayerColor(activeOwnerNameForDisplay),
+    [activeOwnerNameForDisplay]
+  );
+  const activeOwnerHighlightStyle = useMemo(() => {
+    if (activeOwnerKey === 'master') {
+      return {
+        color: MASTER_COLOR,
+        textShadow: `0 0 6px ${MASTER_COLOR}`,
+      };
+    }
+    return { color: activeOwnerDisplayColor };
+  }, [activeOwnerDisplayColor, activeOwnerKey]);
   const isSharedMasterQuadrant = useMemo(() => {
     if (!isPlayerMode) return false;
     return activeOwnerKey === 'master';
@@ -1256,6 +1293,51 @@ function MinimapBuilder({
     if (!normalizedPlayerName) return false;
     return activeOwnerKey === normalizedPlayerName;
   }, [isPlayerMode, activeOwnerKey, normalizedPlayerName]);
+  const shouldShowPlayerOwnerLock = useMemo(
+    () =>
+      isPlayerMode &&
+      !canEditActiveQuadrant &&
+      activeOwnerKey !== 'master' &&
+      activeOwnerKey !== normalizedPlayerName,
+    [
+      activeOwnerKey,
+      canEditActiveQuadrant,
+      isPlayerMode,
+      normalizedPlayerName,
+    ]
+  );
+  useEffect(() => {
+    if (!shouldShowPlayerOwnerLock) {
+      lastReadOnlyToastKeyRef.current = '';
+      return;
+    }
+    if (!activeQuadrantId) return;
+    const toastKey = `${activeQuadrantId}:${activeOwnerKey}`;
+    if (lastReadOnlyToastKeyRef.current === toastKey) {
+      return;
+    }
+    lastReadOnlyToastKeyRef.current = toastKey;
+    showInfoToast(
+      <span className="leading-snug">
+        {L.playerQuadrantLockedIntro}{' '}
+        <span className="font-semibold" style={activeOwnerHighlightStyle}>
+          {activeOwnerNameForDisplay}
+        </span>
+        {'. '}
+        {L.playerQuadrantLockedOutro}
+      </span>,
+      {
+        title: L.playerQuadrantLockedTitle,
+      }
+    );
+  }, [
+    activeOwnerHighlightStyle,
+    activeOwnerKey,
+    activeOwnerNameForDisplay,
+    activeQuadrantId,
+    showInfoToast,
+    shouldShowPlayerOwnerLock,
+  ]);
   const canAnnotateActiveQuadrant = useMemo(() => {
     if (!isPlayerMode) return true;
     if (!normalizedPlayerName) return false;
@@ -1818,6 +1900,7 @@ function MinimapBuilder({
   const headerSectionRef = useRef(null);
   const skipRebuildRef = useRef(false);
   const longPressTimersRef = useRef(new Map());
+  const lastReadOnlyToastKeyRef = useRef('');
   const lastLongPressRef = useRef({ key: null, t: 0 });
   const activePanPointerRef = useRef(null);
   const panStartRef = useRef({ x: 0, y: 0 });
@@ -4208,6 +4291,18 @@ function MinimapBuilder({
           {L.masterQuadrantLocked}
         </div>
       )}
+      {!isSharedMasterQuadrant && shouldShowPlayerOwnerLock && (
+        <div className="rounded-lg border border-sky-500/30 bg-sky-500/10 px-3 py-2 text-xs text-sky-100">
+          <p>
+            {L.playerQuadrantLockedIntro}{' '}
+            <span className="font-semibold" style={activeOwnerHighlightStyle}>
+              {activeOwnerNameForDisplay}
+            </span>
+            {'. '}
+            {L.playerQuadrantLockedOutro}
+          </p>
+        </div>
+      )}
       {isMobile && (
         <div className="space-y-3">
           <div className="text-xs font-semibold uppercase tracking-wide text-gray-400">
@@ -4413,8 +4508,15 @@ function MinimapBuilder({
           </div>
         )}
         {currentQuadrantIndex !== null && (
-          <div className="text-xs text-emerald-400">
-            Editando: {quadrants[currentQuadrantIndex]?.title}
+          <div
+            className={`text-xs ${
+              canEditActiveQuadrant ? 'text-emerald-400' : 'text-sky-200'
+            }`}
+          >
+            {canEditActiveQuadrant
+              ? `${L.editingQuadrantLabel}: `
+              : `${L.viewingQuadrantLabel}: `}
+            {quadrants[currentQuadrantIndex]?.title}
           </div>
         )}
         {currentQuadrantIndex !== null && hasUnsavedChanges && (
@@ -4770,6 +4872,24 @@ function MinimapBuilder({
                 )}
               </div>
             )}
+          </div>
+        )}
+        {!isSharedMasterQuadrant && shouldShowPlayerOwnerLock && (
+          <div className="flex items-start gap-3 rounded-xl border border-sky-500/40 bg-sky-900/40 px-3 py-2 text-sm text-sky-100 shadow-inner">
+            <LucideIcons.Lock className="mt-1 h-4 w-4 text-sky-300" />
+            <div className="flex flex-col gap-1 leading-snug">
+              <span className="text-[11px] font-semibold uppercase tracking-wide text-sky-200">
+                {L.playerQuadrantLockedTitle}
+              </span>
+              <span className="text-xs text-sky-100/90">
+                {L.playerQuadrantLockedIntro}{' '}
+                <span className="font-semibold" style={activeOwnerHighlightStyle}>
+                  {activeOwnerNameForDisplay}
+                </span>
+                {'. '}
+                {L.playerQuadrantLockedOutro}
+              </span>
+            </div>
           </div>
         )}
       </div>

--- a/src/utils/playerColors.js
+++ b/src/utils/playerColors.js
@@ -1,0 +1,31 @@
+const stripDiacritics = (value) =>
+  String(value || '')
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '');
+
+export const MASTER_COLOR = '#FFD700';
+
+export const getPlayerColor = (name, fallback = '#6B7280') => {
+  const trimmed = typeof name === 'string' ? name.trim() : '';
+  if (!trimmed) {
+    return fallback;
+  }
+
+  const normalized = stripDiacritics(trimmed).toLowerCase();
+  if (normalized === 'master') {
+    return MASTER_COLOR;
+  }
+
+  let hash = 0;
+  for (let i = 0; i < trimmed.length; i += 1) {
+    hash = trimmed.charCodeAt(i) + ((hash << 5) - hash);
+    hash |= 0;
+  }
+
+  const safeHash = Math.abs(hash);
+  const hue = safeHash % 360;
+  const saturation = 65 + (safeHash % 20);
+  const lightness = 55 + (safeHash % 15);
+
+  return `hsl(${hue}, ${saturation}%, ${lightness}%)`;
+};


### PR DESCRIPTION
## Summary
- show a prominent lock banner with the owner's name and color when players open another user's quadrant in read-only mode
- adjust the quadrant status label to switch between "Editando" and "Solo lectura" based on permissions
- document the persistent banner in the minimap feature list
- ensure the read-only owner toast registers after its dependent values so it no longer throws a runtime initialization error

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68e255641de48326ae4907ed573a1452