### PR TITLE
Fix minimap owner lock hook initialization order

### DIFF
--- a/src/components/MinimapBuilder.jsx
+++ b/src/components/MinimapBuilder.jsx
@@ -1238,38 +1238,6 @@ function MinimapBuilder({
       prev && quadrantSnapshotsEqual(prev, snapshot) ? prev : snapshot
     );
   }, [quadrants, currentQuadrantIndex, defaultOwner]);
-  useEffect(() => {
-    if (!shouldShowPlayerOwnerLock) {
-      lastReadOnlyToastKeyRef.current = '';
-      return;
-    }
-    if (!activeQuadrantId) return;
-    const toastKey = `${activeQuadrantId}:${activeOwnerKey}`;
-    if (lastReadOnlyToastKeyRef.current === toastKey) {
-      return;
-    }
-    lastReadOnlyToastKeyRef.current = toastKey;
-    showInfoToast(
-      <span className="leading-snug">
-        {L.playerQuadrantLockedIntro}{' '}
-        <span className="font-semibold" style={activeOwnerHighlightStyle}>
-          {activeOwnerNameForDisplay}
-        </span>
-        {'. '}
-        {L.playerQuadrantLockedOutro}
-      </span>,
-      {
-        title: L.playerQuadrantLockedTitle,
-      }
-    );
-  }, [
-    activeOwnerHighlightStyle,
-    activeOwnerKey,
-    activeOwnerNameForDisplay,
-    activeQuadrantId,
-    showInfoToast,
-    shouldShowPlayerOwnerLock,
-  ]);
   const getLocalQuadrantsSnapshot = () =>
     Array.isArray(localQuadrantsRef.current) ? localQuadrantsRef.current : [];
   const quadrantsMigrationRef = useRef(false);
@@ -1343,6 +1311,38 @@ function MinimapBuilder({
       normalizedPlayerName,
     ]
   );
+  useEffect(() => {
+    if (!shouldShowPlayerOwnerLock) {
+      lastReadOnlyToastKeyRef.current = '';
+      return;
+    }
+    if (!activeQuadrantId) return;
+    const toastKey = `${activeQuadrantId}:${activeOwnerKey}`;
+    if (lastReadOnlyToastKeyRef.current === toastKey) {
+      return;
+    }
+    lastReadOnlyToastKeyRef.current = toastKey;
+    showInfoToast(
+      <span className="leading-snug">
+        {L.playerQuadrantLockedIntro}{' '}
+        <span className="font-semibold" style={activeOwnerHighlightStyle}>
+          {activeOwnerNameForDisplay}
+        </span>
+        {'. '}
+        {L.playerQuadrantLockedOutro}
+      </span>,
+      {
+        title: L.playerQuadrantLockedTitle,
+      }
+    );
+  }, [
+    activeOwnerHighlightStyle,
+    activeOwnerKey,
+    activeOwnerNameForDisplay,
+    activeQuadrantId,
+    showInfoToast,
+    shouldShowPlayerOwnerLock,
+  ]);
   useEffect(() => {
     if (!shouldShowPlayerOwnerLock) {
       lastReadOnlyToastKeyRef.current = '';


### PR DESCRIPTION
## Summary
- move the player owner lock toast effect below the memoized owner values to avoid temporal dead zone access
- preserve the existing toast logic while ensuring memoized styles are initialized before the effect runs

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68e2d8dfca188326aa43af398a4d017d