### PR TITLE
Adjust enemy filters button layout and card width

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -4467,14 +4467,20 @@ function App() {
               </Boton>
             </div>
           </div>
-          <div className="flex flex-wrap gap-2 mb-3">
-            <Boton color="green" onClick={createNewEnemy}>
+          <div className="flex flex-col md:flex-row md:flex-wrap md:items-center gap-2 mb-3">
+            <Boton
+              color="green"
+              onClick={createNewEnemy}
+              className="w-full md:w-auto"
+            >
               Crear Nuevo Enemigo
             </Boton>
-            <Boton onClick={refreshCatalog}>Refrescar</Boton>
+            <Boton onClick={refreshCatalog} className="w-full md:w-auto">
+              Refrescar
+            </Boton>
             <button
               type="button"
-              className="md:hidden ml-auto inline-flex items-center gap-2 px-3 py-2 rounded bg-gray-700 hover:bg-gray-600"
+              className="md:hidden w-full inline-flex items-center justify-center gap-2 px-3 py-2 rounded bg-gray-700 hover:bg-gray-600"
               onClick={() => setEnemyFiltersOpen((v) => !v)}
               aria-expanded={enemyFiltersOpen}
               aria-controls="enemy-filters"

--- a/src/components/Tarjeta.jsx
+++ b/src/components/Tarjeta.jsx
@@ -92,8 +92,10 @@ const Tarjeta = ({
         borderRadius: '1.25rem',
         overflow: 'visible',
         minHeight: '320px',
-        maxWidth: '420px',
-        margin: 'auto',
+        width: '100%',
+        maxWidth: 'none',
+        margin: 0,
+        height: '100%',
       }
     : {
         boxShadow: '0 2px 12px 0 #0006',


### PR DESCRIPTION
## Summary
- adjust the enemy management toolbar to stack on mobile and center the filters toggle
- allow magic variant cards to stretch to the full width of their grid cell so desktop spacing is tighter

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68e5130408e88326b17334668fdf9b7f